### PR TITLE
fix(month): render single-month displayRange (numberOfPages off-by-one)

### DIFF
--- a/lib/src/models/view_configurations/page_index_calculator.dart
+++ b/lib/src/models/view_configurations/page_index_calculator.dart
@@ -118,7 +118,10 @@ class DayIndexCalculator extends PageIndexCalculator {
     final startOfRange = internalRange(location).start;
     // Calculate the difference in days between the two dates.
     final days = startOfDate.difference(startOfRange).inDays;
-    return days.clamp(0, numberOfPages(location) - 1);
+    // Guard against an empty range (numberOfPages == 0), where numberOfPages - 1
+    // would be a negative upper bound and make clamp throw.
+    final pageCount = numberOfPages(location);
+    return pageCount == 0 ? 0 : days.clamp(0, pageCount - 1);
   }
 
   @override
@@ -288,7 +291,10 @@ class FreeScrollFunctions extends PageIndexCalculator {
     final startOfRange = internalRange(location).start;
     // Calculate the difference in days between the two dates.
     final days = startOfDate.difference(startOfRange).inDays;
-    return days.clamp(0, numberOfPages(location) - 1);
+    // Guard against an empty range (numberOfPages == 0), where numberOfPages - 1
+    // would be a negative upper bound and make clamp throw.
+    final pageCount = numberOfPages(location);
+    return pageCount == 0 ? 0 : days.clamp(0, pageCount - 1);
   }
 
   @override

--- a/lib/src/models/view_configurations/page_index_calculator.dart
+++ b/lib/src/models/view_configurations/page_index_calculator.dart
@@ -74,10 +74,15 @@ abstract class PageIndexCalculator {
 
   /// Calculates the page index of the [date].
   ///
-  /// The returned index should be clamped between 0 and the number of pages.
+  /// The returned index should be clamped between 0 and [numberOfPages] minus one.
+  /// [numberOfPages] is a count, while page indices are zero-based, so the last
+  /// valid index is `numberOfPages - 1`.
   int indexFromDate(DateTime date, Location? location);
 
   /// The number of pages that can be displayed.
+  ///
+  /// This is a count (starting at 1), not an index. The last valid page index is
+  /// therefore `numberOfPages - 1`.
   int numberOfPages(Location? location);
 
   /// The adjusted [DateTimeRange] for a specific location.
@@ -113,7 +118,7 @@ class DayIndexCalculator extends PageIndexCalculator {
     final startOfRange = internalRange(location).start;
     // Calculate the difference in days between the two dates.
     final days = startOfDate.difference(startOfRange).inDays;
-    return days.clamp(0, numberOfPages(location));
+    return days.clamp(0, numberOfPages(location) - 1);
   }
 
   @override
@@ -186,7 +191,7 @@ class WeekIndexCalculator extends PageIndexCalculator {
       debugPrint('Warning: index is not an integer: $index');
     }
 
-    return index.round().clamp(0, numberOfPages(location));
+    return index.round().clamp(0, numberOfPages(location) - 1);
   }
 
   @override
@@ -196,7 +201,7 @@ class WeekIndexCalculator extends PageIndexCalculator {
     if (numberOfPages.round() != numberOfPages) {
       debugPrint('Warning: numberOfPages is not an integer: $numberOfPages');
     }
-    return (numberOfPages - 1).round();
+    return numberOfPages.round();
   }
 
   @override
@@ -233,14 +238,14 @@ class CustomIndexCalculator extends PageIndexCalculator {
     final startOfDateUtc = startOfDate.startOfDay;
     final internalRange = this.internalRange(location);
     final index = startOfDateUtc.difference(internalRange.start).inDays ~/ numberOfDays;
-    return index.clamp(0, numberOfPages(location));
+    return index.clamp(0, numberOfPages(location) - 1);
   }
 
   @override
   int numberOfPages(Location? location) {
     final internalRange = this.internalRange(location);
     final numberOfDays = internalRange.end.difference(internalRange.start).inDays;
-    return (numberOfDays ~/ this.numberOfDays) - 1;
+    return numberOfDays ~/ this.numberOfDays;
   }
 
   @override
@@ -283,7 +288,7 @@ class FreeScrollFunctions extends PageIndexCalculator {
     final startOfRange = internalRange(location).start;
     // Calculate the difference in days between the two dates.
     final days = startOfDate.difference(startOfRange).inDays;
-    return days.clamp(0, numberOfPages(location));
+    return days.clamp(0, numberOfPages(location) - 1);
   }
 
   @override
@@ -334,7 +339,7 @@ class MonthIndexCalculator extends PageIndexCalculator {
     date = InternalDateTime.fromExternal(date, location: location).startOfDay;
     final internalRange = this.internalRange(location);
     final dateTimeRange = InternalDateTimeRange(start: internalRange.start, end: date);
-    return dateTimeRange.monthDifference.clamp(0, numberOfPages(location));
+    return dateTimeRange.monthDifference.clamp(0, numberOfPages(location) - 1);
   }
 
   /// Returns the number of rows that need to be displayed for the given [range].
@@ -345,7 +350,7 @@ class MonthIndexCalculator extends PageIndexCalculator {
   @override
   int numberOfPages(Location? location) {
     final internalRange = this.internalRange(location);
-    return internalRange.monthDifference - 1;
+    return internalRange.monthDifference;
   }
 
   @override
@@ -408,13 +413,13 @@ class PaginatedScheduleIndexCalculator extends PageIndexCalculator {
     date = InternalDateTime.fromExternal(date, location: location).startOfDay;
     final internalRange = this.internalRange(location);
     final dateTimeRange = InternalDateTimeRange(start: internalRange.start, end: date);
-    return dateTimeRange.monthDifference.clamp(0, numberOfPages(location));
+    return dateTimeRange.monthDifference.clamp(0, numberOfPages(location) - 1);
   }
 
   @override
   int numberOfPages(Location? location) {
     final internalRange = this.internalRange(location);
-    return internalRange.monthDifference - 1;
+    return internalRange.monthDifference;
   }
 
   @override

--- a/test/models/page_index_calculator_test.dart
+++ b/test/models/page_index_calculator_test.dart
@@ -68,13 +68,15 @@ void main() {
         index = calculator.indexFromDate(TZDateTime(location, 2020, 12, 31), location);
         expect(index, 365);
 
+        // range.end is the exclusive end of the range, so it clamps to the last page index.
         index = calculator.indexFromDate(range.end, location);
-        expect(index, 366);
+        expect(index, 365);
       });
 
       test('test numberOfPages', () {
-        final endIndex = calculator.numberOfPages(location);
-        expect(endIndex, 366);
+        // 366 days in the 2020 range (leap year) → 366 pages.
+        final numberOfPages = calculator.numberOfPages(location);
+        expect(numberOfPages, 366);
       });
 
       test('test internalRange', () {
@@ -139,8 +141,9 @@ void main() {
       });
 
       test('test numberOfPages', () {
-        final endIndex = calculator.numberOfPages(location);
-        expect(endIndex, 52);
+        // 53 whole weeks span the adjusted range → 53 pages.
+        final numberOfPages = calculator.numberOfPages(location);
+        expect(numberOfPages, 53);
       });
 
       test('test internalRange', () {
@@ -208,8 +211,9 @@ void main() {
       });
 
       test('test numberOfPages', () {
-        final endIndex = calculator.numberOfPages(location);
-        expect(endIndex, 121);
+        // 366 days / 3 days per page → 122 pages.
+        final numberOfPages = calculator.numberOfPages(location);
+        expect(numberOfPages, 122);
       });
 
       test('test internalRange', () {
@@ -278,8 +282,9 @@ void main() {
       });
 
       test('test numberOfPages', () {
-        final endIndex = calculator.numberOfPages(location);
-        expect(endIndex, 11);
+        // The range spans 12 calendar months (Jan–Dec 2020), so there are 12 pages.
+        final numberOfPages = calculator.numberOfPages(location);
+        expect(numberOfPages, 12);
       });
 
       test('test internalRange', () {
@@ -288,6 +293,21 @@ void main() {
           internalRange,
           InternalDateTimeRange(start: InternalDateTime(2020), end: InternalDateTime(2021)),
         );
+      });
+
+      // Regression: https://github.com/werner-scholtz/kalender/issues/266
+      // A range spanning exactly one calendar month must report a single page,
+      // otherwise the month view renders nothing.
+      test('test numberOfPages for a single-month range', () {
+        final singleMonth = MonthIndexCalculator(
+          dateTimeRange: DateTimeRange(
+            start: TZDateTime(location, 2020, 5),
+            end: TZDateTime(location, 2020, 5, 31),
+          ),
+          firstDayOfWeek: DateTime.monday,
+        );
+        expect(singleMonth.numberOfPages(location), 1);
+        expect(singleMonth.indexFromDate(TZDateTime(location, 2020, 5, 15), location), 0);
       });
     });
 
@@ -380,8 +400,9 @@ void main() {
       });
 
       test('test numberOfPages', () {
-        final endIndex = calculator.numberOfPages(location);
-        expect(endIndex, 11);
+        // 12 calendar months (Jan–Dec 2020) → 12 pages.
+        final numberOfPages = calculator.numberOfPages(location);
+        expect(numberOfPages, 12);
       });
 
       test('test internalRange', () {

--- a/test/models/page_index_calculator_test.dart
+++ b/test/models/page_index_calculator_test.dart
@@ -83,6 +83,19 @@ void main() {
         final internalRange = calculator.internalRange(location);
         expect(internalRange, InternalDateTimeRange.fromDateTimeRange(range));
       });
+
+      // An empty range (start == end) has 0 pages; indexFromDate must not throw
+      // on the negative clamp bound, and should fall back to index 0.
+      test('test indexFromDate for an empty range', () {
+        final emptyRange = DateTimeRange(
+          start: TZDateTime(location, 2020),
+          end: TZDateTime(location, 2020),
+        );
+        final emptyCalculator = DayIndexCalculator(dateTimeRange: emptyRange);
+        expect(emptyCalculator.numberOfPages(location), 0);
+        expect(() => emptyCalculator.indexFromDate(TZDateTime(location, 2020), location), returnsNormally);
+        expect(emptyCalculator.indexFromDate(TZDateTime(location, 2020), location), 0);
+      });
     });
 
     group('WeekIndexCalculator for $location', () {

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -79,6 +79,32 @@ void main() {
     }
 
     // ---------------------------------------------------------------------------
+    // Regression: https://github.com/werner-scholtz/kalender/issues/266
+    //
+    // A displayRange that spans exactly one calendar month must still render a
+    // page. Previously the single-month page was dropped (itemCount was off by
+    // one), leaving a blank view.
+    // ---------------------------------------------------------------------------
+
+    testWidgets('renders a month when the displayRange spans a single month', (tester) async {
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        CalendarView(
+          eventsController: eventsController,
+          calendarController: calendarController,
+          viewConfiguration: MonthViewConfiguration.singleMonth(
+            displayRange: DateTimeRange(start: DateTime(2026, 5), end: DateTime(2026, 5, 31)),
+            initialDateTime: DateTime(2026, 5),
+          ),
+          body: const CalendarBody(),
+        ),
+      );
+
+      // May 2026: May 1 is Friday → startOfWeek Apr 27; Apr 27 + 35 days = Jun 1 > May 31 → 5 rows.
+      _expectMonthRows(tester, 5);
+    });
+
+    // ---------------------------------------------------------------------------
     // Per-row structure
     // ---------------------------------------------------------------------------
 

--- a/test/widgets/page_boundary_test.dart
+++ b/test/widgets/page_boundary_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+/// App-level tests for the page that sits at the very end of a `displayRange`.
+///
+/// Before treating `numberOfPages` as a count, every paginated view dropped its
+/// final in-range page (and a single-page range rendered nothing at all). These
+/// tests navigate to / render that last page and assert it is actually shown, so
+/// they fail on the old behaviour and pass once the off-by-one is fixed.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  Future<void> pump(WidgetTester tester, ViewConfiguration config) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: config,
+        body: const CalendarBody(),
+      ),
+    );
+  }
+
+  bool visibleRangeContains(DateTime date) {
+    final range = calendarController.internalDateTimeRange.value!;
+    return range.dates().any((d) => d.year == date.year && d.month == date.month && d.day == date.day);
+  }
+
+  testWidgets('week view can navigate to the final in-range week', (tester) async {
+    // June 18 and the range end (June 20) are in the same — and therefore the
+    // last — week of the range.
+    final lastWeekDate = DateTime(2025, 6, 18);
+    await pump(
+      tester,
+      MultiDayViewConfiguration.week(
+        displayRange: DateTimeRange(start: DateTime(2025, 6, 1), end: DateTime(2025, 6, 20)),
+        initialDateTime: DateTime(2025, 6, 1),
+      ),
+    );
+
+    calendarController.jumpToDate(lastWeekDate);
+    await tester.pumpAndSettle();
+
+    expect(visibleRangeContains(lastWeekDate), isTrue, reason: 'The last week of the range should be reachable');
+  });
+
+  testWidgets('month view can navigate to the final in-range month', (tester) async {
+    // Range spans May–June 2025; June is the last month.
+    await pump(
+      tester,
+      MonthViewConfiguration.singleMonth(
+        displayRange: DateTimeRange(start: DateTime(2025, 5, 10), end: DateTime(2025, 6, 20)),
+        initialDateTime: DateTime(2025, 5, 15),
+      ),
+    );
+
+    calendarController.jumpToDate(DateTime(2025, 6, 15));
+    await tester.pumpAndSettle();
+
+    final range = calendarController.internalDateTimeRange.value!;
+    expect(range.dominantMonthDate.month, 6, reason: 'The last month of the range should be reachable');
+  });
+
+  testWidgets('paginated schedule renders a single-month range', (tester) async {
+    await pump(
+      tester,
+      ScheduleViewConfiguration.paginated(
+        displayRange: DateTimeRange(start: DateTime(2025, 6, 1), end: DateTime(2025, 6, 30)),
+        initialDateTime: DateTime(2025, 6, 1),
+      ),
+    );
+
+    // With itemCount off by one this PageView had 0 pages and rendered nothing.
+    expect(find.byType(SchedulePositionList), findsWidgets, reason: 'A single-month schedule must render its page');
+  });
+}

--- a/test/widgets/page_navigation_test.dart
+++ b/test/widgets/page_navigation_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+/// Characterization tests for page navigation that must hold regardless of the
+/// page-count convention.
+///
+/// These navigate to a date in the **middle** of a wide range, well away from
+/// the range boundary. The visible page must always contain the requested date.
+/// They are expected to pass both before and after the `numberOfPages` change,
+/// proving that change does not alter normal (non-boundary) navigation.
+void main() {
+  group('Page navigation (preserved behaviour)', () {
+    late DefaultEventsController eventsController;
+    late CalendarController calendarController;
+
+    // A wide range so the target date is nowhere near the first/last page.
+    final wideRange = DateTimeRange(start: DateTime(2024), end: DateTime(2027));
+    // A Wednesday, comfortably inside the range.
+    final target = DateTime(2025, 6, 18);
+
+    setUp(() {
+      eventsController = DefaultEventsController();
+      calendarController = CalendarController();
+    });
+
+    Future<void> pump(WidgetTester tester, ViewConfiguration config) {
+      return pumpAndSettleWithMaterialApp(
+        tester,
+        CalendarView(
+          eventsController: eventsController,
+          calendarController: calendarController,
+          viewConfiguration: config,
+          body: const CalendarBody(),
+        ),
+      );
+    }
+
+    bool visibleRangeContains(DateTime date) {
+      final range = calendarController.internalDateTimeRange.value!;
+      return range.dates().any((d) => d.year == date.year && d.month == date.month && d.day == date.day);
+    }
+
+    testWidgets('single day view lands on the requested mid-range day', (tester) async {
+      await pump(
+        tester,
+        MultiDayViewConfiguration.singleDay(displayRange: wideRange, initialDateTime: DateTime(2024, 1, 1)),
+      );
+      calendarController.jumpToDate(target);
+      await tester.pumpAndSettle();
+      expect(visibleRangeContains(target), isTrue);
+    });
+
+    testWidgets('week view lands on the week containing a mid-range date', (tester) async {
+      await pump(
+        tester,
+        MultiDayViewConfiguration.week(displayRange: wideRange, initialDateTime: DateTime(2024, 1, 1)),
+      );
+      calendarController.jumpToDate(target);
+      await tester.pumpAndSettle();
+      expect(visibleRangeContains(target), isTrue);
+    });
+
+    testWidgets('month view lands on the month containing a mid-range date', (tester) async {
+      await pump(
+        tester,
+        MonthViewConfiguration.singleMonth(displayRange: wideRange, initialDateTime: DateTime(2024, 1, 1)),
+      );
+      calendarController.jumpToDate(target);
+      await tester.pumpAndSettle();
+      final range = calendarController.internalDateTimeRange.value!;
+      expect(range.dominantMonthDate.year, target.year);
+      expect(range.dominantMonthDate.month, target.month);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #266 — `MonthViewConfiguration.singleMonth` with a `displayRange` spanning exactly one month rendered a blank page.

**Root cause:** `MonthIndexCalculator.numberOfPages` returned `monthDifference - 1`, but every consumer (`itemCount:` on the PageViews, `populateMaps`) treats it as a **count**. For a single-month range that count was `0`, so the `PageView` had no pages and rendered nothing. The same off-by-one silently dropped the final in-range page in the Week, Custom and PaginatedSchedule calculators too — just masked by the huge default range.

**Fix:** standardise every `PageIndexCalculator` so `numberOfPages` is a true count (matching `DayIndexCalculator`, which already was), and clamp `indexFromDate` to `numberOfPages - 1` (the last zero-based index). An empty range (`start == end`) guard keeps Day/FreeScroll from throwing on the now-negative clamp bound.

## Behavioural impact

- Week / Custom / Month / PaginatedSchedule now render the final in-range page that was previously dropped (and a single-month month/schedule no longer renders blank).
- `indexFromDate` results are numerically unchanged for Week/Custom/Month/Paginated (clamp value is identical), so navigation, `initialPage` and `currentPage` don't move.
- Day/FreeScroll only change when navigating to a date at/after the exclusive range end.

## Tests

Commits are ordered so the behaviour change is reviewable:

1. **characterization tests** (before the fix) — mid-range day/week/month navigation; green on the old code, proving normal paging is preserved.
2. the two **fix** commits.
3. **boundary tests** (after the fix) — last in-range week/month and a single-month paginated schedule; red on the old code, green after.

Calculator unit tests run across a 5-zone timezone matrix. Full suite: 1151 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)