### PR TITLE
test(month): regression coverage for #255 overflow button with no events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Fixes
 
-- Fixed a blank page when a `displayRange` spanned exactly one month, and the same off-by-one page count that dropped the final in-range page in the week, custom multi-day, and paginated schedule views (#266).
+- Fixed a blank page when a `displayRange` spanned exactly one month, and the same off-by-one page count that dropped the final in-range page in the week, custom multi-day, and paginated schedule views. [#266](https://github.com/werner-scholtz/kalender/issues/266)
+- Fixed the month view showing a "+N more" overflow button when there were no events, and on very short row heights. Added end-to-end regression coverage. [#255](https://github.com/werner-scholtz/kalender/issues/255)
 
 ## 0.18.6
 

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -198,5 +198,68 @@ void main() {
         reason: 'Month week numbers should respect the configured vertical alignment',
       );
     });
+
+    // ---------------------------------------------------------------------------
+    // Regression: https://github.com/werner-scholtz/kalender/issues/255
+    //
+    // A month view showed a "+N more" overflow button (MultiDayPortalOverlayButton)
+    // even when there were no events. A large tileHeight forces MonthBody to compute
+    // maxNumberOfVerticalEvents == 0 (floor(cellHeight / tileHeight) - 1, clamped to
+    // 0), which is the exact condition that used to produce the spurious buttons.
+    //
+    // Unlike the MultiDayEventLayoutWidget-level tests in
+    // test/layout/multi_day_event_layout_test.dart, these drive the full CalendarView
+    // month path so MonthBody itself derives the max from the cell height.
+    // ---------------------------------------------------------------------------
+
+    // A tileHeight far larger than any week-row height guarantees max == 0.
+    const tallTileHeight = 1000.0;
+
+    Future<void> pumpShortCellMonthView(WidgetTester tester, DateTime initialDateTime) =>
+        pumpAndSettleWithMaterialApp(
+          tester,
+          CalendarView(
+            eventsController: eventsController,
+            calendarController: calendarController,
+            viewConfiguration: MonthViewConfiguration.singleMonth(
+              displayRange: displayRange,
+              initialDateTime: initialDateTime,
+            ),
+            body: const CalendarBody(
+              monthBodyConfiguration: MonthBodyConfiguration(tileHeight: tallTileHeight),
+            ),
+          ),
+        );
+
+    testWidgets('shows no overflow button in month view when there are no events (#255)', (tester) async {
+      // eventsController is empty – do not add any events.
+      await pumpShortCellMonthView(tester, DateTime(2025, 1));
+
+      // The month renders, but with zero events there must be no overflow buttons,
+      // even though maxNumberOfVerticalEvents is 0.
+      expect(find.byType(MonthBody), findsOneWidget);
+      expect(find.byType(MultiDayPortalOverlayButton), findsNothing);
+    });
+
+    testWidgets('shows exactly one overflow button for a single event when max is 0 (#255)', (tester) async {
+      // A single-day event on Jan 15, 2025 (within the displayed month).
+      eventsController.addEvent(
+        CalendarEvent(
+          dateTimeRange: DateTimeRange(
+            start: DateTime(2025, 1, 15, 9),
+            end: DateTime(2025, 1, 15, 10),
+          ),
+        ),
+      );
+
+      await pumpShortCellMonthView(tester, DateTime(2025, 1));
+
+      // With max == 0 the single event is hidden behind exactly one overflow button;
+      // every other (empty) day must stay button-free.
+      expect(find.byType(MultiDayPortalOverlayButton), findsOneWidget);
+
+      final button = tester.widget<MultiDayPortalOverlayButton>(find.byType(MultiDayPortalOverlayButton));
+      expect(button.numberOfHiddenRows, greaterThan(0));
+    });
   });
 }


### PR DESCRIPTION
## Summary

Issue #255 reports the month view showing a "+N more" overflow button (`MultiDayPortalOverlayButton`) even when there are **no events**.

The underlying bug was **already fixed** on `main` (and is present in the yet-to-be-published `v0.18.7`) via three changes:
- `columnRowMap` initialized to `-1` (sentinel) instead of `0` — empty columns don't trigger buttons when `maxNumberOfRows == 0`.
- `totalNumberOfRows: sortedEvents.isEmpty ? 0 : maxRow + 1` — empty event lists yield `0` rows.
- `MonthBody` clamps `maxNumberOfVerticalEvents` to `>= 0` — a short cell height can no longer produce a negative max.

However, the existing tests only drove `MultiDayEventLayoutWidget` directly with `maximumNumberOfVerticalEvents: 0`. **Nothing exercised the real reported path** — a full `CalendarView` + `MonthViewConfiguration` where `MonthBody` derives the max from cell height. This PR closes that gap and documents the fix.

## Changes

- **`test/widgets/month_body_test.dart`** — two end-to-end regression tests that pump a full month `CalendarView` with a large `tileHeight` (forcing `maxNumberOfVerticalEvents == 0`, the original trigger):
  - no overflow button when there are no events;
  - exactly one overflow button (`numberOfHiddenRows > 0`) for a single event, with empty days staying button-free.
- **`CHANGELOG.md`** — documents #255 under the (unpublished) `0.18.7` section and links both #255 and #266 to their issues.

No production code changes — the fix already exists in `lib/`.

## Verification

- `flutter test test/widgets/month_body_test.dart test/layout/multi_day_event_layout_test.dart` — all pass.
- `dart analyze` — no issues.
- Sanity check: temporarily reverting the `columnRowMap` sentinel + empty-list guard makes the "no events" test fail, confirming it catches the bug.

> Note: `v0.18.7` is tagged in git but was never published to pub.dev, so this does **not** bump the version. After merge the stale `v0.18.7` tag should be deleted and re-created on the new merge commit before publishing.

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)