### PR TITLE
Fix erroneous warning in month_body

### DIFF
--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -27,7 +27,7 @@ class MonthBody<T extends Object?> extends StatelessWidget {
       'The CalendarController\'s $ViewController<$T> needs to be a $MonthViewController<$T>',
     );
 
-    if (this.configuration is MonthBodyConfiguration<T>) {
+    if (this.configuration is! MonthBodyConfiguration<T>) {
       debugPrint('Warning: The configuration provided to the $MonthBody is not a $MonthBodyConfiguration.');
     }
 


### PR DESCRIPTION
https://github.com/werner-scholtz/kalender/issues/236

## Description

## Testing
No tests added or updated but did successfully run all existing tests

## Checklist
- [X ] I have run `flutter analyze` and fixed any issues
- [ ] I have run `dart format .`

## Additional Notes
This code change was a single character so I did not run dart format.