### PR TITLE
fix(month)!: localize monthDayHeaderBuilder date (v0.19.0) + timezone today-detection coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-## 0.18.8
+## 0.19.0
+
+### Breaking Changes
+
+- `monthDayHeaderBuilder` now receives a localized wall-clock `DateTime` (via `.forLocation()`) instead of a UTC-flagged `InternalDateTime`, matching `dayHeaderBuilder`. This fixes incorrect `DateTime.now()` comparisons in custom month-view day headers. Custom `monthDayHeaderBuilder` implementations must change their `date` parameter type from `InternalDateTime` to `DateTime` — see [MIGRATION.md](MIGRATION.md#v018x--v0190). [#248](https://github.com/werner-scholtz/kalender/issues/248)
 
 ### Tests
 
-- Added end-to-end `CalendarView` regression coverage for the time indicator (correct day column, hidden on off-page days), run across the timezone matrix. Confirms the timezone `isSameDay`/today-detection fix from `0.18.0` resolves the reported time-indicator behaviour. [#261](https://github.com/werner-scholtz/kalender/issues/261) [#254](https://github.com/werner-scholtz/kalender/issues/254)
+- Added end-to-end `CalendarView` regression coverage for the time indicator (correct day column, hidden on off-page days), run across the timezone matrix. Confirms the timezone `isSameDay`/today-detection fix from `0.18.0` resolves the reported time-indicator behaviour. [#261](https://github.com/werner-scholtz/kalender/issues/261)
+- Added end-to-end `CalendarView` today-highlighting coverage (month + multi-day headers, month boundaries, and the `#251` neighbour-day repro), run across the timezone matrix. [#254](https://github.com/werner-scholtz/kalender/issues/254) [#251](https://github.com/werner-scholtz/kalender/issues/251)
 
 ## 0.18.7
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,33 @@
 # Migration Guide
 
+## v0.18.x → v0.19.0
+
+### `monthDayHeaderBuilder` receives a localized `DateTime`
+
+`monthDayHeaderBuilder` now provides a localized wall-clock `DateTime` (via `.forLocation()`), consistent with `dayHeaderBuilder`, instead of a UTC-flagged `InternalDateTime`. This fixes incorrect "today" comparisons against `DateTime.now()` in custom month-view day headers ([#248](https://github.com/werner-scholtz/kalender/issues/248)).
+
+This only affects custom `monthDayHeaderBuilder` implementations that annotate the `date` parameter. Change the type from `InternalDateTime` to `DateTime`:
+
+**Before:**
+```dart
+MonthComponents(
+  bodyComponents: MonthBodyComponents(
+    monthDayHeaderBuilder: (InternalDateTime date, style) => MyHeader(date),
+  ),
+)
+```
+
+**After:**
+```dart
+MonthComponents(
+  bodyComponents: MonthBodyComponents(
+    monthDayHeaderBuilder: (DateTime date, style) => MyHeader(date),
+  ),
+)
+```
+
+The received `date` is already in the calendar's configured location, so any manual `.forLocation()` conversion inside the builder is no longer needed.
+
 ## v0.16.x → v0.17.0
 
 ### Input mode replaces platform-based mobile/desktop split

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -3,8 +3,12 @@ import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
 /// The month day header builder.
+///
+/// The [date] is provided as a wall-clock [DateTime] in the calendar's
+/// configured location (via `.forLocation()`), so consumer comparisons against
+/// `DateTime.now()` behave correctly. See #248.
 typedef MonthDayHeaderBuilder = Widget Function(
-  InternalDateTime date,
+  DateTime date,
   MonthDayHeaderStyle? style,
 );
 
@@ -32,11 +36,11 @@ class MonthDayHeader extends StatelessWidget {
   /// Key applied to the [IconButton] when the date is today.
   static const todayKey = ValueKey('MonthDayHeader.today');
 
-  final InternalDateTime date;
+  final DateTime date;
   final MonthDayHeaderStyle? style;
 
   const MonthDayHeader({super.key, required this.date, this.style});
-  static MonthDayHeader builder(InternalDateTime date, MonthDayHeaderStyle? style) {
+  static MonthDayHeader builder(DateTime date, MonthDayHeaderStyle? style) {
     return MonthDayHeader(date: date, style: style);
   }
 
@@ -44,13 +48,14 @@ class MonthDayHeader extends StatelessWidget {
     final components = context.components;
     final dayHeader = components.monthComponents.bodyComponents.monthDayHeaderBuilder;
     final style = components.monthComponentStyles.bodyStyles.monthDayHeaderStyle;
-    return dayHeader(date, style);
+    return dayHeader(date.forLocation(location: context.location), style);
   }
 
   @override
   Widget build(BuildContext context) {
     final now = context.calendarController.viewController?.viewConfiguration.nowCallback?.call();
-    final isToday = now != null ? date.isToday(now: now) : date.isToday(location: context.location);
+    final localDate = InternalDateTime.fromExternal(date, location: context.location);
+    final isToday = now != null ? localDate.isToday(now: now) : localDate.isToday(location: context.location);
     final button = isToday
         ? IconButton.filled(
             key: todayKey,

--- a/test/widgets/today_highlight_test.dart
+++ b/test/widgets/today_highlight_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:timezone/data/latest_10y.dart' as tz;
+
+import '../utilities.dart';
+
+/// End-to-end regression coverage for "today" highlighting in a real
+/// [CalendarView], targeting the timezone bug reported in:
+///
+///   * #254 — `isSameDay` produced wrong results for non-UTC timezones,
+///   * #251 — wrong current-date highlighting (e.g. Dec 24 highlighted Dec 23),
+///   * #248 — header dates compared against a local `DateTime.now()` incorrectly
+///            near midnight in offset timezones.
+///
+/// The root cause was fixed by the `InternalDateTime` + `NowCallback` refactor in
+/// `0.18.0`. The isolated component checks live in `now_callback_is_today_test.dart`;
+/// these exercise the layer users actually hit — a full `CalendarView` — and are
+/// run across the timezone matrix (`tool/test_timezones_linux.dart`) to cover the
+/// non-UTC / near-midnight condition that made the original bug visible.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  Finder todayNumber(Key todayKey, int day) => find.descendant(
+        of: find.byKey(todayKey),
+        matching: find.text('$day'),
+      );
+
+  group('Today highlighting in CalendarView (#254 #248 #251)', () {
+    // ── Month view ──────────────────────────────────────────────────────────
+    group('MonthView', () {
+      Future<void> pumpMonth(
+        WidgetTester tester,
+        DateTime month, {
+        NowCallback? nowCallback,
+      }) =>
+          pumpAndSettleWithMaterialApp(
+            tester,
+            CalendarView(
+              eventsController: eventsController,
+              calendarController: calendarController,
+              viewConfiguration: MonthViewConfiguration.singleMonth(
+                displayRange: DateTimeRange(
+                  start: DateTime(month.year, month.month - 1),
+                  end: DateTime(month.year, month.month + 2),
+                ),
+                initialDateTime: month,
+                nowCallback: nowCallback,
+              ),
+              body: const CalendarBody(),
+            ),
+          );
+
+      testWidgets('highlights exactly the real today (default location path)', (tester) async {
+        final now = DateTime.now();
+        await pumpMonth(tester, DateTime(now.year, now.month));
+
+        // Exactly one day is "today", and it carries today's day-of-month number.
+        expect(find.byKey(MonthDayHeader.todayKey), findsOneWidget);
+        expect(todayNumber(MonthDayHeader.todayKey, now.day), findsOneWidget);
+      });
+
+      testWidgets('highlights the callback day, not its neighbour (#251)', (tester) async {
+        // The #251 report: current date Dec 24, but Dec 23 was highlighted.
+        await pumpMonth(
+          tester,
+          DateTime(2025, 12),
+          nowCallback: () => DateTime(2025, 12, 24, 10),
+        );
+
+        expect(find.byKey(MonthDayHeader.todayKey), findsOneWidget);
+        expect(todayNumber(MonthDayHeader.todayKey, 24), findsOneWidget, reason: 'Dec 24 must be highlighted');
+        expect(todayNumber(MonthDayHeader.todayKey, 23), findsNothing, reason: 'Dec 23 must not be highlighted');
+      });
+
+      testWidgets('highlights correctly on a month boundary', (tester) async {
+        // Last day of the month — a classic near-midnight / offset failure point.
+        await pumpMonth(
+          tester,
+          DateTime(2025, 12),
+          nowCallback: () => DateTime(2025, 12, 31, 23),
+        );
+
+        expect(find.byKey(MonthDayHeader.todayKey), findsOneWidget);
+        expect(todayNumber(MonthDayHeader.todayKey, 31), findsOneWidget);
+      });
+
+      // #248: a custom monthDayHeaderBuilder must receive a localized wall-clock
+      // DateTime (via .forLocation()), not a raw UTC-flagged InternalDateTime, so
+      // consumer comparisons against DateTime.now() behave correctly.
+      testWidgets('custom builder receives localized (non-UTC) dates (#248)', (tester) async {
+        final received = <DateTime>[];
+        await pumpAndSettleWithMaterialApp(
+          tester,
+          CalendarView(
+            eventsController: eventsController,
+            calendarController: calendarController,
+            viewConfiguration: MonthViewConfiguration.singleMonth(
+              displayRange: DateTimeRange(start: DateTime(2025, 11), end: DateTime(2026)),
+              initialDateTime: DateTime(2025, 12),
+            ),
+            components: CalendarComponents(
+              monthComponents: MonthComponents(
+                bodyComponents: MonthBodyComponents(
+                  monthDayHeaderBuilder: (date, style) {
+                    received.add(date);
+                    return MonthDayHeader(date: date, style: style);
+                  },
+                ),
+              ),
+            ),
+            body: const CalendarBody(),
+          ),
+        );
+
+        expect(received, isNotEmpty);
+        // No local timezone is configured, so dates arrive as local wall-clock
+        // (isUtc == false) rather than the UTC-flagged InternalDateTime.
+        expect(
+          received.every((d) => !d.isUtc),
+          isTrue,
+          reason: 'monthDayHeaderBuilder should receive localized (non-UTC) dates',
+        );
+      });
+
+      testWidgets('custom builder receives TZDateTime for a configured location (#248)', (tester) async {
+        tz.initializeTimeZones();
+        final newYork = getLocation('America/New_York');
+        final received = <DateTime>[];
+
+        await pumpAndSettleWithMaterialApp(
+          tester,
+          CalendarView(
+            eventsController: eventsController,
+            calendarController: calendarController,
+            location: newYork,
+            viewConfiguration: MonthViewConfiguration.singleMonth(
+              displayRange: DateTimeRange(start: DateTime(2025, 11), end: DateTime(2026)),
+              initialDateTime: DateTime(2025, 12),
+            ),
+            components: CalendarComponents(
+              monthComponents: MonthComponents(
+                bodyComponents: MonthBodyComponents(
+                  monthDayHeaderBuilder: (date, style) {
+                    received.add(date);
+                    return MonthDayHeader(date: date, style: style);
+                  },
+                ),
+              ),
+            ),
+            body: const CalendarBody(),
+          ),
+        );
+
+        expect(received, isNotEmpty);
+        expect(
+          received.every((d) => d is TZDateTime && d.location == newYork),
+          isTrue,
+          reason: 'monthDayHeaderBuilder should receive TZDateTime in the configured location',
+        );
+      });
+    });
+
+    // ── Multi-day (week) header ─────────────────────────────────────────────
+    group('MultiDayView header', () {
+      final monday = DateTime(2026, 4, 13);
+      final weekRange = DateTimeRange(start: monday, end: monday.add(const Duration(days: 7)));
+
+      Future<void> pumpWeek(
+        WidgetTester tester, {
+        NowCallback? nowCallback,
+      }) =>
+          pumpAndSettleWithMaterialApp(
+            tester,
+            CalendarView(
+              eventsController: eventsController,
+              calendarController: calendarController,
+              viewConfiguration: MultiDayViewConfiguration.week(
+                displayRange: weekRange,
+                initialDateTime: monday,
+                nowCallback: nowCallback,
+              ),
+              header: const CalendarHeader(),
+              body: const CalendarBody(),
+            ),
+          );
+
+      testWidgets('highlights exactly the callback day', (tester) async {
+        // Wednesday of the visible week.
+        await pumpWeek(tester, nowCallback: () => DateTime(2026, 4, 15, 12));
+
+        expect(find.byKey(DayHeader.todayKey), findsOneWidget);
+        expect(todayNumber(DayHeader.todayKey, 15), findsOneWidget);
+      });
+
+      testWidgets('does not highlight any day when today is outside the visible range', (tester) async {
+        // "Today" is a week later — no header in view should be highlighted.
+        await pumpWeek(tester, nowCallback: () => DateTime(2026, 4, 22, 12));
+
+        expect(find.byKey(DayHeader.todayKey), findsNothing);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Addresses the cluster of timezone "today"-detection issues — #254 (`isSameDay` for non-UTC), #251 (wrong current-date highlighting), #248 (header builders provide UTC dates), and #261 (time-indicator behaviour). All share one root cause.

**Investigation:** the behavioural root cause was fixed by the `InternalDateTime` + `NowCallback` refactor in **0.18.0** — `isSameDay` now only compares uniformly-normalised wall-clock components, so the non-UTC divergence can no longer occur. Verified green across the full timezone matrix (New_York, London, Tokyo, Sydney, Johannesburg, UTC).

**One real remaining bug fixed:** `monthDayHeaderBuilder` still handed custom builders a raw UTC-flagged `InternalDateTime`, unlike `dayHeaderBuilder` which passes a localized `DateTime` via `.forLocation()`. That is exactly #248's month-view complaint. Fixed to mirror `DayHeader`.

## ⚠️ Breaking change → v0.19.0

Custom `monthDayHeaderBuilder` implementations must change their `date` parameter type from `InternalDateTime` to `DateTime`. Documented in [MIGRATION.md](MIGRATION.md). The builder-signature change warrants a minor version bump (0.19.0).

## Changes

- **`fix(month)`** — `month_day_header.dart` passes `date.forLocation(location)` to the builder and recovers the `InternalDateTime` internally for the today check.
- **`test`** — `today_highlight_test.dart`: end-to-end today-highlighting (month + multi-day headers, month boundary, the #251 neighbour-day repro) + #248 assertions that custom builders receive localized/`TZDateTime` dates. Mutation-verified. (End-to-end time-indicator coverage for #261 already landed on main via #274.)
- **`docs`** — CHANGELOG `0.19.0` "Breaking Changes" section + MIGRATION.md entry. **No pubspec bump** — versioning handled at release time.

## Issues

- Closes #248, #254, #251, #261

## Test plan

- `flutter test` ✅
- `dart tool/test_timezones_linux.dart` ✅ (all 6 timezones)
- `dart analyze` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
