### PR TITLE
feat: preserve vertical scroll + zoom across view switches (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - `monthDayHeaderBuilder` now receives a localized wall-clock `DateTime` (via `.forLocation()`) instead of a UTC-flagged `InternalDateTime`, matching `dayHeaderBuilder`. This fixes incorrect `DateTime.now()` comparisons in custom month-view day headers. Custom `monthDayHeaderBuilder` implementations must change their `date` parameter type from `InternalDateTime` to `DateTime` — see [MIGRATION.md](MIGRATION.md#v018x--v0190). [#248](https://github.com/werner-scholtz/kalender/issues/248)
 
+### Features
+
+- The vertical scroll position (time-of-day) and zoom (`heightPerMinute`) of a multi-day view are now preserved when switching between view types (e.g. Week → Month → Week) instead of resetting to `initialTimeOfDay`. This is on by default; set `MultiDayViewConfiguration.preserveVerticalScrollOnViewChange: false` to restore the previous reset-on-switch behaviour. [#249](https://github.com/werner-scholtz/kalender/issues/249)
+- Added `CalendarController.visibleTimeOfDay` (a `ValueNotifier<TimeOfDay?>` reflecting the time aligned with the top of the viewport, `null` for views without vertical scroll) and a `CalendarCallbacks.onScrollPositionChanged` callback, so consumers can observe/persist the vertical scroll position. [#249](https://github.com/werner-scholtz/kalender/issues/249)
+
 ### Tests
 
 - Added end-to-end `CalendarView` regression coverage for the time indicator (correct day column, hidden on off-page days), run across the timezone matrix. Confirms the timezone `isSameDay`/today-detection fix from `0.18.0` resolves the reported time-indicator behaviour. [#261](https://github.com/werner-scholtz/kalender/issues/261)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,6 +28,16 @@ MonthComponents(
 
 The received `date` is already in the calendar's configured location, so any manual `.forLocation()` conversion inside the builder is no longer needed.
 
+### Vertical scroll & zoom now persist across view switches
+
+Switching between view types (e.g. Week → Month → Week) now restores the vertical scroll position (time-of-day) and zoom (`heightPerMinute`) of the multi-day view, instead of resetting to `initialTimeOfDay`. This is the new default. If you relied on the old behaviour (always resetting to `initialTimeOfDay` on a view change), opt out per view configuration:
+
+```dart
+MultiDayViewConfiguration.week(
+  preserveVerticalScrollOnViewChange: false,
+)
+```
+
 ## v0.16.x → v0.17.0
 
 ### Input mode replaces platform-based mobile/desktop split

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Presents events in a chronological scrollable list.
 | Notifier               | Type                                | Description                                            |
 | ---------------------- | ----------------------------------- | ------------------------------------------------------ |
 | `visibleDateTimeRange` | `ValueNotifier<DateTimeRange>`      | The currently visible date range                       |
+| `visibleTimeOfDay`     | `ValueNotifier<TimeOfDay?>`         | Time aligned with the top of the viewport (multi-day views; `null` otherwise) |
 | `visibleEvents`        | `ValueNotifier<Set<CalendarEvent>>` | Events visible on screen                               |
 | `selectedEvent`        | `ValueNotifier<CalendarEvent?>`     | The focused event (shows drop target / resize handles) |
 
@@ -602,6 +603,10 @@ CalendarCallbacks(
 
   // Called when the visible page changes.
   onPageChanged: (visibleDateTimeRange) {},
+
+  // Called when the vertical scroll position of a multi-day view changes.
+  // 'visibleTimeOfDay' is the time aligned with the top of the viewport.
+  onScrollPositionChanged: (visibleTimeOfDay) {},
 
   // Called when the user taps an empty area (day / week body).
   onTapped: (date) {},

--- a/lib/src/calendar_view.dart
+++ b/lib/src/calendar_view.dart
@@ -69,6 +69,15 @@ class CalendarView extends StatefulWidget {
 class CalendarViewState extends State<CalendarView> {
   /// The [ViewController] that will be used by the children of the [CalendarView].
   late ViewController _viewController;
+
+  /// The last known vertical scroll offset / zoom of a [MultiDayViewController].
+  ///
+  /// These persist across view-configuration changes (they live on the state, not
+  /// the disposable controller) so the scroll position and zoom can be restored
+  /// even after a round-trip through a view that has no vertical scroll (e.g.
+  /// Week → Month → Week). See [MultiDayViewConfiguration.preserveVerticalScrollOnViewChange].
+  double? _rememberedScrollOffset;
+  double? _rememberedHeightPerMinute;
   // TODO: update this to be a valueNotifier.
   late dynamic _locale = widget.locale;
   late final _location = ValueNotifier<Location?>(widget.location);
@@ -104,10 +113,17 @@ class CalendarViewState extends State<CalendarView> {
     final didChangeViewConfiguration = widget.viewConfiguration != oldWidget.viewConfiguration;
     // If the view configuration has changed or location, recreate the view controller.
     if (didChangeViewConfiguration || didChangeLocation) {
-      // Preserve the current height per minute (zoom level) when only the location changed.
-      final oldHeightPerMinute = _viewController is MultiDayViewController
-          ? (_viewController as MultiDayViewController).heightPerMinute.value
-          : null;
+      // Remember the current vertical scroll offset / zoom so it can be restored
+      // when returning to a multi-day view. These are kept even when switching to a
+      // view without vertical scroll (e.g. Month), so a Week → Month → Week
+      // round-trip still restores the position.
+      if (_viewController is MultiDayViewController) {
+        final multiDay = _viewController as MultiDayViewController;
+        _rememberedHeightPerMinute = multiDay.heightPerMinute.value;
+        if (multiDay.scrollController.hasClients) {
+          _rememberedScrollOffset = multiDay.scrollController.offset;
+        }
+      }
 
       // Use selectedDate if available, otherwise use the initial date selection strategy
       final initialDate = widget.viewConfiguration.initialDateTime != null
@@ -117,13 +133,17 @@ class CalendarViewState extends State<CalendarView> {
               newViewConfiguration: widget.viewConfiguration,
             );
 
-      // Create the new view controller.
-      _viewController = _createViewController(initialDate: initialDate);
+      // Restore the remembered scroll offset / zoom only when the new view is a
+      // multi-day view that opts into preservation.
+      final newConfig = widget.viewConfiguration;
+      final preserve = newConfig is MultiDayViewConfiguration && newConfig.preserveVerticalScrollOnViewChange;
 
-      // Restore the zoom level if the new controller is also a MultiDayViewController.
-      if (oldHeightPerMinute != null && _viewController is MultiDayViewController) {
-        (_viewController as MultiDayViewController).heightPerMinute.value = oldHeightPerMinute;
-      }
+      // Create the new view controller.
+      _viewController = _createViewController(
+        initialDate: initialDate,
+        initialScrollOffset: preserve ? _rememberedScrollOffset : null,
+        initialHeightPerMinute: preserve ? _rememberedHeightPerMinute : null,
+      );
 
       // Dispose the old view controller if it exists.
       widget.calendarController.viewController?.dispose();
@@ -160,7 +180,11 @@ class CalendarViewState extends State<CalendarView> {
   }
 
   /// Create the [ViewController] based on the [ViewConfiguration].
-  ViewController _createViewController({required InternalDateTime initialDate}) {
+  ViewController _createViewController({
+    required InternalDateTime initialDate,
+    double? initialScrollOffset,
+    double? initialHeightPerMinute,
+  }) {
     final viewConfiguration = widget.viewConfiguration;
 
     return switch (viewConfiguration.runtimeType) {
@@ -169,6 +193,8 @@ class CalendarViewState extends State<CalendarView> {
           visibleDateTimeRange: widget.calendarController.internalDateTimeRange,
           visibleEvents: widget.calendarController.visibleEvents,
           initialDate: initialDate,
+          initialScrollOffset: initialScrollOffset,
+          initialHeightPerMinute: initialHeightPerMinute,
           location: widget.location,
         ),
       const (MonthViewConfiguration) => MonthViewController(

--- a/lib/src/models/calendar_callbacks.dart
+++ b/lib/src/models/calendar_callbacks.dart
@@ -57,6 +57,12 @@ class CalendarCallbacks {
   /// The callback for when the calendar page is changed.
   final OnPageChanged? onPageChanged;
 
+  /// The callback for when the vertical scroll position of a multi-day view changes.
+  ///
+  /// The provided [TimeOfDay] is the time currently aligned with the top of the
+  /// visible viewport. Only fires for views with vertical scroll (day/week/etc).
+  final OnScrollPositionChanged? onScrollPositionChanged;
+
   /// TODO: Check how these interact with the [Draggable] and [LongPressDraggable]s.
 
   /// The callback for when a user taps on the calendar.
@@ -117,6 +123,7 @@ class CalendarCallbacks {
     this.onEventCreateWithDetail,
     this.onEventCreated,
     this.onPageChanged,
+    this.onScrollPositionChanged,
     this.onTapped,
     this.onTappedWithDetail,
     this.onSecondaryTapped,
@@ -136,6 +143,7 @@ class CalendarCallbacks {
   bool get hasOnSecondaryLongPressed => onSecondaryLongPressed != null || onSecondaryLongPressedWithDetail != null;
   bool get hasOnTapped => onTapped != null || onTappedWithDetail != null;
   bool get hasOnSecondaryTapped => onSecondaryTapped != null || onSecondaryTappedWithDetail != null;
+  bool get hasOnScrollPositionChanged => onScrollPositionChanged != null;
 
   CalendarCallbacks copyWith({
     OnEventTapped? onEventTapped,
@@ -148,6 +156,7 @@ class CalendarCallbacks {
     OnEventChange? onEventChange,
     OnEventChanged? onEventChanged,
     OnPageChanged? onPageChanged,
+    OnScrollPositionChanged? onScrollPositionChanged,
     OnTapped? onTapped,
     OnTappedWithDetails? onTappedWithDetail,
     OnTapped? onSecondaryTapped,
@@ -169,6 +178,7 @@ class CalendarCallbacks {
       onEventChange: onEventChange ?? this.onEventChange,
       onEventChanged: onEventChanged ?? this.onEventChanged,
       onPageChanged: onPageChanged ?? this.onPageChanged,
+      onScrollPositionChanged: onScrollPositionChanged ?? this.onScrollPositionChanged,
       onTapped: onTapped ?? this.onTapped,
       onTappedWithDetail: onTappedWithDetail ?? this.onTappedWithDetail,
       onSecondaryTapped: onSecondaryTapped ?? this.onSecondaryTapped,
@@ -237,6 +247,11 @@ typedef OnEventCreated = void Function(CalendarEvent event);
 ///
 /// [dateTimeRange] is the range of dates that can be displayed in the new page.
 typedef OnPageChanged = void Function(DateTimeRange dateTimeRange);
+
+/// The callback for when the vertical scroll position of a multi-day view changes.
+///
+/// [visibleTimeOfDay] is the time currently aligned with the top of the viewport.
+typedef OnScrollPositionChanged = void Function(TimeOfDay visibleTimeOfDay);
 
 /// The callback for when a user taps on an empty space in the calendar.
 ///

--- a/lib/src/models/controllers/calendar_controller.dart
+++ b/lib/src/models/controllers/calendar_controller.dart
@@ -42,6 +42,18 @@ class CalendarController extends ChangeNotifier with CalendarNavigationFunctions
   /// The [CalendarEvent]s that are currently visible.
   final visibleEvents = ValueNotifier<Set<CalendarEvent>>({});
 
+  /// The [TimeOfDay] currently aligned with the top of the visible viewport.
+  ///
+  /// This reflects the vertical scroll position of a multi-day view (day/week/etc)
+  /// and updates as the user scrolls or zooms. It is `null` when the attached view
+  /// has no vertical scroll (e.g. month or schedule views).
+  final visibleTimeOfDay = ValueNotifier<TimeOfDay?>(null);
+
+  /// The multi-day view's [MultiDayViewController.visibleTimeOfDay] source that is
+  /// currently being forwarded into [visibleTimeOfDay], and its listener.
+  ValueNotifier<TimeOfDay?>? _visibleTimeOfDaySource;
+  VoidCallback? _visibleTimeOfDayForwarder;
+
   /// The event currently being focused on.
   final selectedEvent = ValueNotifier<CalendarEvent?>(null);
   String? _selectedEventId;
@@ -88,12 +100,34 @@ class CalendarController extends ChangeNotifier with CalendarNavigationFunctions
     visibleDateTimeRange.value = null;
     visibleDateTimeRange.value = newRange;
 
+    // Forward the visible time-of-day from multi-day views; null for views without
+    // vertical scroll (month/schedule).
+    if (viewController is MultiDayViewController) {
+      final source = viewController.visibleTimeOfDay;
+      void forwarder() => visibleTimeOfDay.value = source.value;
+      source.addListener(forwarder);
+      _visibleTimeOfDaySource = source;
+      _visibleTimeOfDayForwarder = forwarder;
+      visibleTimeOfDay.value = source.value;
+    } else {
+      visibleTimeOfDay.value = null;
+    }
+
     notifyListeners();
   }
 
   /// Detach the [ViewController] from this [CalendarController].
   void detach() {
+    _detachVisibleTimeOfDay();
+    visibleTimeOfDay.value = null;
     _viewController = null;
+  }
+
+  void _detachVisibleTimeOfDay() {
+    final forwarder = _visibleTimeOfDayForwarder;
+    if (forwarder != null) _visibleTimeOfDaySource?.removeListener(forwarder);
+    _visibleTimeOfDaySource = null;
+    _visibleTimeOfDayForwarder = null;
   }
 
   /// Jump to the given [DateTime].
@@ -183,6 +217,8 @@ class CalendarController extends ChangeNotifier with CalendarNavigationFunctions
   @override
   void dispose() {
     _internalDateTimeRange.removeListener(_updateVisibleDateTimeRange);
+    _detachVisibleTimeOfDay();
+    visibleTimeOfDay.dispose();
     super.dispose();
   }
 }

--- a/lib/src/models/controllers/view_controllers/multi_day_view_controller.dart
+++ b/lib/src/models/controllers/view_controllers/multi_day_view_controller.dart
@@ -8,6 +8,8 @@ class MultiDayViewController extends ViewController {
     required super.visibleDateTimeRange,
     required this.visibleEvents,
     InternalDateTime? initialDate,
+    double? initialScrollOffset,
+    double? initialHeightPerMinute,
     super.location,
   }) {
     final pageIndexCalculator = viewConfiguration.pageIndexCalculator;
@@ -20,7 +22,7 @@ class MultiDayViewController extends ViewController {
     headerController = _controllerGroup.create(viewportFraction: viewPortFraction, initialPage: initialPage);
 
     numberOfPages = pageIndexCalculator.numberOfPages(location);
-    heightPerMinute = ValueNotifier<double>(viewConfiguration.initialHeightPerMinute);
+    heightPerMinute = ValueNotifier<double>(initialHeightPerMinute ?? viewConfiguration.initialHeightPerMinute);
 
     final range = pageIndexCalculator.dateTimeRangeFromIndex(initialPage, location);
 
@@ -33,16 +35,30 @@ class MultiDayViewController extends ViewController {
       visibleDateTimeRange.value = range;
     }
 
-    // Calculate the scroll offset so that the initialTimeOfDay is aligned with the top.
-    final initialTimeOfDay = viewConfiguration.initialTimeOfDay.toInternalDateTime(now);
-    final dayStart = viewConfiguration.timeOfDayRange.start.toInternalDateTime(now);
-    final timeDifference = initialTimeOfDay.difference(dayStart);
-    final initialScrollOffset = timeDifference.inMinutes * (heightPerMinute.value);
-    scrollController = ScrollController(initialScrollOffset: initialScrollOffset);
+    // Use the provided scroll offset (e.g. preserved across a view switch) if
+    // available, otherwise align the initialTimeOfDay with the top. The offset is
+    // in pixels and only maps back to the same time-of-day when heightPerMinute
+    // matches the value it was captured under, which is why both are restored
+    // together (see [preserveVerticalScrollOnViewChange]).
+    final double scrollOffset;
+    if (initialScrollOffset != null) {
+      scrollOffset = initialScrollOffset;
+    } else {
+      final initialTimeOfDay = viewConfiguration.initialTimeOfDay.toInternalDateTime(now);
+      final dayStart = viewConfiguration.timeOfDayRange.start.toInternalDateTime(now);
+      final timeDifference = initialTimeOfDay.difference(dayStart);
+      scrollOffset = timeDifference.inMinutes * (heightPerMinute.value);
+    }
+    scrollController = ScrollController(initialScrollOffset: scrollOffset);
+    // Seed the visible time-of-day from the initial offset, since a ScrollController
+    // does not necessarily notify its listeners when it first attaches.
+    visibleTimeOfDay.value = _timeOfDayFromOffset(scrollOffset);
 
     visibleEvents.value = {};
 
     pageController.addListener(_offsetListener);
+    scrollController.addListener(_updateVisibleTimeOfDay);
+    heightPerMinute.addListener(_updateVisibleTimeOfDay);
   }
 
   @override
@@ -73,11 +89,33 @@ class MultiDayViewController extends ViewController {
   /// This is a value notifier that updates when the page is scrolled.
   ValueNotifier<double> pageOffset = ValueNotifier<double>(0.0);
 
+  /// The [TimeOfDay] currently aligned with the top of the visible viewport.
+  ///
+  /// Updates as the view is scrolled vertically or zoomed. It is `null` until the
+  /// [scrollController] has been attached to a scroll view.
+  final ValueNotifier<TimeOfDay?> visibleTimeOfDay = ValueNotifier<TimeOfDay?>(null);
+
   @override
   final ValueNotifier<Set<CalendarEvent>> visibleEvents;
 
   void _offsetListener() =>
       pageOffset.value = pageController.position.pixels / pageController.position.viewportDimension;
+
+  /// Converts a vertical scroll [offset] (in pixels) to the [TimeOfDay] aligned
+  /// with the top of the viewport, using the current zoom level and time range.
+  TimeOfDay _timeOfDayFromOffset(double offset) {
+    final perMinute = heightPerMinute.value;
+    final minutesFromStart = perMinute <= 0 ? 0 : (offset / perMinute).round();
+    final start = viewConfiguration.timeOfDayRange.start;
+    final totalMinutes = (start.hour * 60 + start.minute + minutesFromStart).clamp(0, Duration.minutesPerDay - 1);
+    return TimeOfDay(hour: totalMinutes ~/ 60, minute: totalMinutes % 60);
+  }
+
+  /// Recomputes [visibleTimeOfDay] from the current scroll offset and zoom level.
+  void _updateVisibleTimeOfDay() {
+    if (!scrollController.hasClients) return;
+    visibleTimeOfDay.value = _timeOfDayFromOffset(scrollController.offset);
+  }
 
   @override
   Future<void> animateToDate(
@@ -189,6 +227,9 @@ class MultiDayViewController extends ViewController {
     headerController.dispose();
     pageController.removeListener(_offsetListener);
     _controllerGroup.dispose();
+    scrollController.removeListener(_updateVisibleTimeOfDay);
     scrollController.dispose();
+    heightPerMinute.removeListener(_updateVisibleTimeOfDay);
+    visibleTimeOfDay.dispose();
   }
 }

--- a/lib/src/models/view_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_view_configuration.dart
@@ -39,6 +39,20 @@ class MultiDayViewConfiguration extends ViewConfiguration {
   /// The initial heightPerMinute (zoom level).
   final double initialHeightPerMinute;
 
+  /// Whether the vertical scroll position (time-of-day) should be preserved when
+  /// the [CalendarView] switches between view configurations.
+  ///
+  /// When `true` (the default), switching away from and back to a multi-day view
+  /// (e.g. Week → Month → Week) restores the scroll position the user was last
+  /// looking at instead of resetting to [initialTimeOfDay]. The zoom level
+  /// ([initialHeightPerMinute] / `heightPerMinute`) is carried over as well,
+  /// because the scroll offset only maps back to the same time-of-day when the
+  /// zoom is the same.
+  ///
+  /// Set to `false` to always reset to [initialTimeOfDay] and
+  /// [initialHeightPerMinute] on a view change.
+  final bool preserveVerticalScrollOnViewChange;
+
   MultiDayViewConfiguration({
     required super.name,
     super.initialDateTime,
@@ -51,6 +65,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     required this.type,
     required this.initialTimeOfDay,
     required this.initialHeightPerMinute,
+    this.preserveVerticalScrollOnViewChange = defaultPreserveVerticalScrollOnViewChange,
   }) : assert(
           firstDayOfWeek >= 1 && firstDayOfWeek <= 7,
           'First day of week must be a valid week day number\n'
@@ -68,6 +83,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     this.firstDayOfWeek = defaultFirstDayOfWeek,
     this.initialTimeOfDay = defaultInitialTimeOfDay,
     this.initialHeightPerMinute = defaultHeightPerMinute,
+    this.preserveVerticalScrollOnViewChange = defaultPreserveVerticalScrollOnViewChange,
   })  : timeOfDayRange = timeOfDayRange ?? TimeOfDayRange.allDay(),
         numberOfDays = 1,
         type = MultiDayViewType.singleDay,
@@ -85,6 +101,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     this.numberOfDays = 7,
     this.initialTimeOfDay = defaultInitialTimeOfDay,
     this.initialHeightPerMinute = defaultHeightPerMinute,
+    this.preserveVerticalScrollOnViewChange = defaultPreserveVerticalScrollOnViewChange,
   })  : timeOfDayRange = timeOfDayRange ?? TimeOfDayRange.allDay(),
         type = MultiDayViewType.week,
         pageIndexCalculator = PageIndexCalculator.week(
@@ -103,6 +120,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     this.numberOfDays = 5,
     this.initialTimeOfDay = defaultInitialTimeOfDay,
     this.initialHeightPerMinute = defaultHeightPerMinute,
+    this.preserveVerticalScrollOnViewChange = defaultPreserveVerticalScrollOnViewChange,
   })  : timeOfDayRange = timeOfDayRange ?? TimeOfDayRange.allDay(),
         firstDayOfWeek = defaultFirstDayOfWeek,
         type = MultiDayViewType.workWeek,
@@ -120,6 +138,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     this.firstDayOfWeek = defaultFirstDayOfWeek,
     this.initialTimeOfDay = defaultInitialTimeOfDay,
     this.initialHeightPerMinute = defaultHeightPerMinute,
+    this.preserveVerticalScrollOnViewChange = defaultPreserveVerticalScrollOnViewChange,
   })  : timeOfDayRange = timeOfDayRange ?? TimeOfDayRange.allDay(),
         type = MultiDayViewType.custom,
         pageIndexCalculator = PageIndexCalculator.custom(displayRange ?? kDefaultRange(), numberOfDays);
@@ -135,6 +154,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     required this.numberOfDays,
     this.initialTimeOfDay = defaultInitialTimeOfDay,
     this.initialHeightPerMinute = defaultHeightPerMinute,
+    this.preserveVerticalScrollOnViewChange = defaultPreserveVerticalScrollOnViewChange,
   })  : timeOfDayRange = timeOfDayRange ?? TimeOfDayRange.allDay(),
         firstDayOfWeek = defaultFirstDayOfWeek,
         type = MultiDayViewType.freeScroll,
@@ -150,6 +170,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     int? numberOfDays,
     int? firstDayOfWeek,
     TimeOfDay? initialTimeOfDay,
+    bool? preserveVerticalScrollOnViewChange,
   }) {
     final name0 = name ?? this.name;
     final selectedDate0 = initialDateTime ?? this.initialDateTime;
@@ -159,6 +180,8 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     final displayRange0 = displayRange ?? dateTimeRange;
     final firstDayOfWeek0 = firstDayOfWeek ?? this.firstDayOfWeek;
     final initialTimeOfDay0 = initialTimeOfDay ?? this.initialTimeOfDay;
+    final preserveVerticalScrollOnViewChange0 =
+        preserveVerticalScrollOnViewChange ?? this.preserveVerticalScrollOnViewChange;
 
     return switch (type) {
       MultiDayViewType.singleDay => MultiDayViewConfiguration.singleDay(
@@ -170,6 +193,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
           displayRange: displayRange0,
           firstDayOfWeek: firstDayOfWeek0,
           initialTimeOfDay: initialTimeOfDay0,
+          preserveVerticalScrollOnViewChange: preserveVerticalScrollOnViewChange0,
         ),
       MultiDayViewType.week => MultiDayViewConfiguration.week(
           name: name0,
@@ -180,6 +204,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
           displayRange: displayRange0,
           firstDayOfWeek: firstDayOfWeek0,
           initialTimeOfDay: initialTimeOfDay0,
+          preserveVerticalScrollOnViewChange: preserveVerticalScrollOnViewChange0,
         ),
       MultiDayViewType.workWeek => MultiDayViewConfiguration.workWeek(
           name: name0,
@@ -189,6 +214,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
           timeOfDayRange: timeOfDayRange0,
           displayRange: displayRange0,
           initialTimeOfDay: initialTimeOfDay0,
+          preserveVerticalScrollOnViewChange: preserveVerticalScrollOnViewChange0,
         ),
       MultiDayViewType.custom => MultiDayViewConfiguration.custom(
           name: name0,
@@ -200,6 +226,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
           firstDayOfWeek: firstDayOfWeek0,
           numberOfDays: numberOfDays ?? this.numberOfDays,
           initialTimeOfDay: initialTimeOfDay0,
+          preserveVerticalScrollOnViewChange: preserveVerticalScrollOnViewChange0,
         ),
       MultiDayViewType.freeScroll => MultiDayViewConfiguration.freeScroll(
           name: name0,
@@ -210,6 +237,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
           displayRange: displayRange0,
           numberOfDays: numberOfDays ?? this.numberOfDays,
           initialTimeOfDay: initialTimeOfDay0,
+          preserveVerticalScrollOnViewChange: preserveVerticalScrollOnViewChange0,
         ),
     };
   }

--- a/lib/src/models/view_configurations/view_configuration.dart
+++ b/lib/src/models/view_configurations/view_configuration.dart
@@ -245,6 +245,7 @@ const defaultFirstDayOfWeek = DateTime.monday;
 const defaultShowEventTiles = true;
 const defaultInitialTimeOfDay = TimeOfDay(hour: 0, minute: 0);
 const defaultHeightPerMinute = 0.7;
+const defaultPreserveVerticalScrollOnViewChange = true;
 const defaultHorizontalPadding = EdgeInsets.only(left: 0, right: 4);
 
 const kDefaultMultiDayEventPadding = EdgeInsets.only(left: 0, right: 4, bottom: 2);

--- a/lib/src/widgets/multi_day/multi_day_body.dart
+++ b/lib/src/widgets/multi_day/multi_day_body.dart
@@ -174,6 +174,7 @@ class _MultiDayPageState extends State<MultiDayPage> {
   void initState() {
     super.initState();
     _initialPage();
+    widget.viewController.visibleTimeOfDay.addListener(_onVisibleTimeOfDayChanged);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       widget.eventsController.addListener(_currentPage);
     });
@@ -182,6 +183,10 @@ class _MultiDayPageState extends State<MultiDayPage> {
   @override
   void didUpdateWidget(covariant MultiDayPage oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.viewController != widget.viewController) {
+      oldWidget.viewController.visibleTimeOfDay.removeListener(_onVisibleTimeOfDayChanged);
+      widget.viewController.visibleTimeOfDay.addListener(_onVisibleTimeOfDayChanged);
+    }
     if (oldWidget.location != widget.location) {
       setState(() {});
     }
@@ -190,7 +195,15 @@ class _MultiDayPageState extends State<MultiDayPage> {
   @override
   void dispose() {
     widget.eventsController.removeListener(_currentPage);
+    widget.viewController.visibleTimeOfDay.removeListener(_onVisibleTimeOfDayChanged);
     super.dispose();
+  }
+
+  /// Forwards the multi-day view's visible time-of-day to the [CalendarCallbacks].
+  void _onVisibleTimeOfDayChanged() {
+    final visibleTimeOfDay = widget.viewController.visibleTimeOfDay.value;
+    if (visibleTimeOfDay == null) return;
+    context.callbacks?.onScrollPositionChanged?.call(visibleTimeOfDay);
   }
 
   void _initialPage() => _updateVisibleEvents(widget.viewController.initialPage, widget.location);

--- a/test/configuration/calendar_view_configuration_changes_test.dart
+++ b/test/configuration/calendar_view_configuration_changes_test.dart
@@ -515,6 +515,94 @@ void main() {
       expect(calendarController.internalDateTimeRange.value, isNotNull);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Vertical scroll / zoom preservation across view switches (#249)
+  // ---------------------------------------------------------------------------
+  group('Vertical scroll & zoom preservation (#249)', () {
+    MultiDayViewController multiDay() => calendarController.viewController as MultiDayViewController;
+
+    MonthViewConfiguration month() => MonthViewConfiguration.singleMonth(name: 'Month', displayRange: calendarRange);
+    MultiDayViewConfiguration week({bool preserve = true}) => MultiDayViewConfiguration.week(
+          name: 'Week',
+          displayRange: calendarRange,
+          preserveVerticalScrollOnViewChange: preserve,
+        );
+
+    testWidgets('restores scroll position across Week → Month → Week (default)', (tester) async {
+      await pumpCalendarView(tester, config: week(), withBody: true);
+
+      // Scroll down to a non-zero offset (initialTimeOfDay is midnight → offset 0).
+      multiDay().scrollController.jumpTo(200);
+      await tester.pump();
+      final offsetBefore = multiDay().scrollController.offset;
+      final todBefore = calendarController.visibleTimeOfDay.value;
+      expect(offsetBefore, greaterThan(0));
+      expect(todBefore, isNotNull);
+
+      await pumpCalendarView(tester, config: month(), withBody: true);
+      await pumpCalendarView(tester, config: week(), withBody: true);
+
+      expect(multiDay().scrollController.offset, closeTo(offsetBefore, 1.0));
+      expect(calendarController.visibleTimeOfDay.value, equals(todBefore));
+    });
+
+    testWidgets('resets scroll position when preserveVerticalScrollOnViewChange is false', (tester) async {
+      await pumpCalendarView(tester, config: week(preserve: false), withBody: true);
+
+      multiDay().scrollController.jumpTo(200);
+      await tester.pump();
+      expect(multiDay().scrollController.offset, greaterThan(0));
+
+      await pumpCalendarView(tester, config: month(), withBody: true);
+      await pumpCalendarView(tester, config: week(preserve: false), withBody: true);
+
+      // Back to the configured initialTimeOfDay (midnight → offset 0).
+      expect(multiDay().scrollController.offset, closeTo(0, 1.0));
+    });
+
+    testWidgets('restores zoom (heightPerMinute) across Week → Month → Week', (tester) async {
+      await pumpCalendarView(tester, config: week(), withBody: true);
+
+      multiDay().heightPerMinute.value = 1.5;
+      await tester.pump();
+
+      await pumpCalendarView(tester, config: month(), withBody: true);
+      await pumpCalendarView(tester, config: week(), withBody: true);
+
+      expect(multiDay().heightPerMinute.value, equals(1.5));
+    });
+
+    testWidgets('visibleTimeOfDay is non-null in a multi-day view and null in month', (tester) async {
+      await pumpCalendarView(tester, config: week(), withBody: true);
+      expect(calendarController.visibleTimeOfDay.value, isNotNull);
+
+      await pumpCalendarView(tester, config: month(), withBody: true);
+      expect(calendarController.visibleTimeOfDay.value, isNull);
+    });
+
+    testWidgets('onScrollPositionChanged fires with the visible time-of-day on scroll', (tester) async {
+      final reported = <TimeOfDay>[];
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        CalendarView(
+          key: calendarViewKey,
+          eventsController: eventsController,
+          calendarController: calendarController,
+          viewConfiguration: week(),
+          callbacks: CalendarCallbacks(onScrollPositionChanged: reported.add),
+          body: const CalendarBody(),
+        ),
+      );
+
+      // Scroll to 02:00 → offset = 120 minutes * defaultHeightPerMinute (0.7) = 84px.
+      multiDay().scrollController.jumpTo(120 * 0.7);
+      await tester.pump();
+
+      expect(reported, isNotEmpty);
+      expect(reported.last, equals(const TimeOfDay(hour: 2, minute: 0)));
+    });
+  });
 }
 
 InternalDateTime _alwaysReturnJanuaryStrategy({


### PR DESCRIPTION
## Summary

Part of #249 (the vertical scroll/zoom half; the date half is #278). When switching view types (e.g. **Week → Month → Week**), the vertical scroll position (time-of-day) was reset to `initialTimeOfDay` instead of being restored.

**Root cause:** on a view-config change, `CalendarView.didUpdateWidget` disposes the old `ViewController` and builds a new one; `MultiDayViewController` always computed its `initialScrollOffset` from `initialTimeOfDay`, and the old controller's live `scrollController.offset` was never captured. Zoom (`heightPerMinute`) was only preserved across *adjacent* multi-day switches, so a round-trip through Month dropped it too.

## What changed

**Preservation (default on, opt-out):**
- The last multi-day scroll offset and `heightPerMinute` are remembered on the `CalendarView` state (which survives `didUpdateWidget`, so it persists through an intermediate Month view) and restored at controller construction.
- Offset is restored as **raw pixels alongside the zoom it was captured under**, so it maps back to the exact time-of-day even if zoom differs.
- New flag `MultiDayViewConfiguration.preserveVerticalScrollOnViewChange` (**default `true`**); set `false` to keep the old reset-to-`initialTimeOfDay` behaviour.

**Observability API (requested in the issue):**
- `CalendarController.visibleTimeOfDay` — `ValueNotifier<TimeOfDay?>` reflecting the time aligned with the top of the viewport (updates on scroll/zoom; `null` for views without vertical scroll, e.g. Month/Schedule).
- `CalendarCallbacks.onScrollPositionChanged` — fires with the visible `TimeOfDay` as the multi-day view scrolls.

## Tests
Added a `Vertical scroll & zoom preservation (#249)` group to `test/configuration/calendar_view_configuration_changes_test.dart` (reuses the existing shared-`GlobalKey` harness that drives `didUpdateWidget`):
- scroll restored across Week → Month → Week (default);
- scroll resets when the flag is `false`;
- zoom restored across the round-trip;
- `visibleTimeOfDay` non-null in multi-day, null in Month;
- `onScrollPositionChanged` fires with the expected `TimeOfDay`.

Mutation-verified (disabling the restore path fails exactly the scroll-restore test).

## Verification
- `flutter test` — full suite green (1176 tests)
- `dart analyze` — no issues

No `pubspec.yaml` bump (version bumped at release time). Default-on behaviour change + opt-out documented in CHANGELOG/MIGRATION; new API added to README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

