### PR TITLE
docs: add benchmarks overlay badge + link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="https://pub.dev/packages/kalender"><img src="https://img.shields.io/pub/v/kalender.svg" alt="pub.dev version"></a>
   <a href="https://github.com/werner-scholtz/kalender/actions"><img src="https://github.com/werner-scholtz/kalender/actions/workflows/flutter_analyze_and_test.yml/badge.svg" alt="build status"></a>
+  <a href="https://werner-scholtz.github.io/kalender/dev/bench/"><img src="https://img.shields.io/badge/benchmarks-live-blueviolet.svg" alt="benchmarks"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license: MIT"></a>
 </p>
 
@@ -12,7 +13,7 @@
 
 A highly customizable Flutter calendar widget with Day, MultiDay, Month, and Schedule views — featuring drag-and-drop rescheduling, event resizing, timezone support, and full control over appearance and behavior.
 
-**[Live Demo](https://werner-scholtz.github.io/kalender/)** · **[Migration Guide](MIGRATION.md)**
+**[Live Demo](https://werner-scholtz.github.io/kalender/)** · **[Benchmarks](https://werner-scholtz.github.io/kalender/dev/bench/)** · **[Migration Guide](MIGRATION.md)**
 
 > [!WARNING]
 > This package is still in development — API changes may occur before version 1.0.0.


### PR DESCRIPTION
## What

Adds a link to the live performance overlay from the README:

1. A **badge** in the top badge row (between build status and license) — `benchmarks: live`, linking to https://werner-scholtz.github.io/kalender/dev/bench/
2. A **text link** in the header line next to the Live Demo.

## Why

The github-action-benchmark dashboard (micro-benchmarks + frame profiling, with backfilled history) is live but wasn't discoverable from the README. This surfaces it.

## Notes

The badge is a static shields.io badge — github-action-benchmark doesn't expose a dynamic status endpoint, so a static "live" badge is the clean option and won't go stale on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)