### PR TITLE
test: regression coverage for time-indicator behaviour (#261) + 0.18.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.18.8
+
+### Tests
+
+- Added end-to-end `CalendarView` regression coverage for the time indicator (correct day column, hidden on off-page days), run across the timezone matrix. Confirms the timezone `isSameDay`/today-detection fix from `0.18.0` resolves the reported time-indicator behaviour. [#261](https://github.com/werner-scholtz/kalender/issues/261) [#254](https://github.com/werner-scholtz/kalender/issues/254)
+
 ## 0.18.7
 
 ### Fixes

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: This Flutter package offers a Calendar Widget featuring Day, MultiDay, Month and Schedule views. Moreover, it empowers you to tailor the visual aspects of the calendar widget.
-version: 0.18.7
+version: 0.18.8
 repository: https://github.com/werner-scholtz/kalender.git
 topics: 
   - calendar

--- a/test/widgets/time_indicator_calendar_view_test.dart
+++ b/test/widgets/time_indicator_calendar_view_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/internal_components/time_indicator_positioner.dart';
+
+import '../utilities.dart';
+
+/// End-to-end regression coverage for the time indicator inside a real
+/// [CalendarView], targeting the manifestations reported in
+/// https://github.com/werner-scholtz/kalender/issues/261 (a follow-up to the
+/// `isSameDay` timezone bug in #254):
+///
+///   * the indicator showing up on the wrong day (dates other than "today"),
+///   * the indicator appearing on days that are several pages ahead,
+///   * the indicator not showing up at all on the correct day.
+///
+/// The isolated positioner widgets are already covered elsewhere; these tests
+/// exercise the layer users actually hit — a full `CalendarView` + `CalendarBody`
+/// where the real `TimeIndicator` is positioned by `TimeIndicatorPositioner`.
+///
+/// A `nowCallback` fixes "today" so the assertions are deterministic regardless
+/// of the machine's clock, and the suite is run across the timezone matrix via
+/// `tool/test_timezones_linux.dart` to cover the "far from GMT" condition that
+/// made the original bug visible.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  // A known Monday and the week that starts on it.
+  final monday = DateTime(2026, 4, 13);
+  final weekRange = DateTimeRange(start: monday, end: monday.add(const Duration(days: 7)));
+
+  Future<void> pumpCalendarView(
+    WidgetTester tester,
+    ViewConfiguration viewConfiguration,
+  ) =>
+      pumpAndSettleWithMaterialApp(
+        tester,
+        CalendarView(
+          eventsController: eventsController,
+          calendarController: calendarController,
+          viewConfiguration: viewConfiguration,
+          body: const CalendarBody(),
+        ),
+      );
+
+  group('TimeIndicator in CalendarView (#261)', () {
+    // For each weekday, "today" is fixed to that day at noon (well within the
+    // default time-of-day range so the indicator is drawn). The indicator must
+    // render exactly once and sit in that weekday's column — never on another.
+    for (var weekday = 0; weekday < 7; weekday++) {
+      final today = monday.add(Duration(days: weekday));
+
+      testWidgets('renders in the correct column for weekday $weekday', (tester) async {
+        await pumpCalendarView(
+          tester,
+          MultiDayViewConfiguration.week(
+            displayRange: weekRange,
+            initialDateTime: monday,
+            nowCallback: () => DateTime(today.year, today.month, today.day, 12),
+          ),
+        );
+
+        // Guards "indicator not showing up at all on the correct day".
+        final indicator = find.byType(TimeIndicator);
+        expect(indicator, findsOneWidget, reason: 'The time indicator should be visible on today.');
+
+        // Guards "indicator on the wrong day / several days ahead": the drawn
+        // indicator must line up with the weekday's column. Derive the column
+        // geometry from the positioner so the assertion is independent of the
+        // timeline gutter width.
+        final positionerRect = tester.getRect(find.byType(TimeIndicatorPositioner));
+        final dayWidth = positionerRect.width / 7;
+        final expectedLeft = positionerRect.left + weekday * dayWidth;
+        final indicatorRect = tester.getRect(indicator);
+
+        expect(
+          indicatorRect.left,
+          closeTo(expectedLeft, 1.0),
+          reason: 'Indicator should be in weekday $weekday\'s column.',
+        );
+        expect(
+          indicatorRect.width,
+          closeTo(dayWidth, 1.0),
+          reason: 'Indicator should span exactly one day column.',
+        );
+      });
+    }
+
+    testWidgets('single-day view shows the indicator when today is the visible day', (tester) async {
+      await pumpCalendarView(
+        tester,
+        MultiDayViewConfiguration.singleDay(
+          displayRange: weekRange,
+          initialDateTime: monday,
+          nowCallback: () => DateTime(monday.year, monday.month, monday.day, 12),
+        ),
+      );
+
+      expect(find.byType(TimeIndicator), findsOneWidget);
+    });
+
+    testWidgets('single-day view hides the indicator when today is several days ahead', (tester) async {
+      // "today" is three days past the visible day — the classic #261 symptom
+      // was the indicator leaking onto pages that aren't today. It must be hidden.
+      final threeDaysAhead = monday.add(const Duration(days: 3));
+
+      await pumpCalendarView(
+        tester,
+        MultiDayViewConfiguration.singleDay(
+          displayRange: weekRange,
+          initialDateTime: monday,
+          nowCallback: () => DateTime(threeDaysAhead.year, threeDaysAhead.month, threeDaysAhead.day, 12),
+        ),
+      );
+
+      expect(
+        find.byType(TimeIndicator),
+        findsNothing,
+        reason: 'The indicator must not appear on a day that is not today.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Investigates the "weird time-indicator behaviour" reported in #261, which was a follow-up to the `isSameDay` timezone bug in #254.

**Finding:** #261's root cause is already fixed. The mixed-offset `isSameDay` bug from #254 was resolved by the `InternalDateTime` refactor + `NowCallback` work shipped in **0.18.0** — `isSameDay` now only compares uniformly-normalised `InternalDateTime` wall-clock components, so the divergence that produced the reported symptoms can no longer occur. Verified green across the full timezone matrix (`New_York`, `London`, `Tokyo`, `Sydney`, `Johannesburg`, `UTC`).

The remaining gap was coverage: the time indicator was only tested via the **isolated** positioner widgets. Nothing exercised the reported layer — a full `CalendarView` where the real `TimeIndicator` is positioned in the tree.

## Changes

- **`test/widgets/time_indicator_calendar_view_test.dart`** (new) — end-to-end `CalendarView` regression coverage:
  - week view: indicator renders in the correct day column for every weekday (guards "shows on the wrong day");
  - single-day view: indicator shows on today, and is **hidden** when today is several pages ahead (guards "indicator appearing several days ahead" / "sometimes not at all").
  - Verified meaningful by mutation-testing the positioner (forcing `todayIndex = 0` fails weekdays 1–6).
- **`CHANGELOG.md` / `pubspec.yaml`** — `0.18.8`. Test-only release (no functional change; `test/` is excluded from the published package).

## Issues

- Closes #261
- Relates to #254 — root cause fixed in 0.18.0; this PR confirms + locks it in. (Can be closed too if you consider its manifestations resolved.)

## Test plan

- `flutter test test/widgets/time_indicator_calendar_view_test.dart` ✅
- `dart tool/test_timezones_linux.dart test/widgets/time_indicator_calendar_view_test.dart` ✅ (all 6 timezones)
- `dart analyze` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)