### PR TITLE
feat(month): add optional week numbers to month view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## 0.18.5
+## 0.18.6
 
 ### Features
 
 - Added optional month-view week numbers via `MonthViewConfiguration.showWeekNumbers`, with customizable `MonthBodyComponents.weekNumberBuilder` and `MonthBodyComponentStyles.weekNumberStyle`.
+
+### Fixes 
+
+- Fixed a month-view regression where the `dropTargetTile` preview could fail to render while resizing an event.
+
+## 0.18.5
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.18.5
 
+### Features
+
+- Added optional month-view week numbers via `MonthViewConfiguration.showWeekNumbers`, with customizable `MonthBodyComponents.weekNumberBuilder` and `MonthBodyComponentStyles.weekNumberStyle`.
+
 ### Fixes
 
 - Fixed an issue where the highlighted selection border (`dropTargetTile`) was painted on the wrong tile or missing entirely in month view overlapping events and the "X more" overflow drop-down.

--- a/README.md
+++ b/README.md
@@ -282,6 +282,18 @@ Shows an entire month at a glance, weeks as rows.
 | -------------------------------------- | ------------ |
 | `MonthViewConfiguration.singleMonth()` | Single month |
 
+Month view can be adjusted with `firstDayOfWeek` and `showWeekNumbers`:
+
+```dart
+MonthViewConfiguration.singleMonth(
+  initialDateTime: DateTime(2025, 1, 1),
+  firstDayOfWeek: DateTime.monday,
+  showWeekNumbers: true,
+)
+```
+
+When `showWeekNumbers` is enabled, the month body adds a leading gutter with one week number per visible row while keeping the day grid at 7 columns.
+
 ### Schedule View
 Presents events in a chronological scrollable list.
 
@@ -825,6 +837,7 @@ Style classes: [`MultiDayComponentStyles`](https://github.com/werner-scholtz/kal
         bodyComponents: MonthBodyComponents(
           monthDayHeaderBuilder: (date, style) => SizedBox(),
           monthGridBuilder: (style) => SizedBox(),
+          weekNumberBuilder: (visibleDateTimeRange, style) => SizedBox(),
           leftTriggerBuilder: (pageWidth) => SizedBox(),
           rightTriggerBuilder: (pageWidth) => SizedBox(),
           overlayBuilders: OverlayBuilders(

--- a/examples/web_demo/lib/widgets/calendar/calendar.dart
+++ b/examples/web_demo/lib/widgets/calendar/calendar.dart
@@ -178,9 +178,34 @@ class _CalendarContentState extends State<CalendarContent> {
           daySeparatorStyle: DaySeparatorStyle(color: lineColor),
         ),
       ),
+      monthComponents: MonthComponents(
+        bodyComponents: MonthBodyComponents(
+          weekNumberBuilder: _buildWeekNumberText,
+        ),
+      ),
       monthComponentStyles: MonthComponentStyles(
         bodyStyles: MonthBodyComponentStyles(
           monthGridStyle: MonthGridStyle(color: lineColor),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWeekNumberText(DateTimeRange visibleDateTimeRange, WeekNumberStyle? style) {
+    final internalDateTimeRange = InternalDateTimeRange(
+      start: InternalDateTime.fromExternal(visibleDateTimeRange.start),
+      end: InternalDateTime.fromExternal(visibleDateTimeRange.end),
+    );
+    final (start, end) = internalDateTimeRange.weekNumbers;
+    final weekNumber = start.toString() + ((end == null) ? '' : ' - $end');
+
+    return Align(
+      alignment: style?.alignment ?? Alignment.center,
+      child: Padding(
+        padding: style?.padding ?? const EdgeInsets.symmetric(horizontal: 4),
+        child: Text(
+          weekNumber,
+          style: style?.textStyle,
         ),
       ),
     );

--- a/examples/web_demo/lib/widgets/configuration/view_editors.dart
+++ b/examples/web_demo/lib/widgets/configuration/view_editors.dart
@@ -121,6 +121,13 @@ class MonthViewEditor extends StatelessWidget {
             firstDayOfWeek: value,
           ),
         ),
+        SwitchListTile.adaptive(
+          value: viewConfiguration.showWeekNumbers,
+          onChanged: (value) => context.configuration.viewConfiguration = viewConfiguration.copyWith(
+            showWeekNumbers: value,
+          ),
+          title: const Text('Show Week Numbers'),
+        ),
       ],
     );
   }

--- a/lib/src/layout_delegates/month_week_number_layout_delegate.dart
+++ b/lib/src/layout_delegates/month_week_number_layout_delegate.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+class MonthWeekNumberBodyLayoutDelegate extends MultiChildLayoutDelegate {
+  final int? gutterId;
+  final int gridId;
+  final int contentId;
+
+  MonthWeekNumberBodyLayoutDelegate({
+    required this.gutterId,
+    required this.gridId,
+    required this.contentId,
+  });
+
+  @override
+  void performLayout(Size size) {
+    var gutterWidth = 0.0;
+
+    if (gutterId != null && hasChild(gutterId!)) {
+      final gutterSize = layoutChild(
+        gutterId!,
+        BoxConstraints(
+          minWidth: 0,
+          maxWidth: size.width,
+          minHeight: size.height,
+          maxHeight: size.height,
+        ),
+      );
+      gutterWidth = gutterSize.width;
+      positionChild(gutterId!, Offset.zero);
+    }
+
+    final contentConstraints =
+        BoxConstraints.tight(Size((size.width - gutterWidth).clamp(0.0, size.width), size.height));
+
+    layoutChild(gridId, contentConstraints);
+    positionChild(gridId, Offset(gutterWidth, 0));
+
+    layoutChild(contentId, contentConstraints);
+    positionChild(contentId, Offset(gutterWidth, 0));
+  }
+
+  @override
+  bool shouldRelayout(covariant MonthWeekNumberBodyLayoutDelegate oldDelegate) {
+    return gutterId != oldDelegate.gutterId || gridId != oldDelegate.gridId || contentId != oldDelegate.contentId;
+  }
+}
+
+class MonthWeekNumberHeaderLayoutDelegate extends MultiChildLayoutDelegate {
+  final int? probeId;
+  final int contentId;
+
+  MonthWeekNumberHeaderLayoutDelegate({
+    required this.probeId,
+    required this.contentId,
+  });
+
+  @override
+  void performLayout(Size size) {
+    var probeWidth = 0.0;
+
+    if (probeId != null && hasChild(probeId!)) {
+      final probeSize = layoutChild(
+        probeId!,
+        BoxConstraints(
+          minWidth: 0,
+          maxWidth: size.width,
+          minHeight: 0,
+          maxHeight: size.height,
+        ),
+      );
+      probeWidth = probeSize.width;
+      positionChild(probeId!, Offset.zero);
+    }
+
+    final contentConstraints =
+        BoxConstraints.tight(Size((size.width - probeWidth).clamp(0.0, size.width), size.height));
+    layoutChild(contentId, contentConstraints);
+    positionChild(contentId, Offset(probeWidth, 0));
+  }
+
+  @override
+  bool shouldRelayout(covariant MonthWeekNumberHeaderLayoutDelegate oldDelegate) {
+    return probeId != oldDelegate.probeId || contentId != oldDelegate.contentId;
+  }
+}

--- a/lib/src/models/components/month_components.dart
+++ b/lib/src/models/components/month_components.dart
@@ -2,6 +2,7 @@ import 'package:kalender/src/models/components/components.dart';
 import 'package:kalender/src/widgets/components/month_day_header.dart';
 import 'package:kalender/src/widgets/components/month_grid.dart';
 import 'package:kalender/src/widgets/components/week_day_header.dart';
+import 'package:kalender/src/widgets/components/week_number.dart';
 import 'package:kalender/src/widgets/month/month_body.dart';
 import 'package:kalender/src/widgets/month/month_header.dart';
 
@@ -29,6 +30,9 @@ class MonthBodyComponents {
   /// A function that builds the month day header widget.
   final MonthDayHeaderBuilder monthDayHeaderBuilder;
 
+  /// A function that builds the week number widget.
+  final WeekNumberBuilder weekNumberBuilder;
+
   /// A function that builds the left trigger widget.
   final HorizontalTriggerWidgetBuilder? leftTriggerBuilder;
 
@@ -42,6 +46,7 @@ class MonthBodyComponents {
   const MonthBodyComponents({
     this.monthGridBuilder = MonthGrid.builder,
     this.monthDayHeaderBuilder = MonthDayHeader.builder,
+    this.weekNumberBuilder = WeekNumber.builder,
     this.leftTriggerBuilder,
     this.rightTriggerBuilder,
     this.overlayBuilders = const OverlayBuilders(),

--- a/lib/src/models/components/month_styles.dart
+++ b/lib/src/models/components/month_styles.dart
@@ -1,7 +1,9 @@
+import 'package:flutter/material.dart';
 import 'package:kalender/src/models/components/components.dart';
 import 'package:kalender/src/widgets/components/month_day_header.dart';
 import 'package:kalender/src/widgets/components/month_grid.dart';
 import 'package:kalender/src/widgets/components/week_day_header.dart';
+import 'package:kalender/src/widgets/components/week_number.dart';
 import 'package:kalender/src/widgets/month/month_body.dart';
 import 'package:kalender/src/widgets/month/month_header.dart';
 
@@ -27,6 +29,9 @@ class MonthBodyComponentStyles {
   /// The style of the day header.
   final MonthDayHeaderStyle monthDayHeaderStyle;
 
+  /// The style of the week number.
+  final WeekNumberStyle weekNumberStyle;
+
   /// The styles of the overlay components.
   final OverlayStyles? overlayStyles;
 
@@ -34,6 +39,9 @@ class MonthBodyComponentStyles {
   const MonthBodyComponentStyles({
     this.monthGridStyle = const MonthGridStyle(),
     this.monthDayHeaderStyle = const MonthDayHeaderStyle(),
+    this.weekNumberStyle = const WeekNumberStyle(
+      alignment: Alignment.topCenter,
+    ),
     this.overlayStyles,
   });
 }

--- a/lib/src/models/view_configurations/month_view_configuration.dart
+++ b/lib/src/models/view_configurations/month_view_configuration.dart
@@ -10,12 +10,16 @@ class MonthViewConfiguration extends ViewConfiguration {
   /// The first day of the week.
   final int firstDayOfWeek;
 
+  /// Whether week numbers should be shown in month view.
+  final bool showWeekNumbers;
+
   MonthViewConfiguration({
     required super.name,
     super.initialDateTime,
     super.initialDateSelectionStrategy,
     super.nowCallback,
     required this.firstDayOfWeek,
+    required this.showWeekNumbers,
     required this.pageIndexCalculator,
   }) : assert(
           firstDayOfWeek >= 1 && firstDayOfWeek <= 7,
@@ -30,6 +34,7 @@ class MonthViewConfiguration extends ViewConfiguration {
     super.nowCallback,
     DateTimeRange? displayRange,
     this.firstDayOfWeek = defaultFirstDayOfWeek,
+    this.showWeekNumbers = false,
   }) : pageIndexCalculator = MonthIndexCalculator(
           dateTimeRange: displayRange ?? kDefaultRange(),
           firstDayOfWeek: firstDayOfWeek,
@@ -40,6 +45,7 @@ class MonthViewConfiguration extends ViewConfiguration {
     DateTime? selectedDate,
     InitialDateSelectionStrategy? initialDateSelectionStrategy,
     int? firstDayOfWeek,
+    bool? showWeekNumbers,
     EdgeInsets? eventPadding,
   }) {
     return MonthViewConfiguration.singleMonth(
@@ -47,6 +53,7 @@ class MonthViewConfiguration extends ViewConfiguration {
       initialDateTime: initialDateTime ?? initialDateTime,
       initialDateSelectionStrategy: initialDateSelectionStrategy ?? this.initialDateSelectionStrategy,
       firstDayOfWeek: firstDayOfWeek ?? this.firstDayOfWeek,
+      showWeekNumbers: showWeekNumbers ?? this.showWeekNumbers,
       displayRange: pageIndexCalculator.dateTimeRange,
     );
   }
@@ -58,12 +65,13 @@ class MonthViewConfiguration extends ViewConfiguration {
     return other is MonthViewConfiguration &&
         other.initialDateTime == initialDateTime &&
         other.pageIndexCalculator == pageIndexCalculator &&
-        other.firstDayOfWeek == firstDayOfWeek;
+        other.firstDayOfWeek == firstDayOfWeek &&
+        other.showWeekNumbers == showWeekNumbers;
   }
 
   @override
   int get hashCode {
-    return Object.hash(initialDateTime, pageIndexCalculator, firstDayOfWeek);
+    return Object.hash(initialDateTime, pageIndexCalculator, firstDayOfWeek, showWeekNumbers);
   }
 }
 

--- a/lib/src/widgets/components/month_grid.dart
+++ b/lib/src/widgets/components/month_grid.dart
@@ -44,7 +44,6 @@ class MonthGrid extends StatelessWidget {
   Widget build(BuildContext context) {
     final thickness = style?.thickness ?? 0;
     final color = style?.color ?? Theme.of(context).colorScheme.surfaceContainerHighest;
-
     return Stack(
       children: <Widget>[
         Row(

--- a/lib/src/widgets/components/week_day_header.dart
+++ b/lib/src/widgets/components/week_day_header.dart
@@ -47,14 +47,6 @@ class WeekDayHeader extends StatelessWidget {
     final padding = style?.padding ?? const EdgeInsets.symmetric(vertical: 2);
     final textStyle = style?.textStyle ?? Theme.of(context).textTheme.bodySmall;
     final dateText = style?.stringBuilder?.call(date) ?? date.dayNameLocalized(context.locale);
-    return Padding(
-      padding: padding,
-      child: Center(
-        child: Text(
-          dateText,
-          style: textStyle,
-        ),
-      ),
-    );
+    return Padding(padding: padding, child: Center(child: Text(dateText, style: textStyle)));
   }
 }

--- a/lib/src/widgets/components/week_number.dart
+++ b/lib/src/widgets/components/week_number.dart
@@ -19,6 +19,7 @@ class WeekNumberStyle {
     this.visualDensity,
     this.tooltip,
     this.padding,
+    this.alignment,
   });
 
   /// The [TextStyle] used by the [WeekNumber] widget to display the week number.
@@ -32,6 +33,9 @@ class WeekNumberStyle {
 
   /// The padding around by the [WeekNumber] widget.
   final EdgeInsets? padding;
+
+  /// The alignment of the week number within its available cell.
+  final AlignmentGeometry? alignment;
 }
 
 /// A widget that displays the week number.
@@ -58,7 +62,8 @@ class WeekNumber extends StatelessWidget {
 
     final padding = weekNumberStyle?.padding ?? const EdgeInsets.symmetric(horizontal: 4);
 
-    return Center(
+    return Align(
+      alignment: weekNumberStyle?.alignment ?? Alignment.center,
       child: Padding(
         padding: padding,
         child: IconButton.filledTonal(

--- a/lib/src/widgets/events_widgets/multi_day_events_widget.dart
+++ b/lib/src/widgets/events_widgets/multi_day_events_widget.dart
@@ -294,11 +294,20 @@ class _MultiDayEventLayoutWidgetState extends State<MultiDayEventLayoutWidget> {
         if (!event.internalRange(location: context.location).overlaps(widget.internalDateTimeRange)) {
           return const SizedBox();
         }
+
+        final previewEvents = widget.events.toList();
+        final selectedEventIndex =
+            previewEvents.indexWhere((item) => item.id == context.calendarController.selectedEventId);
+        if (selectedEventIndex != -1) {
+          previewEvents[selectedEventIndex] = event;
+        } else {
+          previewEvents.insert(0, event);
+        }
+
         final frame = generateMultiDayLayoutFrame(
           visibleDateTimeRange: widget.internalDateTimeRange,
-          events: widget.events,
+          events: previewEvents,
           textDirection: widget.textDirection,
-          // TODO: check
           cache: null,
           location: widget.location,
         );
@@ -322,9 +331,7 @@ class _MultiDayEventLayoutWidgetState extends State<MultiDayEventLayoutWidget> {
               child: event.id == context.calendarController.selectedEventId
                   ? Padding(
                       padding: widget.configuration.eventPadding,
-                      child: context.tileComponents.dropTargetTile
-                              ?.call(context.eventsController.byId(event.id) ?? event) ??
-                          const SizedBox(),
+                      child: context.tileComponents.dropTargetTile?.call(event) ?? const SizedBox(),
                     )
                   : const SizedBox(),
             ),

--- a/lib/src/widgets/internal_components/month_week_number_gutter.dart
+++ b/lib/src/widgets/internal_components/month_week_number_gutter.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/providers/calendar_provider.dart';
+
+class MonthWeekNumberGutter extends StatelessWidget {
+  final InternalDateTimeRange visibleRange;
+  final int numberOfRows;
+  final WeekNumberBuilder weekNumberBuilder;
+  final WeekNumberStyle? weekNumberStyle;
+  final BorderSide dividerSide;
+
+  const MonthWeekNumberGutter({
+    super.key,
+    required this.visibleRange,
+    required this.numberOfRows,
+    required this.weekNumberBuilder,
+    required this.weekNumberStyle,
+    required this.dividerSide,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicWidth(
+      child: Column(
+        children: List.generate(
+          numberOfRows,
+          (index) {
+            final range = _rangeForRow(index);
+            return Expanded(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border(
+                    top: index == 0 ? dividerSide : BorderSide.none,
+                    bottom: dividerSide,
+                  ),
+                ),
+                child: weekNumberBuilder(
+                  range.forLocation(location: context.location),
+                  weekNumberStyle,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  InternalDateTimeRange _rangeForRow(int index) {
+    final start = visibleRange.start.add(Duration(days: index * DateTime.daysPerWeek));
+    return InternalDateTimeRange(start: start, end: start.add(const Duration(days: DateTime.daysPerWeek)));
+  }
+}
+
+class MonthWeekNumberSpacer extends StatelessWidget {
+  final InternalDateTimeRange visibleRange;
+  final int numberOfRows;
+  final WeekNumberBuilder weekNumberBuilder;
+  final WeekNumberStyle? weekNumberStyle;
+
+  const MonthWeekNumberSpacer({
+    super.key,
+    required this.visibleRange,
+    required this.numberOfRows,
+    required this.weekNumberBuilder,
+    required this.weekNumberStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return _WidthOnly(
+      child: IntrinsicWidth(
+        child: Stack(
+          children: List.generate(
+            numberOfRows,
+            (index) {
+              final start = visibleRange.start.add(Duration(days: index * DateTime.daysPerWeek));
+              final range = InternalDateTimeRange(
+                start: start,
+                end: start.add(const Duration(days: DateTime.daysPerWeek)),
+              );
+
+              return weekNumberBuilder(
+                range.forLocation(location: context.location),
+                weekNumberStyle,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WidthOnly extends SingleChildRenderObjectWidget {
+  const _WidthOnly({required super.child});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) => _RenderWidthOnly();
+}
+
+class _RenderWidthOnly extends RenderProxyBox {
+  @override
+  void performLayout() {
+    child?.layout(constraints, parentUsesSize: true);
+    final childWidth = child?.size.width ?? 0;
+    size = constraints.constrain(Size(childWidth, 0));
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {}
+}

--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
+import 'package:kalender/src/layout_delegates/month_week_number_layout_delegate.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/drag_targets/horizontal_drag_target.dart';
 import 'package:kalender/src/widgets/draggable/multi_day_draggable.dart';
 import 'package:kalender/src/widgets/events_widgets/multi_day_events_widget.dart';
+import 'package:kalender/src/widgets/internal_components/month_week_number_gutter.dart';
 import 'package:kalender/src/widgets/internal_components/week_day_headers.dart';
 
 /// This widget is used to display a month body.
@@ -33,8 +35,16 @@ class MonthBody extends StatelessWidget {
 
     final viewController = calendarController.viewController as MonthViewController;
     final viewConfiguration = viewController.viewConfiguration;
+    final showWeekNumbers = viewConfiguration.showWeekNumbers;
     final configuration = this.configuration ?? const MonthBodyConfiguration();
     final pageNavigation = viewConfiguration.pageIndexCalculator;
+    final components = context.components;
+    final monthComponents = components.monthComponents;
+    final monthStyles = components.monthComponentStyles.bodyStyles;
+    final dividerSide = BorderSide(
+      color: monthStyles.monthGridStyle.color ?? Theme.of(context).colorScheme.surfaceContainerHighest,
+      width: monthStyles.monthGridStyle.thickness ?? 0,
+    );
 
     return PageView.builder(
       controller: viewController.pageController,
@@ -48,31 +58,49 @@ class MonthBody extends StatelessWidget {
       itemBuilder: (context, index) {
         final visibleRange = pageNavigation.dateTimeRangeFromIndex(index, context.location);
         final numberOfRows = pageNavigation.numberOfRowsForRange(visibleRange);
+        final grid = MonthGrid.fromContext(context, numberOfRows);
+        final content = Column(
+          children: List.generate(
+            numberOfRows,
+            (index) {
+              final start = visibleRange.start.add(Duration(days: index * DateTime.daysPerWeek));
+              final visibleDateTimeRange = InternalDateTimeRange(
+                start: start,
+                end: start.add(const Duration(days: DateTime.daysPerWeek)),
+              );
 
-        return Stack(
+              return Expanded(
+                child: MonthWeek(
+                  key: ValueKey('MonthWeek-${visibleDateTimeRange.start.toIso8601String()}'),
+                  internalRange: visibleDateTimeRange,
+                  configuration: configuration,
+                  viewController: viewController,
+                ),
+              );
+            },
+          ),
+        );
+
+        return CustomMultiChildLayout(
+          delegate: MonthWeekNumberBodyLayoutDelegate(
+            gutterId: showWeekNumbers ? 0 : null,
+            gridId: 1,
+            contentId: 2,
+          ),
           children: [
-            Positioned.fill(child: MonthGrid.fromContext(context, numberOfRows)),
-            Positioned.fill(
-              child: Column(
-                children: List.generate(
-                  numberOfRows,
-                  (index) {
-                    final start = visibleRange.start.add(Duration(days: index * DateTime.daysPerWeek));
-                    final visibleDateTimeRange =
-                        InternalDateTimeRange(start: start, end: start.add(const Duration(days: DateTime.daysPerWeek)));
-
-                    return Expanded(
-                      child: MonthWeek(
-                        key: ValueKey('MonthWeek-${visibleDateTimeRange.start.toIso8601String()}'),
-                        internalRange: visibleDateTimeRange,
-                        configuration: configuration,
-                        viewController: viewController,
-                      ),
-                    );
-                  },
+            if (showWeekNumbers)
+              LayoutId(
+                id: 0,
+                child: MonthWeekNumberGutter(
+                  visibleRange: visibleRange,
+                  numberOfRows: numberOfRows,
+                  weekNumberBuilder: monthComponents.bodyComponents.weekNumberBuilder,
+                  weekNumberStyle: monthStyles.weekNumberStyle,
+                  dividerSide: dividerSide,
                 ),
               ),
-            ),
+            LayoutId(id: 1, child: grid),
+            LayoutId(id: 2, child: content),
           ],
         );
       },

--- a/lib/src/widgets/month/month_header.dart
+++ b/lib/src/widgets/month/month_header.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
+import 'package:kalender/src/widgets/internal_components/month_week_number_gutter.dart';
 
 /// The month header is a simple widget that just displays the day names.
 class MonthHeader extends StatelessWidget {
@@ -17,7 +18,11 @@ class MonthHeader extends StatelessWidget {
     );
 
     // final viewController = calendarController.viewController as MonthViewController;
+    final viewController = calendarController.viewController as MonthViewController;
+    final viewConfiguration = viewController.viewConfiguration;
     final calendarComponents = context.components;
+    final bodyStyles = calendarComponents.monthComponentStyles.bodyStyles;
+    final bodyComponents = calendarComponents.monthComponents.bodyComponents;
     final styles = calendarComponents.monthComponentStyles.headerStyles;
     final components = calendarComponents.monthComponents.headerComponents;
 
@@ -28,17 +33,32 @@ class MonthHeader extends StatelessWidget {
           debugPrint('Warning: The visibleDateTimeRange is null in MonthHeader.');
           return const SizedBox.shrink();
         }
+        final internalVisibleRange = InternalDateTimeRange.fromDateTimeRange(visibleDateTimeRange);
         final style = styles.weekDayHeaderStyle;
+        final showWeekNumbers = viewConfiguration.showWeekNumbers;
+        final numberOfRows = viewConfiguration.pageIndexCalculator.numberOfRowsForRange(internalVisibleRange);
 
         return Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          children: List<Widget>.generate(
-            7,
-            (index) {
-              final date = visibleDateTimeRange.start.add(Duration(days: index));
-              return components.weekDayHeaderBuilder.call(date, style);
-            },
-          ),
+          children: [
+            if (showWeekNumbers)
+              MonthWeekNumberSpacer(
+                visibleRange: internalVisibleRange,
+                numberOfRows: numberOfRows,
+                weekNumberBuilder: bodyComponents.weekNumberBuilder,
+                weekNumberStyle: bodyStyles.weekNumberStyle,
+              ),
+            Expanded(
+              child: Row(
+                children: List<Widget>.generate(
+                  7,
+                  (index) {
+                    final date = visibleDateTimeRange.start.add(Duration(days: index));
+                    return Expanded(child: components.weekDayHeaderBuilder.call(date, style));
+                  },
+                ),
+              ),
+            ),
+          ],
         );
       },
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: This Flutter package offers a Calendar Widget featuring Day, MultiDay, Month and Schedule views. Moreover, it empowers you to tailor the visual aspects of the calendar widget.
-version: 0.18.5
+version: 0.18.6
 repository: https://github.com/werner-scholtz/kalender.git
 topics: 
   - calendar

--- a/test/layout/multi_day_event_layout_test.dart
+++ b/test/layout/multi_day_event_layout_test.dart
@@ -35,6 +35,7 @@ void main() {
         key: ValueKey(event.id),
         child: Text(event.id.toString()),
       ),
+      dropTargetTile: (event) => Container(key: const ValueKey('drop-target')),
     );
 
     final start = InternalDateTime(2025, 3, 24);
@@ -50,7 +51,7 @@ void main() {
     // Widget-building helper – avoids repeating the full provider/widget tree.
     // -----------------------------------------------------------------------
     Widget buildLayoutWidget({
-      required MultiDayHeaderConfiguration configuration,
+      required HorizontalConfiguration configuration,
       Widget? sizedBoxWrapper,
     }) {
       final inner = MultiDayEventLayoutWidget(
@@ -77,7 +78,7 @@ void main() {
 
     // Convenience overload that wraps the layout widget inside a SizedBox.
     Widget buildLayoutWidgetSized({
-      required MultiDayHeaderConfiguration configuration,
+      required HorizontalConfiguration configuration,
       required double width,
       required double height,
     }) {
@@ -197,6 +198,49 @@ void main() {
       // The button must show '1 more' (one hidden event).
       final buttonText = (find.byKey(MultiDayPortalOverlayButton.textKey).evaluate().single.widget as Text).data!;
       expect(buttonText, equals('1 more'));
+    });
+
+    testWidgets('Drop target layout uses the selected event span during horizontal resize', (tester) async {
+      final storedEvent = CalendarEvent(
+        dateTimeRange: DateTimeRange(
+          start: DateTime(2025, 3, 24),
+          end: DateTime(2025, 3, 25),
+        ),
+      );
+      eventsController.addEvent(storedEvent);
+
+      const dayWidth = 80.0;
+      const tileHeight = 40.0;
+
+      await tester.pumpWidget(
+        buildLayoutWidgetSized(
+          configuration: const MonthBodyConfiguration(tileHeight: tileHeight),
+          width: dayWidth * 7,
+          height: tileHeight * 3,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      controller.selectEvent(storedEvent, internal: true);
+      await tester.pump();
+
+      final initialWidth = tester.getSize(find.byKey(const ValueKey('drop-target'))).width;
+
+      controller.selectEvent(
+        storedEvent.copyWith(
+          dateTimeRange: DateTimeRange(
+            start: DateTime(2025, 3, 24),
+            end: DateTime(2025, 3, 27),
+          ),
+        ),
+        internal: true,
+      );
+      await tester.pump();
+
+      final resizedWidth = tester.getSize(find.byKey(const ValueKey('drop-target'))).width;
+
+      expect(resizedWidth, greaterThan(initialWidth));
+      expect(resizedWidth, greaterThan(dayWidth * 2.5));
     });
 
     testWidgets('Multiple events', (tester) async {

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -35,7 +35,12 @@ void main() {
     });
 
     // All cases use firstDayOfWeek = DateTime.monday (the default).
-    Future<void> pumpMonthView(WidgetTester tester, DateTime initialDateTime) =>
+    Future<void> pumpMonthView(
+      WidgetTester tester,
+      DateTime initialDateTime, {
+      bool showWeekNumbers = false,
+      CalendarComponents? components,
+    }) =>
         pumpAndSettleWithMaterialApp(
           tester,
           CalendarView(
@@ -44,7 +49,9 @@ void main() {
             viewConfiguration: MonthViewConfiguration.singleMonth(
               displayRange: displayRange,
               initialDateTime: initialDateTime,
+              showWeekNumbers: showWeekNumbers,
             ),
+            components: components,
             body: const CalendarBody(),
           ),
         );
@@ -93,6 +100,76 @@ void main() {
         find.byType(MonthDayHeader),
         findsNWidgets(rows * DateTime.daysPerWeek),
         reason: 'Each week row should render ${DateTime.daysPerWeek} day headers',
+      );
+    });
+
+    testWidgets('does not render week numbers by default', (tester) async {
+      await pumpMonthView(tester, DateTime(2025, 1));
+
+      expect(
+        find.byType(WeekNumber),
+        findsNothing,
+        reason: 'Week numbers should be hidden in month view unless explicitly enabled',
+      );
+    });
+
+    testWidgets('renders one week number per row when enabled', (tester) async {
+      const rows = 5; // January 2025 → 5 rows
+      await pumpMonthView(
+        tester,
+        DateTime(2025, 1),
+        showWeekNumbers: true,
+      );
+
+      _expectMonthRows(tester, rows);
+
+      expect(
+        find.byType(WeekNumber),
+        findsNWidgets(rows),
+        reason: 'Expected one week number per month row when enabled',
+      );
+    });
+
+    testWidgets('keeps the month grid at 7 day columns when week numbers are enabled', (tester) async {
+      await pumpMonthView(
+        tester,
+        DateTime(2025, 1),
+        showWeekNumbers: true,
+      );
+
+      expect(
+        find.byType(VerticalDivider),
+        findsNWidgets(8),
+        reason: 'Week numbers should use a leading gutter, not an extra day column',
+      );
+    });
+
+    testWidgets('applies custom week number alignment from style', (tester) async {
+      const rows = 5;
+      final components = CalendarComponents(
+        monthComponentStyles: const MonthComponentStyles(
+          bodyStyles: MonthBodyComponentStyles(
+            weekNumberStyle: WeekNumberStyle(alignment: Alignment.topCenter),
+          ),
+        ),
+      );
+
+      await pumpMonthView(
+        tester,
+        DateTime(2025, 1),
+        showWeekNumbers: true,
+        components: components,
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(WeekNumber),
+          matching: find.byWidgetPredicate(
+            (widget) => widget is Align && widget.alignment == Alignment.topCenter,
+          ),
+        ),
+        findsNWidgets(rows),
+        reason: 'Month week numbers should respect the configured vertical alignment',
       );
     });
   });


### PR DESCRIPTION
- add showWeekNumbers to MonthViewConfiguration
- render week numbers in a dedicated leading gutter without changing the 7-day grid
- expose month week number builder and style customization hooks
- add widget coverage for default visibility, gutter layout, and alignment
- document the new customization options in README and CHANGELOG

## Description

## Testing
<!-- Please describe the tests you ran to verify your changes -->
- [x] Unit Tests Added/Updated
- [x] Widget Tests Added/Updated (if applicable)

## Checklist
- [x] I have run `flutter analyze` and fixed any issues
- [x] I have run `dart format .`

## Additional Notes
<!-- Add any additional notes about the PR here --> 