### PR TITLE
Disabling the multiDayHeader will render those events in the calendar grid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.6
+- Renamed `showHeader` to `showMultiDayHeader` in MultiDayViewConfiguration.
+- If `showMultiDayHeader` is false, the header will not be displayed and multiDayEvents will be rendered in the calendar grid.
+
 ## 0.3.5
 - Added animateToDateTime to CalendarController.
 - Fixed visibleStartTimeOfDay so it takes start hour into account.

--- a/lib/src/models/view_configurations/multi_day_configurations/custom_multi_day_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/custom_multi_day_configuration.dart
@@ -24,7 +24,7 @@ class CustomMultiDayConfiguration extends MultiDayViewConfiguration {
     super.startHour = 0,
     super.endHour = 24,
     super.createEventTrigger,
-    super.showHeader,
+    super.showMultiDayHeader,
   });
 
   @override

--- a/lib/src/models/view_configurations/multi_day_configurations/day_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/day_configuration.dart
@@ -28,7 +28,7 @@ class DayConfiguration extends MultiDayViewConfiguration
     super.endHour = 24,
     super.initialHeightPerMinute,
     super.createEventTrigger,
-    super.showHeader,
+    super.showMultiDayHeader,
   }) {
     super.numberOfDays = 1;
     super.firstDayOfWeek = 1;

--- a/lib/src/models/view_configurations/multi_day_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/multi_day_view_configuration.dart
@@ -9,7 +9,7 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
     bool? paintWeekNumber,
     double? initialHeightPerMinute,
     CreateEventTrigger? createEventTrigger,
-    bool showHeader = true,
+    bool showMultiDayHeader = true,
     double hourLineLeftMargin = 56,
     required double timelineWidth,
     required double daySeparatorLeftOffset,
@@ -51,7 +51,7 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
     _enableRescheduling = enableRescheduling;
     _enableResizing = enableResizing;
 
-    _showHeader = showHeader;
+    _showHeader = showMultiDayHeader;
     _hourLineLeftMargin = hourLineLeftMargin;
 
     _initialHeightPerMinute = initialHeightPerMinute ?? 0.7;
@@ -247,8 +247,8 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
   }
 
   late bool _showHeader;
-  bool get showHeader => _showHeader;
-  set showHeader(bool value) {
+  bool get showMultiDayHeader => _showHeader;
+  set showMultiDayHeader(bool value) {
     _showHeader = value;
     notifyListeners();
   }

--- a/lib/src/models/view_configurations/multi_day_configurations/multi_week_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/multi_week_configuration.dart
@@ -25,7 +25,7 @@ class MultiWeekConfiguration extends MultiDayViewConfiguration {
     super.endHour = 24,
     super.initialHeightPerMinute,
     super.createEventTrigger,
-    super.showHeader,
+    super.showMultiDayHeader,
   }) {
     _numberOfWeeks = numberOfWeeks;
     super.numberOfDays = numberOfWeeks * 7;

--- a/lib/src/models/view_configurations/multi_day_configurations/week_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/week_configuration.dart
@@ -24,7 +24,7 @@ class WeekConfiguration extends MultiDayViewConfiguration {
     super.endHour = 24,
     super.initialHeightPerMinute,
     super.createEventTrigger,
-    super.showHeader,
+    super.showMultiDayHeader,
   }) {
     super.numberOfDays = 7;
   }

--- a/lib/src/models/view_configurations/multi_day_configurations/work_week_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/work_week_configuration.dart
@@ -24,7 +24,7 @@ class WorkWeekConfiguration extends MultiDayViewConfiguration {
     super.endHour = 24,
     super.initialHeightPerMinute,
     super.createEventTrigger,
-    super.showHeader,
+    super.showMultiDayHeader,
   }) {
     super.numberOfDays = 5;
   }

--- a/lib/src/views/multi_day_view/multi_day_header.dart
+++ b/lib/src/views/multi_day_view/multi_day_header.dart
@@ -47,7 +47,7 @@ class MultiDayHeader<T> extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               calendarHeader,
-              if (viewConfiguration.showHeader) dayHeader,
+              if (viewConfiguration.showMultiDayHeader) dayHeader,
             ],
           );
         },

--- a/lib/src/views/multi_day_view/multi_day_page_content.dart
+++ b/lib/src/views/multi_day_view/multi_day_page_content.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kalender/src/models/calendar/calendar_event.dart';
 import 'package:kalender/src/models/calendar/view_state/multi_day_view_state.dart';
 import 'package:kalender/src/providers/calendar_scope.dart';
 import 'package:kalender/src/components/gesture_detectors/multi_day_page_gesture_detector.dart';
@@ -56,10 +57,16 @@ class MultiDayPageContent<T> extends StatelessWidget {
           listenable: scope.eventsController,
           builder: (context, child) {
             // Get the list of events that are visible on the tile stack.
-            final visibleEvents =
-                scope.eventsController.getDayEventsFromDateRange(
-              visibleDateRange,
-            );
+            final Iterable<CalendarEvent<T>> visibleEvents;
+            if (viewConfiguration.showMultiDayHeader) {
+              visibleEvents = scope.eventsController.getDayEventsFromDateRange(
+                visibleDateRange,
+              );
+            } else {
+              visibleEvents = scope.eventsController.getEventsFromDateRange(
+                visibleDateRange,
+              );
+            }
 
             controller.visibleEvents = visibleEvents;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: This Flutter package offers a Calendar Widget featuring integrated Day, MultiDay, and Month views. Moreover, it empowers you to tailor the visual aspects of the calendar widget.
-version: 0.3.5
+version: 0.3.6
 repository: https://github.com/werner-scholtz/kalender.git
 
 environment:


### PR DESCRIPTION
Renamed the `showHeader` to `showMultiDayHeader` to be more specific.
If `showMultiDayHeader` is disabled multiDayEvents will be rendered in the calendar grid.