### PR TITLE
Added configuration for custom `MonthDayHeader` style and component

### DIFF
--- a/lib/src/models/components/month_components.dart
+++ b/lib/src/models/components/month_components.dart
@@ -16,6 +16,9 @@ class MonthBodyComponents {
   /// A function that builds the month grid widget.
   final MonthGridBuilder? monthGridBuilder;
 
+  /// A function that builds the month day header widget.
+  final MonthDayHeaderBuilder? monthDayHeaderBuilder;
+
   /// A function that builds the left trigger widget.
   final HorizontalTriggerWidgetBuilder? leftTriggerBuilder;
 
@@ -25,6 +28,7 @@ class MonthBodyComponents {
   /// Creates overrides for the default components used by the [MonthBody].
   const MonthBodyComponents({
     this.monthGridBuilder,
+    this.monthDayHeaderBuilder,
     this.leftTriggerBuilder,
     this.rightTriggerBuilder,
   });

--- a/lib/src/models/components/month_styles.dart
+++ b/lib/src/models/components/month_styles.dart
@@ -1,3 +1,4 @@
+import 'package:kalender/src/widgets/components/month_day_header.dart';
 import 'package:kalender/src/widgets/components/month_grid.dart';
 import 'package:kalender/src/widgets/components/week_day_header.dart';
 import 'package:kalender/src/widgets/month/month_body.dart';
@@ -16,8 +17,14 @@ class MonthBodyComponentStyles {
   /// The style of the month grid.
   final MonthGridStyle? monthGridStyle;
 
+  /// The style of the day header.
+  final MonthDayHeaderStyle? monthDayHeaderStyle;
+
   /// Creates a override(s) for the default styles used by the [MonthBody].
-  const MonthBodyComponentStyles({this.monthGridStyle});
+  const MonthBodyComponentStyles({
+    this.monthGridStyle,
+    this.monthDayHeaderStyle,
+  });
 }
 
 /// The styles of the default components used by the [MonthHeader].

--- a/lib/src/type_definitions.dart
+++ b/lib/src/type_definitions.dart
@@ -4,6 +4,7 @@ import 'package:kalender/src/models/time_of_day_range.dart';
 import 'package:kalender/src/widgets/components/day_header.dart';
 import 'package:kalender/src/widgets/components/day_separator.dart';
 import 'package:kalender/src/widgets/components/hour_lines.dart';
+import 'package:kalender/src/widgets/components/month_day_header.dart';
 import 'package:kalender/src/widgets/components/month_grid.dart';
 import 'package:kalender/src/widgets/components/resize_handle_positioner.dart';
 import 'package:kalender/src/widgets/components/time_indicator.dart';
@@ -134,6 +135,12 @@ typedef WeekDayHeaderBuilder = Widget Function(
 /// The [style] is used to style the month grid.
 typedef MonthGridBuilder = Widget Function(
   MonthGridStyle? style,
+);
+
+/// The month day header builder.
+typedef MonthDayHeaderBuilder = Widget Function(
+  DateTime date,
+  MonthDayHeaderStyle? style,
 );
 
 /// The trigger widget builder, should be constrained in width.

--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -150,7 +150,13 @@ class MonthBody<T extends Object?> extends StatelessWidget {
 
                 final dates = List.generate(7, (index) {
                   final date = visibleDateTimeRange.start.addDays(index);
-                  return MonthDayHeader(date: date);
+
+                  final monthDayHeaderStyle = styles?.monthDayHeaderStyle;
+                  final monthDayHeder = components?.monthDayHeaderBuilder
+                          ?.call(date, monthDayHeaderStyle) ??
+                      MonthDayHeader(date: date, style: monthDayHeaderStyle);
+
+                  return monthDayHeder;
                 });
 
                 return Expanded(


### PR DESCRIPTION
This pull request adds the option to customize the day header used for the month view.
I needed to style the current day header and I found no possible way since an `IconButton.filled` is used and every style I tried to set was applied both to `IconButton` and `IconButton.filled`.

I maintained the same structure used to customize `WeekDayHeader`.