### PR TITLE
test(#235): month-view custom generateMultiDayLayoutFrame regression coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added end-to-end `CalendarView` regression coverage for the time indicator (correct day column, hidden on off-page days), run across the timezone matrix. Confirms the timezone `isSameDay`/today-detection fix from `0.18.0` resolves the reported time-indicator behaviour. [#261](https://github.com/werner-scholtz/kalender/issues/261)
 - Added end-to-end `CalendarView` today-highlighting coverage (month + multi-day headers, month boundaries, and the `#251` neighbour-day repro), run across the timezone matrix. [#254](https://github.com/werner-scholtz/kalender/issues/254) [#251](https://github.com/werner-scholtz/kalender/issues/251)
+- Added end-to-end `CalendarView` month-view regression coverage for a custom `generateMultiDayLayoutFrame`, confirming the generic-variance crash fixed by the de-genericization in `0.16.0` cannot recur. [#235](https://github.com/werner-scholtz/kalender/issues/235)
 
 ## 0.18.7
 

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -261,5 +261,92 @@ void main() {
       final button = tester.widget<MultiDayPortalOverlayButton>(find.byType(MultiDayPortalOverlayButton));
       expect(button.numberOfHiddenRows, greaterThan(0));
     });
+
+    // ---------------------------------------------------------------------------
+    // #235: a custom generateMultiDayLayoutFrame supplied to MonthBodyConfiguration
+    // ---------------------------------------------------------------------------
+    // Supplying a custom generateMultiDayLayoutFrame to MonthBodyConfiguration used
+    // to throw a `_TypeError` at build time because the generator carried a `<T>`
+    // type parameter that no longer matched the (now non-generic) typedef:
+    //
+    //   type '(... => MultiDayLayoutFrame<Todo>)' is not a subtype of type
+    //   '(... => MultiDayLayoutFrame<Object?>)?'
+    //
+    // The generics were removed in 0.16.0, so the crash is structurally impossible.
+    // These tests lock that in at the exact layer the reporter hit — a custom
+    // generator wired through MonthBodyConfiguration in a full CalendarView month
+    // view. The explicit closure signature (matching the current typedef) is itself
+    // the regression guard: a return to a generic typedef would fail to compile.
+    group('custom generateMultiDayLayoutFrame (#235)', () {
+      late bool invoked;
+
+      // A generator with the exact signature of the current typedef, delegating to
+      // the real default implementation.
+      MultiDayLayoutFrame customFrame({
+        required InternalDateTimeRange visibleDateTimeRange,
+        required List<CalendarEvent> events,
+        required TextDirection textDirection,
+        required Location? location,
+        MultiDayLayoutFrameCache? cache,
+      }) {
+        invoked = true;
+        return defaultMultiDayFrameGenerator(
+          visibleDateTimeRange: visibleDateTimeRange,
+          events: events,
+          textDirection: textDirection,
+          location: location,
+          cache: cache,
+        );
+      }
+
+      Future<void> pumpWithCustomFrame(WidgetTester tester, DateTime initialDateTime) =>
+          pumpAndSettleWithMaterialApp(
+            tester,
+            CalendarView(
+              eventsController: eventsController,
+              calendarController: calendarController,
+              viewConfiguration: MonthViewConfiguration.singleMonth(
+                displayRange: displayRange,
+                initialDateTime: initialDateTime,
+              ),
+              body: CalendarBody(
+                monthBodyConfiguration: MonthBodyConfiguration(generateMultiDayLayoutFrame: customFrame),
+              ),
+            ),
+          );
+
+      setUp(() => invoked = false);
+
+      testWidgets('renders month view without error and is invoked', (tester) async {
+        final event = CalendarEvent(
+          dateTimeRange: DateTimeRange(
+            start: DateTime(2025, 1, 15, 9),
+            end: DateTime(2025, 1, 15, 10),
+          ),
+        );
+        eventsController.addEvent(event);
+
+        await pumpWithCustomFrame(tester, DateTime(2025, 1));
+
+        // The core #235 assertion: no `_TypeError` (or anything else) during build.
+        expect(tester.takeException(), isNull);
+        // The custom generator was actually used, and its frame was consumed to
+        // render the event tile.
+        expect(invoked, isTrue, reason: 'custom generateMultiDayLayoutFrame should be called');
+        expect(find.byType(MonthBody), findsOneWidget);
+        // Month events render as MultiDayEventTile (keyed 'MultiDayEventTile-<id>').
+        expect(find.byKey(Key('MultiDayEventTile-${event.id}')), findsOneWidget);
+      });
+
+      testWidgets('renders without error when there are no events', (tester) async {
+        // eventsController is empty – exercises the empty-list path through a custom
+        // generator.
+        await pumpWithCustomFrame(tester, DateTime(2025, 1));
+
+        expect(tester.takeException(), isNull);
+        expect(invoked, isTrue, reason: 'custom generateMultiDayLayoutFrame should be called');
+        expect(find.byType(MonthBody), findsOneWidget);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

Issue #235 reported that supplying a custom `generateMultiDayLayoutFrame` to `MonthBodyConfiguration<Todo>` threw a `_TypeError` at build time:

```
type '(... => MultiDayLayoutFrame<Todo>)' is not a subtype of type '(... => MultiDayLayoutFrame<Object?>)?'
```

**This is already fixed.** The generic-variance mismatch was eliminated when the `<T extends Object?>` / `<T>` type parameters were removed in **v0.16.0** (commit `dbc1c9b2`). On `main` today, `GenerateMultiDayLayoutFrame`, `MonthBodyConfiguration`, `HorizontalConfiguration`, and `CalendarBody` are all non-generic, so the crash is structurally impossible — the issue's own repro (`MonthBodyConfiguration<Todo>(...)`) no longer even compiles.

The one remaining gap: no test drove a custom `generateMultiDayLayoutFrame` through `MonthBodyConfiguration` in a full `CalendarView` month view — the exact path the reporter hit — and the CHANGELOG never credited the fix.

## Changes

- **test:** added a `custom generateMultiDayLayoutFrame (#235)` group in `test/widgets/month_body_test.dart` that pumps a full `CalendarView` month view wired with a custom generator (matching the current typedef signature), asserting `tester.takeException() == null`, that the generator is invoked, and that the event tile renders. Covers both a single-event and an empty-events case. The explicit closure signature is itself the regression guard — a return to a generic typedef would fail to compile.
- **docs:** added a `0.19.0` → Tests CHANGELOG line crediting #235.

No production code changes (the fix already shipped in v0.16.0). No `pubspec.yaml` bump.

## Verification

- `flutter test test/widgets/month_body_test.dart` — 12/12 pass
- `flutter test test/layout/multi_day_event_layout_test.dart` — existing custom-generator tests still green
- `dart analyze` — no issues

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)
