### PR TITLE
Export TileHandleStyle

### DIFF
--- a/lib/src/components/general/styles_export.dart
+++ b/lib/src/components/general/styles_export.dart
@@ -5,6 +5,7 @@ export 'package:kalender/src/components/general/material_header/material_header_
 export 'package:kalender/src/components/general/month_cell_header/month_cell_header_style.dart';
 export 'package:kalender/src/components/general/month_grid/month_grid_style.dart';
 export 'package:kalender/src/components/general/month_header/month_header_style.dart';
+export 'package:kalender/src/components/general/tile_handle/tile_handle_style.dart';
 export 'package:kalender/src/components/general/time_indicator/time_indicator_style.dart';
 export 'package:kalender/src/components/general/time_line/timeline_style.dart';
 export 'package:kalender/src/components/general/week_number/week_number_style.dart';

--- a/lib/src/models/calendar/calendar_style.dart
+++ b/lib/src/models/calendar/calendar_style.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/src/components/general/styles_export.dart';
-import 'package:kalender/src/components/general/tile_handle/tile_handle_style.dart';
 
 /// The [CalendarStyle] class is used to store custom style's for the [CalendarComponents].
 class CalendarStyle {


### PR DESCRIPTION
Fixed an issue where users can not to set `TileHandleStyle` due to `tile_handle_style.dart` is not exported.

![CleanShot 2024-03-04 at 18 21 59@2x](https://github.com/werner-scholtz/kalender/assets/1491856/880474c7-7d41-4d8f-848e-26f394f532b6)

I've added code to `styles_export.dart` to export `tile_handle_style.dart`.
