### PR TITLE
170 scheduleviewconfiguration field itempositionslistener has not been initialized

### DIFF
--- a/lib/src/widgets/drag_targets/schedule_drag_target.dart
+++ b/lib/src/widgets/drag_targets/schedule_drag_target.dart
@@ -122,14 +122,16 @@ class _ScheduleDragTargetState<T extends Object?> extends State<ScheduleDragTarg
         final topScrollTrigger = CursorNavigationTrigger(
           triggerDelay: scrollTrigger.triggerDelay,
           onTrigger: () {
-            final positions = viewController.itemPositionsListener.itemPositions.value;
+            if (!viewController.hasInitialized) return;
+
+            final positions = viewController.itemPositionsListener!.itemPositions.value;
             if (positions.isEmpty) return;
             final first = positions.reduce((value, element) => value.index < element.index ? value : element).index;
 
             final targetIndex = first - 1;
             if (targetIndex < 0) return;
 
-            viewController.itemScrollController.scrollTo(
+            viewController.itemScrollController!.scrollTo(
               index: targetIndex,
               duration: scrollTrigger.animationDuration,
               curve: scrollTrigger.animationCurve,
@@ -141,13 +143,16 @@ class _ScheduleDragTargetState<T extends Object?> extends State<ScheduleDragTarg
         final bottomScrollTrigger = CursorNavigationTrigger(
           triggerDelay: scrollTrigger.triggerDelay,
           onTrigger: () {
-            final positions = viewController.itemPositionsListener.itemPositions.value;
+            if (!viewController.hasInitialized) return;
+
+            final positions = viewController.itemPositionsListener!.itemPositions.value;
             if (positions.isEmpty) return;
+
             final last = positions.reduce((value, element) => value.index > element.index ? value : element).index;
             final targetIndex = last + 1;
             if (targetIndex >= viewController.itemCount) return;
 
-            viewController.itemScrollController.scrollTo(
+            viewController.itemScrollController!.scrollTo(
               index: targetIndex,
               duration: scrollTrigger.animationDuration,
               curve: scrollTrigger.animationCurve,
@@ -176,7 +181,9 @@ class _ScheduleDragTargetState<T extends Object?> extends State<ScheduleDragTarg
 
     // Find the item index based on the cursor position.
     final viewController = widget.viewController;
-    final itemPositions = viewController.itemPositionsListener.itemPositions.value;
+    if (!viewController.hasInitialized) return null;
+
+    final itemPositions = viewController.itemPositionsListener!.itemPositions.value;
     final proportionalOffset = localCursorPosition.dy / widget.constraints.maxHeight;
     final itemIndex = itemPositions
         .where((item) => item.itemLeadingEdge <= proportionalOffset && item.itemTrailingEdge >= proportionalOffset)

--- a/lib/src/widgets/schedule/schedule_body.dart
+++ b/lib/src/widgets/schedule/schedule_body.dart
@@ -205,13 +205,13 @@ class _SchedulePositionListState<T extends Object?> extends State<SchedulePositi
 
     _generateMap();
     eventsController.addListener(_updateMap);
-    viewController.itemPositionsListener.itemPositions.addListener(_positionListener);
+    _itemPositionsListener.itemPositions.addListener(_positionListener);
   }
 
   @override
   void dispose() {
     eventsController.removeListener(_updateMap);
-    viewController.itemPositionsListener.itemPositions.removeListener(_positionListener);
+    _itemPositionsListener.itemPositions.removeListener(_positionListener);
     super.dispose();
   }
 
@@ -270,7 +270,7 @@ class _SchedulePositionListState<T extends Object?> extends State<SchedulePositi
   }
 
   void _positionListener() {
-    final itemPositions = viewController.itemPositionsListener.itemPositions.value;
+    final itemPositions = _itemPositionsListener.itemPositions.value;
     if (itemPositions.isNotEmpty) {
       // Get the first and last visible item positions.
       var first = viewController.itemCount;

--- a/test/view_configuration_test.dart
+++ b/test/view_configuration_test.dart
@@ -88,6 +88,21 @@ void main() {
     });
   });
   group('ScheduleViewConfiguration', () {
+    test('continuous (uninitialized)', () async {
+      final viewConfiguration = ScheduleViewConfiguration.continuous(displayRange: displayRange);
+      final viewController = ContinuousScheduleViewController(
+        viewConfiguration: viewConfiguration,
+        visibleDateTimeRange: ValueNotifier<DateTimeRange>(displayRange),
+        visibleEvents: ValueNotifier<Set<CalendarEvent>>({}),
+        initialDate: initialDate,
+      );
+
+      await expectLater(viewController.animateToDate(DateTime.now()), completes);
+      await expectLater(viewController.animateToDateTime(DateTime.now()), completes);
+      await expectLater(viewController.animateToNextPage(), completes);
+      await expectLater(viewController.animateToPreviousPage(), completes);
+    });
+
     testWidgets('continuous', (tester) async {
       final viewConfiguration = ScheduleViewConfiguration.continuous(displayRange: displayRange);
       final controller = CalendarController(initialDate: initialDate);
@@ -202,6 +217,21 @@ void main() {
           reason: 'Event start ${event.start} should be within the visible range after animating to it',
         );
       }
+    });
+
+    test('paginated (uninitialized)', () async {
+      final viewConfiguration = ScheduleViewConfiguration.continuous(displayRange: displayRange);
+      final viewController = PaginatedScheduleViewController(
+        viewConfiguration: viewConfiguration,
+        visibleDateTimeRange: ValueNotifier<DateTimeRange>(displayRange),
+        visibleEvents: ValueNotifier<Set<CalendarEvent>>({}),
+        initialDate: initialDate,
+      );
+
+      await expectLater(viewController.animateToDate(DateTime.now()), completes);
+      await expectLater(viewController.animateToDateTime(DateTime.now()), completes);
+      await expectLater(viewController.animateToNextPage(), completes);
+      await expectLater(viewController.animateToPreviousPage(), completes);
     });
 
     testWidgets('paginated', (tester) async {


### PR DESCRIPTION
## Description
ScheduleViewController:
- Fix for uninitialized ItemScrollController/ItemPositionsListener.
- Fix for using the PageController when it does not have client.

## Testing
<!-- Please describe the tests you ran to verify your changes -->
- [x] Unit Tests Added/Updated
- [x] Widget Tests Added/Updated (if applicable)

## Checklist
- [x] I have run `flutter analyze` and fixed any issues
- [x] I have run `dart format .`

## Additional Notes
<!-- Add any additional notes about the PR here --> 