### PR TITLE
made TextAlign and TextOverflow configurable for TimelineStyle

### DIFF
--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -34,6 +34,12 @@ class TimelineStyle {
   /// The text direction of the text.
   final TextDirection? textDirection;
 
+  /// The text align of the text.
+  final TextAlign? textAlign;
+
+  /// The text overflow of the text.
+  final TextOverflow? textOverflow;
+
   /// The padding of the text.
   final EdgeInsets? textPadding;
 
@@ -49,6 +55,8 @@ class TimelineStyle {
   const TimelineStyle({
     this.textStyle,
     this.textDirection,
+    this.textAlign,
+    this.textOverflow,
     this.stringBuilder,
     this.textPadding,
     this.startDecoration,
@@ -203,6 +211,8 @@ class TimeLine extends StatelessWidget with TimeLineUtils {
             text,
             style: textStyle,
             textDirection: textDirection,
+            textAlign: style?.textAlign,
+            overflow: style?.textOverflow,
           ),
         ),
       );


### PR DESCRIPTION
## Description

## Testing
<!-- Please describe the tests you ran to verify your changes -->
- [ ] Unit Tests Added/Updated
- [ ] Widget Tests Added/Updated (if applicable)

## Checklist
- [x] I have run `flutter analyze` and fixed any issues
- [x] I have run `dart format .`

## Additional Notes

previously `TimeLine` did not allow for `TextAlign.right` without abusing it in some way (such as wrapping it in `DefaultTextStyle`). There is already a style object and it seems to make sense that this also provides the ability to set `TextAlign` and `TextOverflow`, so we added these. We did not add it to the `TimeLineUtils` as this really adds no value as no sharing is needed, just doubles the amount of code.