### PR TITLE
Added support for displaying multidayEvents in the MultiDayPageContent.

### DIFF
--- a/lib/src/models/calendar/calendar_event.dart
+++ b/lib/src/models/calendar/calendar_event.dart
@@ -112,9 +112,15 @@ class CalendarEvent<T> with ChangeNotifier {
       if (date.isSameDay(start)) {
         // The date is the same as the start.
         return DateTimeRange(start: start, end: start.endOfDay);
-      } else {
+      } else if (date.isSameDay(end)) {
         // The date is the same as the end.
         return DateTimeRange(start: end.startOfDay, end: end);
+      } else {
+        // The date is between the start and end.
+        return DateTimeRange(
+          start: date.startOfDay,
+          end: date.endOfDay,
+        );
       }
     }
   }

--- a/lib/src/models/event_group_controllers/event_group_controller.dart
+++ b/lib/src/models/event_group_controllers/event_group_controller.dart
@@ -13,25 +13,6 @@ class EventGroupController<T> {
   }) {
     final tileGroups = <EventGroup<T>>[];
 
-    if (events.length == 1) {
-      for (final date in visibleDates) {
-        final eventDateTimeRange = events.first.dateTimeRangeOnDate(date);
-
-        if (events.first.start.isWithin(date.dayRange) ||
-            events.first.end.isWithin(date.dayRange)) {
-          tileGroups.add(
-            EventGroup<T>(
-              date: date,
-              events: [events.first],
-              dateTimeRange: eventDateTimeRange,
-            ),
-          );
-        }
-      }
-
-      return tileGroups;
-    }
-
     // Loop through each date.
     for (final date in visibleDates) {
       // log(date.toString(), name: 'Date');
@@ -129,12 +110,14 @@ class EventGroupController<T> {
     Iterable<CalendarEvent<T>> events,
     DateTime date,
   ) {
-    return events
-        .where(
-          (element) =>
-              element.start.isSameDay(date) || element.end.isSameDay(date),
-        )
-        .toList()
+    final eventsOnDate = events.where(
+      (element) {
+        return element.occursDuringDateTimeRange(date.dayRange);
+        // element.start.isSameDay(date) || element.end.isSameDay(date);
+      },
+    );
+
+    return eventsOnDate.toList()
       ..sort(
         (a, b) => a.start.compareTo(b.start),
       );

--- a/lib/src/models/view_configurations/multi_day_configurations/custom_multi_day_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/custom_multi_day_configuration.dart
@@ -24,6 +24,7 @@ class CustomMultiDayConfiguration extends MultiDayViewConfiguration {
     super.startHour = 0,
     super.endHour = 24,
     super.createEventTrigger,
+    super.showDayHeader,
     super.showMultiDayHeader,
   });
 
@@ -43,10 +44,14 @@ class CustomMultiDayConfiguration extends MultiDayViewConfiguration {
   }) {
     return DateTimeRange(
       start: visibleStart.startOfDay.subtractDays(
-          (visibleStart.difference(dateTimeRange.start).inDays ~/ numberOfDays).ceil() * numberOfDays,
+        (visibleStart.difference(dateTimeRange.start).inDays ~/ numberOfDays)
+                .ceil() *
+            numberOfDays,
       ),
       end: visibleStart.startOfDay.addDays(
-          (dateTimeRange.end.difference(visibleStart).inDays ~/ numberOfDays).ceil() * numberOfDays,
+        (dateTimeRange.end.difference(visibleStart).inDays ~/ numberOfDays)
+                .ceil() *
+            numberOfDays,
       ),
     );
   }

--- a/lib/src/models/view_configurations/multi_day_configurations/day_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/day_configuration.dart
@@ -28,6 +28,7 @@ class DayConfiguration extends MultiDayViewConfiguration
     super.endHour = 24,
     super.initialHeightPerMinute,
     super.createEventTrigger,
+    super.showDayHeader,
     super.showMultiDayHeader,
   }) {
     super.numberOfDays = 1;

--- a/lib/src/models/view_configurations/multi_day_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/multi_day_view_configuration.dart
@@ -9,6 +9,7 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
     bool? paintWeekNumber,
     double? initialHeightPerMinute,
     CreateEventTrigger? createEventTrigger,
+    bool showDayHeader = true,
     bool showMultiDayHeader = true,
     double hourLineLeftMargin = 56,
     required double timelineWidth,
@@ -51,7 +52,9 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
     _enableRescheduling = enableRescheduling;
     _enableResizing = enableResizing;
 
-    _showHeader = showMultiDayHeader;
+    _showDayHeader = showDayHeader;
+    _showMultiDayHeader = showMultiDayHeader;
+
     _hourLineLeftMargin = hourLineLeftMargin;
 
     _initialHeightPerMinute = initialHeightPerMinute ?? 0.7;
@@ -246,10 +249,20 @@ abstract class MultiDayViewConfiguration extends ViewConfiguration {
     notifyListeners();
   }
 
-  late bool _showHeader;
-  bool get showMultiDayHeader => _showHeader;
-  set showMultiDayHeader(bool value) {
-    _showHeader = value;
+  /// Show the header that displays the days.
+  late bool _showDayHeader;
+  bool get showDayHeader => _showDayHeader;
+  set showDayHeader(bool value) {
+    _showDayHeader = value;
+    notifyListeners();
+  }
+
+  /// Show the multiDay events header.
+  /// If this is disabled the multiDay events will be displayed in the calendar grid.
+  late bool _showMultiDayHeader;
+  bool get showMultiDayEventsHeader => _showMultiDayHeader;
+  set showMultiDayEventsHeader(bool value) {
+    _showMultiDayHeader = value;
     notifyListeners();
   }
 

--- a/lib/src/models/view_configurations/multi_day_configurations/multi_week_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/multi_week_configuration.dart
@@ -25,6 +25,7 @@ class MultiWeekConfiguration extends MultiDayViewConfiguration {
     super.endHour = 24,
     super.initialHeightPerMinute,
     super.createEventTrigger,
+    super.showDayHeader,
     super.showMultiDayHeader,
   }) {
     _numberOfWeeks = numberOfWeeks;

--- a/lib/src/models/view_configurations/multi_day_configurations/week_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/week_configuration.dart
@@ -24,6 +24,7 @@ class WeekConfiguration extends MultiDayViewConfiguration {
     super.endHour = 24,
     super.initialHeightPerMinute,
     super.createEventTrigger,
+    super.showDayHeader,
     super.showMultiDayHeader,
   }) {
     super.numberOfDays = 7;

--- a/lib/src/models/view_configurations/multi_day_configurations/work_week_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_configurations/work_week_configuration.dart
@@ -24,6 +24,7 @@ class WorkWeekConfiguration extends MultiDayViewConfiguration {
     super.endHour = 24,
     super.initialHeightPerMinute,
     super.createEventTrigger,
+    super.showDayHeader,
     super.showMultiDayHeader,
   }) {
     super.numberOfDays = 5;

--- a/lib/src/views/multi_day_view/multi_day_header.dart
+++ b/lib/src/views/multi_day_view/multi_day_header.dart
@@ -47,7 +47,7 @@ class MultiDayHeader<T> extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               calendarHeader,
-              if (viewConfiguration.showMultiDayHeader) dayHeader,
+              dayHeader,
             ],
           );
         },
@@ -71,36 +71,43 @@ class MultipleDayHeader<T> extends StatelessWidget {
     final scope = CalendarScope.of<T>(context);
     final components = CalendarStyleProvider.of(context).components;
 
-    return Row(
+    final weekNumber = SizedBox(
+      width: viewConfiguration.timelineWidth +
+          viewConfiguration.daySeparatorLeftOffset,
+      child: Center(
+        child: viewConfiguration.paintWeekNumber
+            ? components.weekNumberBuilder(visibleDateTimeRange)
+            : null,
+      ),
+    );
+
+    final daysHeader = Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
       children: [
-        SizedBox(
-          width: viewConfiguration.timelineWidth +
-              viewConfiguration.daySeparatorLeftOffset,
-          child: Center(
-            child: viewConfiguration.paintWeekNumber
-                ? components.weekNumberBuilder(visibleDateTimeRange)
-                : null,
+        ...List.generate(
+          viewConfiguration.numberOfDays,
+          (index) => components.dayHeaderBuilder(
+            visibleDateTimeRange.start.add(Duration(days: index)),
+            (date) => scope.functions.onDateTapped?.call(date),
           ),
         ),
+      ],
+    );
+
+    final multiDayEventsHeader = AnimatedMultiDayEventsHeader<T>(
+      viewConfiguration: viewConfiguration,
+      visibleDateRange: visibleDateTimeRange,
+    );
+
+    return Row(
+      children: [
+        weekNumber,
         Expanded(
           child: Column(
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: [
-                  ...List.generate(
-                    viewConfiguration.numberOfDays,
-                    (index) => components.dayHeaderBuilder(
-                      visibleDateTimeRange.start.add(Duration(days: index)),
-                      (date) => scope.functions.onDateTapped?.call(date),
-                    ),
-                  ),
-                ],
-              ),
-              AnimatedMultiDayEventsHeader<T>(
-                viewConfiguration: viewConfiguration,
-                visibleDateRange: visibleDateTimeRange,
-              ),
+              if (viewConfiguration.showDayHeader) daysHeader,
+              if (viewConfiguration.showMultiDayEventsHeader)
+                multiDayEventsHeader,
             ],
           ),
         ),
@@ -123,27 +130,31 @@ class SingleDayHeader<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     final components = CalendarStyleProvider.of(context).components;
 
+    final dateHeader = Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: <Widget>[
+        SizedBox(
+          width: viewConfiguration.timelineWidth +
+              viewConfiguration.daySeparatorLeftOffset,
+          child: components.dayHeaderBuilder(
+            visibleDateTimeRange.start,
+            null,
+          ),
+        ),
+      ],
+    );
+
+    final multiDayEventsHeader = AnimatedMultiDayEventsHeader<T>(
+      viewConfiguration: viewConfiguration,
+      visibleDateRange: visibleDateTimeRange,
+    );
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.end,
       children: <Widget>[
-        Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: <Widget>[
-            SizedBox(
-              width: viewConfiguration.timelineWidth +
-                  viewConfiguration.daySeparatorLeftOffset,
-              child: components.dayHeaderBuilder(
-                visibleDateTimeRange.start,
-                null,
-              ),
-            ),
-          ],
-        ),
+        dateHeader,
         Expanded(
-          child: AnimatedMultiDayEventsHeader<T>(
-            viewConfiguration: viewConfiguration,
-            visibleDateRange: visibleDateTimeRange,
-          ),
+          child: multiDayEventsHeader,
         ),
       ],
     );

--- a/lib/src/views/multi_day_view/multi_day_page_content.dart
+++ b/lib/src/views/multi_day_view/multi_day_page_content.dart
@@ -129,8 +129,6 @@ class MultiDayPageContent<T> extends StatelessWidget {
                     events: [selectedEvent],
                   );
 
-                  print(selectedEventWidgetGroups.length);
-
                   return Stack(
                     clipBehavior: Clip.hardEdge,
                     fit: StackFit.expand,

--- a/lib/src/views/multi_day_view/multi_day_page_content.dart
+++ b/lib/src/views/multi_day_view/multi_day_page_content.dart
@@ -58,7 +58,7 @@ class MultiDayPageContent<T> extends StatelessWidget {
           builder: (context, child) {
             // Get the list of events that are visible on the tile stack.
             final Iterable<CalendarEvent<T>> visibleEvents;
-            if (viewConfiguration.showMultiDayHeader) {
+            if (viewConfiguration.showMultiDayEventsHeader) {
               visibleEvents = scope.eventsController.getDayEventsFromDateRange(
                 visibleDateRange,
               );
@@ -128,6 +128,8 @@ class MultiDayPageContent<T> extends StatelessWidget {
                     visibleDates: visibleDates,
                     events: [selectedEvent],
                   );
+
+                  print(selectedEventWidgetGroups.length);
 
                   return Stack(
                     clipBehavior: Clip.hardEdge,
@@ -219,6 +221,12 @@ class MultiDayPageContent<T> extends StatelessWidget {
         viewConfiguration.daySeparatorLeftOffset);
   }
 
-  bool showSelectedTile(CalendarEventsController<T> controller) =>
-      controller.hasChangingEvent && !controller.selectedEvent!.isMultiDayEvent;
+  bool showSelectedTile(CalendarEventsController<T> controller) {
+    if (viewConfiguration.showMultiDayEventsHeader) {
+      return controller.hasChangingEvent &&
+          !controller.selectedEvent!.isMultiDayEvent;
+    } else {
+      return controller.hasChangingEvent;
+    }
+  }
 }

--- a/lib/src/views/multi_day_view/multi_day_page_content.dart
+++ b/lib/src/views/multi_day_view/multi_day_page_content.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kalender/src/models/calendar/calendar_event.dart';
 import 'package:kalender/src/models/calendar/view_state/multi_day_view_state.dart';
 import 'package:kalender/src/providers/calendar_scope.dart';
 import 'package:kalender/src/components/gesture_detectors/multi_day_page_gesture_detector.dart';


### PR DESCRIPTION
Disabling `showMultiDayEventsHeader` in the ViewConfiguration will remove the MultidayDayHeader and display those events in the MultiDayPageContent.