### PR TITLE
Add option to use long tap instead of tap to create events

### DIFF
--- a/lib/src/components/gesture_detectors/multi_day_header_gesture_detector.dart
+++ b/lib/src/components/gesture_detectors/multi_day_header_gesture_detector.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:kalender/src/providers/calendar_scope.dart';
+import 'package:kalender/kalender.dart';
 import 'package:kalender/src/extensions.dart';
-import 'package:kalender/src/models/calendar/calendar_event_controller.dart';
-import 'package:kalender/src/models/calendar/calendar_functions.dart';
 
 /// This widget is used to detect gestures on the [MultiDayHeaderWidget] and [MonthViewPageContent].
 class MultiDayHeaderGestureDetector<T> extends StatefulWidget {
@@ -12,6 +10,7 @@ class MultiDayHeaderGestureDetector<T> extends StatefulWidget {
     required this.horizontalStep,
     this.verticalStep,
     required this.createMultiDayEvents,
+    required this.createEventTrigger,
   });
 
   final DateTimeRange visibleDateRange;
@@ -19,6 +18,7 @@ class MultiDayHeaderGestureDetector<T> extends StatefulWidget {
   final bool createMultiDayEvents;
   final double horizontalStep;
   final double? verticalStep;
+  final CreateEventTrigger createEventTrigger;
 
   @override
   State<MultiDayHeaderGestureDetector<T>> createState() =>
@@ -51,7 +51,12 @@ class _MultiDayHeaderGestureDetectorState<T>
           for (final date in widget.visibleDateRange.datesSpanned)
             Expanded(
               child: GestureDetector(
-                onTap: () => _onTap(date),
+                onLongPress: () => widget.createEventTrigger == CreateEventTrigger.longPress
+                    ? _createEvent(date)
+                    : controller.deselectEvent(),
+                onTap: () => widget.createEventTrigger == CreateEventTrigger.tap
+                    ? _createEvent(date)
+                    : controller.deselectEvent(),
                 onPanStart: createEvents
                     ? (details) => _onPanStart(details, date)
                     : null,
@@ -64,7 +69,7 @@ class _MultiDayHeaderGestureDetectorState<T>
     );
   }
 
-  void _onTap(DateTime date) async {
+  void _createEvent(DateTime date) async {
     // If the create events flag is false, return.
     if (!createEvents) return;
 

--- a/lib/src/components/gesture_detectors/multi_day_page_gesture_detector.dart
+++ b/lib/src/components/gesture_detectors/multi_day_page_gesture_detector.dart
@@ -54,7 +54,12 @@ class _MultiDayPageGestureDetectorState<T>
                   (slotIndex) => Expanded(
                     child: SizedBox.expand(
                       child: GestureDetector(
-                        onTap: () => _onTap(
+                        onLongPress: widget.viewConfiguration.useLongPressForCreateEvent ? () => _createEvent(
+                          calculateNewEventDateTimeRange(date, slotIndex),
+                        ) : null,
+                        onTap: widget.viewConfiguration.useLongPressForCreateEvent ? () {
+                          controller.deselectEvent();
+                        } : () => _createEvent(
                           calculateNewEventDateTimeRange(date, slotIndex),
                         ),
                         onVerticalDragStart: isMobileDevice || !createEvents
@@ -89,8 +94,8 @@ class _MultiDayPageGestureDetectorState<T>
     );
   }
 
-  /// Handles the onTap event.
-  void _onTap(DateTimeRange dateTimeRange) async {
+  /// Creates new event.
+  void _createEvent(DateTimeRange dateTimeRange) async {
     // If the create events flag is false, return.
     if (!createEvents) return;
 

--- a/lib/src/components/gesture_detectors/multi_day_page_gesture_detector.dart
+++ b/lib/src/components/gesture_detectors/multi_day_page_gesture_detector.dart
@@ -54,14 +54,12 @@ class _MultiDayPageGestureDetectorState<T>
                   (slotIndex) => Expanded(
                     child: SizedBox.expand(
                       child: GestureDetector(
-                        onLongPress: widget.viewConfiguration.useLongPressForCreateEvent ? () => _createEvent(
-                          calculateNewEventDateTimeRange(date, slotIndex),
-                        ) : null,
-                        onTap: widget.viewConfiguration.useLongPressForCreateEvent ? () {
-                          controller.deselectEvent();
-                        } : () => _createEvent(
-                          calculateNewEventDateTimeRange(date, slotIndex),
-                        ),
+                        onLongPress: () => widget.viewConfiguration.createEventTrigger == CreateEventTrigger.longPress
+                            ? _createEvent(calculateNewEventDateTimeRange(date, slotIndex))
+                            : controller.deselectEvent(),
+                        onTap: () => widget.viewConfiguration.createEventTrigger == CreateEventTrigger.tap
+                            ? _createEvent(calculateNewEventDateTimeRange(date, slotIndex))
+                            : controller.deselectEvent(),
                         onVerticalDragStart: isMobileDevice || !createEvents
                             ? null
                             : (details) => _onVerticalDragStart(

--- a/lib/src/enumerations.dart
+++ b/lib/src/enumerations.dart
@@ -14,3 +14,11 @@ enum TileType {
   /// This is used to show the size and position of a tile that is being modified.
   selected,
 }
+
+enum CreateEventTrigger {
+  /// Creates event on tap gesture.
+  tap,
+
+  /// Creates event on tap hold gesture.
+  longPress,
+}

--- a/lib/src/models/view_configurations/month_configurations/month_view_configuration.dart
+++ b/lib/src/models/view_configurations/month_configurations/month_view_configuration.dart
@@ -21,7 +21,7 @@ abstract class MonthViewConfiguration extends ViewConfiguration {
     _multiDayTileHeight = multiDayTileHeight;
     _createMultiDayEvents = createMultiDayEvents;
     _enableRescheduling = enableRescheduling;
-    _createEventTrigger = createEventTrigger ?? CreateEventTrigger.longPress;
+    _createEventTrigger = createEventTrigger ?? CreateEventTrigger.tap;
     _showHeader = showHeader;
   }
 

--- a/lib/src/models/view_configurations/month_configurations/month_view_configuration.dart
+++ b/lib/src/models/view_configurations/month_configurations/month_view_configuration.dart
@@ -1,3 +1,4 @@
+import 'package:kalender/src/enumerations.dart';
 import 'package:kalender/src/models/view_configurations/view_configuration.dart';
 
 /// This is the base class for all [MonthViewConfiguration]s.
@@ -11,6 +12,7 @@ abstract class MonthViewConfiguration extends ViewConfiguration {
     required double multiDayTileHeight,
     required bool createMultiDayEvents,
     required bool enableRescheduling,
+    CreateEventTrigger? createEventTrigger,
   }) {
     _verticalStepDuration = verticalStepDuration;
     _horizontalStepDuration = horizontalStepDuration;
@@ -19,6 +21,8 @@ abstract class MonthViewConfiguration extends ViewConfiguration {
     _multiDayTileHeight = multiDayTileHeight;
     _createMultiDayEvents = createMultiDayEvents;
     _enableRescheduling = enableRescheduling;
+    _createEventTrigger = createEventTrigger ?? CreateEventTrigger.longPress;
+    _showHeader = showHeader;
   }
 
   /// The duration of one vertical step.
@@ -84,4 +88,8 @@ abstract class MonthViewConfiguration extends ViewConfiguration {
     _showHeader = value;
     notifyListeners();
   }
+
+  /// Gesture type for creating events.
+  late CreateEventTrigger _createEventTrigger;
+  CreateEventTrigger get createEventTrigger => _createEventTrigger;
 }

--- a/lib/src/models/view_configurations/multi_day_configurations/custom_multi_day_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/custom_multi_day_configuration.dart
@@ -22,6 +22,7 @@ class CustomMultiDayConfiguration extends MultiDayViewConfiguration {
     super.enableResizing = true,
     super.startHour = 0,
     super.endHour = 24,
+    super.useLongPressForCreateEvent = false,
   });
 
   @override

--- a/lib/src/models/view_configurations/multi_day_configurations/custom_multi_day_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/custom_multi_day_configuration.dart
@@ -22,7 +22,7 @@ class CustomMultiDayConfiguration extends MultiDayViewConfiguration {
     super.enableResizing = true,
     super.startHour = 0,
     super.endHour = 24,
-    super.useLongPressForCreateEvent = false,
+    super.createEventTrigger,
   });
 
   @override

--- a/lib/src/models/view_configurations/multi_day_configurations/day_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/day_configuration.dart
@@ -26,6 +26,7 @@ class DayConfiguration extends MultiDayViewConfiguration {
     super.startHour = 0,
     super.endHour = 24,
     super.initialHeightPerMinute,
+    super.createEventTrigger,
     super.showHeader,
   }) {
     super.numberOfDays = 1;

--- a/lib/src/models/view_configurations/multi_day_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/multi_day_view_configuration.dart
@@ -1,3 +1,4 @@
+import 'package:kalender/src/enumerations.dart';
 import 'package:kalender/src/models/view_configurations/view_configuration.dart';
 
 /// This is the base class for all [MultiDayViewConfiguration]s.
@@ -7,7 +8,7 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
     int? firstDayOfWeek,
     bool? paintWeekNumber,
     double? initialHeightPerMinute,
-    bool? useLongPressForCreateEvent,
+    CreateEventTrigger? createEventTrigger,
     required double timelineWidth,
     required double daySeparatorLeftOffset,
     required Duration horizontalStepDuration,
@@ -50,7 +51,7 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
 
     _initialHeightPerMinute = initialHeightPerMinute ?? 0.7;
 
-    _useLongPressForCreateEvent = useLongPressForCreateEvent ?? false;
+    _createEventTrigger = createEventTrigger ?? CreateEventTrigger.tap;
 
     assert(
       startHour >= 0 && startHour <= 23,
@@ -238,7 +239,7 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
 
   bool get customStartEndHour => _startHour != 0 || _endHour != 24;
 
-  /// Use LongPress instead of Tap to create events.
-  late bool _useLongPressForCreateEvent;
-  bool get useLongPressForCreateEvent => _useLongPressForCreateEvent;
+  /// Gesture type for creating events.
+  late CreateEventTrigger _createEventTrigger;
+  CreateEventTrigger get createEventTrigger => _createEventTrigger;
 }

--- a/lib/src/models/view_configurations/multi_day_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/multi_day_view_configuration.dart
@@ -7,6 +7,7 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
     int? firstDayOfWeek,
     bool? paintWeekNumber,
     double? initialHeightPerMinute,
+    bool? useLongPressForCreateEvent,
     required double timelineWidth,
     required double daySeparatorLeftOffset,
     required Duration horizontalStepDuration,
@@ -48,6 +49,8 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
     _enableResizing = enableResizing;
 
     _initialHeightPerMinute = initialHeightPerMinute ?? 0.7;
+
+    _useLongPressForCreateEvent = useLongPressForCreateEvent ?? false;
 
     assert(
       startHour >= 0 && startHour <= 23,
@@ -234,4 +237,8 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
   double get heightPerMinute => _initialHeightPerMinute;
 
   bool get customStartEndHour => _startHour != 0 || _endHour != 24;
+
+  /// Use LongPress instead of Tap to create events.
+  late bool _useLongPressForCreateEvent;
+  bool get useLongPressForCreateEvent => _useLongPressForCreateEvent;
 }

--- a/lib/src/models/view_configurations/multi_day_configurations/multi_week_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/multi_week_configuration.dart
@@ -24,6 +24,7 @@ class MultiWeekConfiguration extends MultiDayViewConfiguration {
     super.startHour = 0,
     super.endHour = 24,
     super.initialHeightPerMinute,
+    super.createEventTrigger,
     super.showHeader,
   }) {
     _numberOfWeeks = numberOfWeeks;

--- a/lib/src/models/view_configurations/multi_day_configurations/week_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/week_configuration.dart
@@ -23,6 +23,7 @@ class WeekConfiguration extends MultiDayViewConfiguration {
     super.startHour = 0,
     super.endHour = 24,
     super.initialHeightPerMinute,
+    super.createEventTrigger,
     super.showHeader,
   }) {
     super.numberOfDays = 7;

--- a/lib/src/models/view_configurations/multi_day_configurations/work_week_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/work_week_configuration.dart
@@ -23,6 +23,7 @@ class WorkWeekConfiguration extends MultiDayViewConfiguration {
     super.startHour = 0,
     super.endHour = 24,
     super.initialHeightPerMinute,
+    super.createEventTrigger,
     super.showHeader,
   }) {
     super.numberOfDays = 5;

--- a/lib/src/views/month_view/month_view_page_content.dart
+++ b/lib/src/views/month_view/month_view_page_content.dart
@@ -86,8 +86,8 @@ class MonthViewPageContent<T> extends StatelessWidget {
                           (multiDayEventGroup.maxNumberOfStackedEvents + 1);
 
                       final gestureDetector = MultiDayHeaderGestureDetector<T>(
-                        createMultiDayEvents:
-                            viewConfiguration.createMultiDayEvents,
+                        createMultiDayEvents: viewConfiguration.createMultiDayEvents,
+                        createEventTrigger: viewConfiguration.createEventTrigger,
                         visibleDateRange: weekDateRange,
                         horizontalStep: horizontalStep,
                         verticalStep: verticalStep,

--- a/lib/src/views/multi_day_view/multi_day_header.dart
+++ b/lib/src/views/multi_day_view/multi_day_header.dart
@@ -196,8 +196,8 @@ class AnimatedMultiDayEventsHeader<T> extends StatelessWidget {
                   clipBehavior: Clip.antiAlias,
                   children: [
                     MultiDayHeaderGestureDetector<T>(
-                      createMultiDayEvents:
-                          viewConfiguration.createMultiDayEvents,
+                      createMultiDayEvents: viewConfiguration.createMultiDayEvents,
+                      createEventTrigger: viewConfiguration.createEventTrigger,
                       visibleDateRange: visibleDateRange,
                       horizontalStep: horizontalStep,
                     ),


### PR DESCRIPTION
Some users use this calendar on mobile devices and can accidentally create events during scrolling/swiping.
So it will be a good option to create new events via long tap.