### PR TITLE
feat!: restore each view's last-visited date via kRestoreLastVisitedDate (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 ### Breaking Changes
 
 - `monthDayHeaderBuilder` now receives a localized wall-clock `DateTime` (via `.forLocation()`) instead of a UTC-flagged `InternalDateTime`, matching `dayHeaderBuilder`. This fixes incorrect `DateTime.now()` comparisons in custom month-view day headers. Custom `monthDayHeaderBuilder` implementations must change their `date` parameter type from `InternalDateTime` to `DateTime` — see [MIGRATION.md](MIGRATION.md#v018x--v0190). [#248](https://github.com/werner-scholtz/kalender/issues/248)
+- `InitialDateSelectionStrategy` now receives an additional `lastVisibleDates` argument (the last visible date per view, keyed by configuration `name`). Custom strategy implementations must add a `required Map<String, InternalDateTime> lastVisibleDates` parameter — see [MIGRATION.md](MIGRATION.md#v018x--v0190). [#249](https://github.com/werner-scholtz/kalender/issues/249)
 
 ### Features
 
 - The vertical scroll position (time-of-day) and zoom (`heightPerMinute`) of a multi-day view are now preserved when switching between view types (e.g. Week → Month → Week) instead of resetting to `initialTimeOfDay`. This is on by default; set `MultiDayViewConfiguration.preserveVerticalScrollOnViewChange: false` to restore the previous reset-on-switch behaviour. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Added `CalendarController.visibleTimeOfDay` (a `ValueNotifier<TimeOfDay?>` reflecting the time aligned with the top of the viewport, `null` for views without vertical scroll) and a `CalendarCallbacks.onScrollPositionChanged` callback, so consumers can observe/persist the vertical scroll position. [#249](https://github.com/werner-scholtz/kalender/issues/249)
+- Added the `kRestoreLastVisitedDate` initial-date strategy: instead of carrying the current date forward, each view restores the last date it displayed (matched by configuration `name`) — so, e.g., Day → Month → Day reopens the day you last had in the Day view. Opt in per view via `initialDateSelectionStrategy: kRestoreLastVisitedDate`. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 
 ### Tests
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -38,6 +38,36 @@ MultiDayViewConfiguration.week(
 )
 ```
 
+### `InitialDateSelectionStrategy` gains a `lastVisibleDates` parameter
+
+Custom `initialDateSelectionStrategy` implementations must accept the new `lastVisibleDates` argument (the last visible date each view showed, keyed by configuration `name`). Existing logic can simply ignore it.
+
+**Before:**
+```dart
+InternalDateTime myStrategy({
+  required ViewController oldViewController,
+  required ViewConfiguration newViewConfiguration,
+}) { ... }
+```
+
+**After:**
+```dart
+InternalDateTime myStrategy({
+  required ViewController oldViewController,
+  required ViewConfiguration newViewConfiguration,
+  required Map<String, InternalDateTime> lastVisibleDates,
+}) { ... }
+```
+
+To have each view restore its own last-visited date (matched by `name`) instead of carrying the current date forward, use the built-in `kRestoreLastVisitedDate`:
+
+```dart
+MultiDayViewConfiguration.singleDay(
+  name: 'Day',
+  initialDateSelectionStrategy: kRestoreLastVisitedDate,
+)
+```
+
 ## v0.16.x → v0.17.0
 
 ### Input mode replaces platform-based mobile/desktop split

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ callbacks: CalendarCallbacks(
 
 Switch between views by passing a different `ViewConfiguration` to `CalendarView`. When switching, the `initialDateSelectionStrategy` on the view configuration determines which date becomes visible.
 
+By default the strategy *carries the current focus* forward (the date you were on follows you into the new view). To instead have each view remember and restore its own last-visited date — e.g. Day → Month → Day reopens the day you last had in the Day view — set `initialDateSelectionStrategy: kRestoreLastVisitedDate` on the relevant configurations (views are matched by their `name`, so give each a distinct name).
+
 All configurations accept:
 - `displayRange` — the total date range the calendar can navigate within (e.g. Jan 2024 – Dec 2025). Defaults to ± 1 year from today.
 - `initialDateTime` — the date to show on first render. Defaults to `DateTime.now()`.

--- a/lib/src/calendar_view.dart
+++ b/lib/src/calendar_view.dart
@@ -78,6 +78,12 @@ class CalendarViewState extends State<CalendarView> {
   /// Week → Month → Week). See [MultiDayViewConfiguration.preserveVerticalScrollOnViewChange].
   double? _rememberedScrollOffset;
   double? _rememberedHeightPerMinute;
+
+  /// The last visible date each view showed, keyed by its view configuration's
+  /// `name`. Persisted on the state (survives view-configuration changes) so
+  /// history-aware strategies like [kRestoreLastVisitedDate] can restore a view's
+  /// own last-visited date. See [ViewConfiguration.initialDateSelectionStrategy].
+  final Map<String, InternalDateTime> _lastVisibleDatePerView = {};
   // TODO: update this to be a valueNotifier.
   late dynamic _locale = widget.locale;
   late final _location = ValueNotifier<Location?>(widget.location);
@@ -125,12 +131,23 @@ class CalendarViewState extends State<CalendarView> {
         }
       }
 
+      // Record the outgoing view's current date under its config name so
+      // history-aware strategies can restore each view's own last-visited date.
+      final oldRange = _viewController.visibleDateTimeRange.value;
+      if (oldRange != null) {
+        final oldConfig = _viewController.viewConfiguration;
+        _lastVisibleDatePerView[oldConfig.name] = oldConfig is MonthViewConfiguration
+            ? InternalDateTime.fromDateTime(oldRange.dominantMonthDate)
+            : oldRange.start;
+      }
+
       // Use selectedDate if available, otherwise use the initial date selection strategy
       final initialDate = widget.viewConfiguration.initialDateTime != null
           ? InternalDateTime.fromDateTime(widget.viewConfiguration.initialDateTime!)
           : widget.viewConfiguration.initialDateSelectionStrategy(
               oldViewController: _viewController,
               newViewConfiguration: widget.viewConfiguration,
+              lastVisibleDates: _lastVisibleDatePerView,
             );
 
       // Restore the remembered scroll offset / zoom only when the new view is a

--- a/lib/src/models/initial_date_selection_strategy.dart
+++ b/lib/src/models/initial_date_selection_strategy.dart
@@ -1,15 +1,23 @@
 import 'package:kalender/kalender.dart';
 
-/// Strategy typedef for determining the initial date when transitioning between view configurations
+/// Strategy typedef for determining the initial date when transitioning between view configurations.
+///
+/// - [oldViewController]: the controller of the view being switched away from.
+/// - [newViewConfiguration]: the configuration of the view being switched to.
+/// - [lastVisibleDates]: the last visible date each view showed, keyed by the
+///   view configuration's `name`. Used by history-aware strategies such as
+///   [kRestoreLastVisitedDate]; ignore it for stateless "carry-focus" strategies.
 typedef InitialDateSelectionStrategy = InternalDateTime Function({
   required ViewController oldViewController,
   required ViewConfiguration newViewConfiguration,
+  required Map<String, InternalDateTime> lastVisibleDates,
 });
 
 /// Default implementation for transitioning to Monthly view
 InternalDateTime kDefaultToMonthly({
   required ViewController oldViewController,
   required ViewConfiguration newViewConfiguration,
+  required Map<String, InternalDateTime> lastVisibleDates,
 }) {
   final oldConfig = oldViewController.viewConfiguration;
   final oldRange = oldViewController.visibleDateTimeRange.value!;
@@ -29,6 +37,7 @@ InternalDateTime kDefaultToMonthly({
 InternalDateTime kDefaultToWeekly({
   required ViewController oldViewController,
   required ViewConfiguration newViewConfiguration,
+  required Map<String, InternalDateTime> lastVisibleDates,
 }) {
   final oldConfig = oldViewController.viewConfiguration;
   final oldRange = oldViewController.visibleDateTimeRange.value!;
@@ -52,6 +61,7 @@ InternalDateTime kDefaultToWeekly({
 InternalDateTime kDefaultToDaily({
   required ViewController oldViewController,
   required ViewConfiguration newViewConfiguration,
+  required Map<String, InternalDateTime> lastVisibleDates,
 }) {
   final oldConfig = oldViewController.viewConfiguration;
   final oldRange = oldViewController.visibleDateTimeRange.value!;
@@ -91,6 +101,7 @@ enum _MultiDayViewType {
 InternalDateTime kDefaultToSchedule({
   required ViewController oldViewController,
   required ViewConfiguration newViewConfiguration,
+  required Map<String, InternalDateTime> lastVisibleDates,
 }) {
   final oldRange = oldViewController.visibleDateTimeRange.value!;
   return oldRange.start;
@@ -100,22 +111,68 @@ InternalDateTime kDefaultToSchedule({
 InternalDateTime kDefaultInitialDateSelectionStrategy({
   required ViewController oldViewController,
   required ViewConfiguration newViewConfiguration,
+  required Map<String, InternalDateTime> lastVisibleDates,
 }) {
   return switch (newViewConfiguration) {
-    MonthViewConfiguration _ =>
-      kDefaultToMonthly(oldViewController: oldViewController, newViewConfiguration: newViewConfiguration),
-    ScheduleViewConfiguration _ =>
-      kDefaultToSchedule(oldViewController: oldViewController, newViewConfiguration: newViewConfiguration),
+    MonthViewConfiguration _ => kDefaultToMonthly(
+        oldViewController: oldViewController,
+        newViewConfiguration: newViewConfiguration,
+        lastVisibleDates: lastVisibleDates,
+      ),
+    ScheduleViewConfiguration _ => kDefaultToSchedule(
+        oldViewController: oldViewController,
+        newViewConfiguration: newViewConfiguration,
+        lastVisibleDates: lastVisibleDates,
+      ),
     final MultiDayViewConfiguration viewConfig => switch (viewConfig.type) {
-        MultiDayViewType.custom when viewConfig.numberOfDays == 1 =>
-          kDefaultToDaily(oldViewController: oldViewController, newViewConfiguration: newViewConfiguration),
-        MultiDayViewType.freeScroll when viewConfig.numberOfDays == 1 =>
-          kDefaultToDaily(oldViewController: oldViewController, newViewConfiguration: newViewConfiguration),
-        MultiDayViewType.singleDay =>
-          kDefaultToDaily(oldViewController: oldViewController, newViewConfiguration: newViewConfiguration),
-        _ => kDefaultToWeekly(oldViewController: oldViewController, newViewConfiguration: newViewConfiguration),
+        MultiDayViewType.custom when viewConfig.numberOfDays == 1 => kDefaultToDaily(
+            oldViewController: oldViewController,
+            newViewConfiguration: newViewConfiguration,
+            lastVisibleDates: lastVisibleDates,
+          ),
+        MultiDayViewType.freeScroll when viewConfig.numberOfDays == 1 => kDefaultToDaily(
+            oldViewController: oldViewController,
+            newViewConfiguration: newViewConfiguration,
+            lastVisibleDates: lastVisibleDates,
+          ),
+        MultiDayViewType.singleDay => kDefaultToDaily(
+            oldViewController: oldViewController,
+            newViewConfiguration: newViewConfiguration,
+            lastVisibleDates: lastVisibleDates,
+          ),
+        _ => kDefaultToWeekly(
+            oldViewController: oldViewController,
+            newViewConfiguration: newViewConfiguration,
+            lastVisibleDates: lastVisibleDates,
+          ),
       },
-    // kDefaultToWeekly(oldViewController: oldViewController, newViewConfiguration: newViewConfiguration),
-    _ => kDefaultToDaily(oldViewController: oldViewController, newViewConfiguration: newViewConfiguration),
+    _ => kDefaultToDaily(
+        oldViewController: oldViewController,
+        newViewConfiguration: newViewConfiguration,
+        lastVisibleDates: lastVisibleDates,
+      ),
   };
+}
+
+/// Strategy that restores each view's own last-visited date.
+///
+/// Unlike the default "carry-focus" strategies (which derive the new date from
+/// the view being switched away from), this looks up the last date the target
+/// view itself displayed — keyed by the view configuration's `name` — so
+/// switching, for example, Day → Month → Day reopens the day you last had in the
+/// Day view. Views are matched by `name`, so give each view a distinct name.
+///
+/// Falls back to [kDefaultInitialDateSelectionStrategy] when the target view has
+/// no recorded history yet (e.g. the first time it is shown).
+InternalDateTime kRestoreLastVisitedDate({
+  required ViewController oldViewController,
+  required ViewConfiguration newViewConfiguration,
+  required Map<String, InternalDateTime> lastVisibleDates,
+}) {
+  return lastVisibleDates[newViewConfiguration.name] ??
+      kDefaultInitialDateSelectionStrategy(
+        oldViewController: oldViewController,
+        newViewConfiguration: newViewConfiguration,
+        lastVisibleDates: lastVisibleDates,
+      );
 }

--- a/test/configuration/calendar_view_configuration_changes_test.dart
+++ b/test/configuration/calendar_view_configuration_changes_test.dart
@@ -132,6 +132,7 @@ void main() {
       InternalDateTime capturingStrategy({
         required ViewController oldViewController,
         required ViewConfiguration newViewConfiguration,
+        required Map<String, InternalDateTime> lastVisibleDates,
       }) {
         capturedOldController = oldViewController;
         capturedNewConfig = newViewConfiguration;
@@ -603,11 +604,99 @@ void main() {
       expect(reported.last, equals(const TimeOfDay(hour: 2, minute: 0)));
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Per-view date restore via kRestoreLastVisitedDate (#249)
+  // ---------------------------------------------------------------------------
+  group('Per-view date restore (#249)', () {
+    MultiDayViewConfiguration dayRestore() => MultiDayViewConfiguration.singleDay(
+          name: 'Day',
+          displayRange: calendarRange,
+          initialDateSelectionStrategy: kRestoreLastVisitedDate,
+        );
+    MonthViewConfiguration monthRestore() => MonthViewConfiguration.singleMonth(
+          name: 'Month',
+          displayRange: calendarRange,
+          initialDateSelectionStrategy: kRestoreLastVisitedDate,
+        );
+
+    InternalDateTime? visibleStart() => calendarController.internalDateTimeRange.value?.start.startOfDay;
+
+    testWidgets('restores the Day view\'s own last date after Day → Month → Day', (tester) async {
+      await pumpCalendarView(tester, config: dayRestore(), withBody: true);
+      calendarController.jumpToDate(DateTime(2024, 6, 15));
+      await tester.pumpAndSettle();
+
+      await pumpCalendarView(tester, config: monthRestore(), withBody: true);
+      await pumpCalendarView(tester, config: dayRestore(), withBody: true);
+
+      expect(visibleStart(), equals(InternalDateTime(2024, 6, 15)));
+    });
+
+    testWidgets('each view keeps its own date (navigating Month does not move Day)', (tester) async {
+      await pumpCalendarView(tester, config: dayRestore(), withBody: true);
+      calendarController.jumpToDate(DateTime(2024, 6, 15));
+      await tester.pumpAndSettle();
+
+      await pumpCalendarView(tester, config: monthRestore(), withBody: true);
+      // Navigate the month view elsewhere.
+      calendarController.jumpToDate(DateTime(2024, 9, 10));
+      await tester.pumpAndSettle();
+
+      await pumpCalendarView(tester, config: dayRestore(), withBody: true);
+
+      // Day restores its own last date, not the month's navigation.
+      expect(visibleStart(), equals(InternalDateTime(2024, 6, 15)));
+    });
+
+    testWidgets('falls back to the default strategy on first visit to a view', (tester) async {
+      // Start in month, then switch to a Day view never shown before.
+      await pumpCalendarView(tester, config: monthRestore(), withBody: true);
+      calendarController.jumpToDate(DateTime(2024, 6, 1));
+      await tester.pumpAndSettle();
+      final monthRange = calendarController.internalDateTimeRange.value;
+
+      await pumpCalendarView(tester, config: dayRestore(), withBody: true);
+
+      // No Day history yet → falls back to carry-focus (dominantMonthDate).
+      expect(visibleStart(), equals(InternalDateTime.fromDateTime(monthRange!.dominantMonthDate)));
+    });
+
+    testWidgets('default strategy still carries focus (regression guard)', (tester) async {
+      // Using the default strategy, Month → Day yields dominantMonthDate, not the
+      // last Day date — confirming the new behaviour is opt-in only.
+      await pumpCalendarView(
+        tester,
+        config: MultiDayViewConfiguration.singleDay(name: 'Day', displayRange: calendarRange),
+        withBody: true,
+      );
+      calendarController.jumpToDate(DateTime(2024, 6, 15));
+      await tester.pumpAndSettle();
+
+      await pumpCalendarView(
+        tester,
+        config: MonthViewConfiguration.singleMonth(name: 'Month', displayRange: calendarRange),
+        withBody: true,
+      );
+      calendarController.jumpToDate(DateTime(2024, 6, 1));
+      await tester.pumpAndSettle();
+      final monthRange = calendarController.internalDateTimeRange.value;
+
+      await pumpCalendarView(
+        tester,
+        config: MultiDayViewConfiguration.singleDay(name: 'Day', displayRange: calendarRange),
+        withBody: true,
+      );
+
+      expect(visibleStart(), equals(InternalDateTime.fromDateTime(monthRange!.dominantMonthDate)));
+    });
+  });
 }
 
 InternalDateTime _alwaysReturnJanuaryStrategy({
   required ViewController oldViewController,
   required ViewConfiguration newViewConfiguration,
+  required Map<String, InternalDateTime> lastVisibleDates,
 }) {
   return _fixedDate;
 }

--- a/test/configuration/default_initial_date_selection_strategies_test.dart
+++ b/test/configuration/default_initial_date_selection_strategies_test.dart
@@ -103,37 +103,37 @@ void main() {
       final newConfig = MonthViewConfiguration.singleMonth(displayRange: range);
 
       test('from Month  → dominantMonthDate of visible range', () {
-        final result = kDefaultToMonthly(oldViewController: buildMonth(), newViewConfiguration: newConfig);
+        final result = kDefaultToMonthly(oldViewController: buildMonth(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, dominantJanuary, reason: 'Month → Month: expected $dominantJanuary but got $result');
       });
 
       test('from Week   → visible-range start', () {
-        final result = kDefaultToMonthly(oldViewController: buildWeek(), newViewConfiguration: newConfig);
+        final result = kDefaultToMonthly(oldViewController: buildWeek(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, monthOrWeekStart, reason: 'Week → Month: expected $monthOrWeekStart but got $result');
       });
 
       test('from WorkWeek → visible-range start', () {
-        final result = kDefaultToMonthly(oldViewController: buildWorkWeek(), newViewConfiguration: newConfig);
+        final result = kDefaultToMonthly(oldViewController: buildWorkWeek(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, monthOrWeekStart, reason: 'WorkWeek → Month: expected $monthOrWeekStart but got $result');
       });
 
       test('from Day → visible-range start', () {
-        final result = kDefaultToMonthly(oldViewController: buildDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToMonthly(oldViewController: buildDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, dayStart, reason: 'Day → Month: expected $dayStart but got $result');
       });
 
       test('from Custom(3) → visible-range start', () {
-        final result = kDefaultToMonthly(oldViewController: buildCustomMultiDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToMonthly(oldViewController: buildCustomMultiDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, customMultiStart, reason: 'Custom(3) → Month: expected $customMultiStart but got $result');
       });
 
       test('from Custom(1) → visible-range start', () {
-        final result = kDefaultToMonthly(oldViewController: buildCustomSingleDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToMonthly(oldViewController: buildCustomSingleDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, dayStart, reason: 'Custom(1) → Month: expected $dayStart but got $result');
       });
 
       test('from Schedule → visible-range start', () {
-        final result = kDefaultToMonthly(oldViewController: buildSchedule(), newViewConfiguration: newConfig);
+        final result = kDefaultToMonthly(oldViewController: buildSchedule(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, scheduleStart, reason: 'Schedule → Month: expected $scheduleStart but got $result');
       });
     });
@@ -144,37 +144,37 @@ void main() {
       final newConfig = MultiDayViewConfiguration.week(displayRange: range);
 
       test('from Month    → visible-range start', () {
-        final result = kDefaultToWeekly(oldViewController: buildMonth(), newViewConfiguration: newConfig);
+        final result = kDefaultToWeekly(oldViewController: buildMonth(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, monthOrWeekStart, reason: 'Month → Week: expected $monthOrWeekStart but got $result');
       });
 
       test('from Week     → visible-range start', () {
-        final result = kDefaultToWeekly(oldViewController: buildWeek(), newViewConfiguration: newConfig);
+        final result = kDefaultToWeekly(oldViewController: buildWeek(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, monthOrWeekStart, reason: 'Week → Week: expected $monthOrWeekStart but got $result');
       });
 
       test('from WorkWeek → visible-range start', () {
-        final result = kDefaultToWeekly(oldViewController: buildWorkWeek(), newViewConfiguration: newConfig);
+        final result = kDefaultToWeekly(oldViewController: buildWorkWeek(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, monthOrWeekStart, reason: 'WorkWeek → Week: expected $monthOrWeekStart but got $result');
       });
 
       test('from Day → visible-range start', () {
-        final result = kDefaultToWeekly(oldViewController: buildDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToWeekly(oldViewController: buildDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, dayStart, reason: 'Day → Week: expected $dayStart but got $result');
       });
 
       test('from Custom(3) → visible-range start', () {
-        final result = kDefaultToWeekly(oldViewController: buildCustomMultiDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToWeekly(oldViewController: buildCustomMultiDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, customMultiStart, reason: 'Custom(3) → Week: expected $customMultiStart but got $result');
       });
 
       test('from Custom(1) → visible-range start', () {
-        final result = kDefaultToWeekly(oldViewController: buildCustomSingleDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToWeekly(oldViewController: buildCustomSingleDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, dayStart, reason: 'Custom(1) → Week: expected $dayStart but got $result');
       });
 
       test('from Schedule → visible-range start', () {
-        final result = kDefaultToWeekly(oldViewController: buildSchedule(), newViewConfiguration: newConfig);
+        final result = kDefaultToWeekly(oldViewController: buildSchedule(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, scheduleStart, reason: 'Schedule → Week: expected $scheduleStart but got $result');
       });
     });
@@ -185,37 +185,37 @@ void main() {
       final newConfig = MultiDayViewConfiguration.singleDay(displayRange: range);
 
       test('from Month  → dominantMonthDate of visible range', () {
-        final result = kDefaultToDaily(oldViewController: buildMonth(), newViewConfiguration: newConfig);
+        final result = kDefaultToDaily(oldViewController: buildMonth(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, dominantJanuary, reason: 'Month → Day: expected $dominantJanuary but got $result');
       });
 
       test('from Week   → visible-range start', () {
-        final result = kDefaultToDaily(oldViewController: buildWeek(), newViewConfiguration: newConfig);
+        final result = kDefaultToDaily(oldViewController: buildWeek(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, monthOrWeekStart, reason: 'Week → Day: expected $monthOrWeekStart but got $result');
       });
 
       test('from WorkWeek → visible-range start', () {
-        final result = kDefaultToDaily(oldViewController: buildWorkWeek(), newViewConfiguration: newConfig);
+        final result = kDefaultToDaily(oldViewController: buildWorkWeek(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, monthOrWeekStart, reason: 'WorkWeek → Day: expected $monthOrWeekStart but got $result');
       });
 
       test('from Day → visible-range start', () {
-        final result = kDefaultToDaily(oldViewController: buildDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToDaily(oldViewController: buildDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, dayStart, reason: 'Day → Day: expected $dayStart but got $result');
       });
 
       test('from Custom(3) → visible-range start', () {
-        final result = kDefaultToDaily(oldViewController: buildCustomMultiDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToDaily(oldViewController: buildCustomMultiDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, customMultiStart, reason: 'Custom(3) → Day: expected $customMultiStart but got $result');
       });
 
       test('from Custom(1) → visible-range start', () {
-        final result = kDefaultToDaily(oldViewController: buildCustomSingleDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToDaily(oldViewController: buildCustomSingleDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, dayStart, reason: 'Custom(1) → Day: expected $dayStart but got $result');
       });
 
       test('from Schedule → visible-range start', () {
-        final result = kDefaultToDaily(oldViewController: buildSchedule(), newViewConfiguration: newConfig);
+        final result = kDefaultToDaily(oldViewController: buildSchedule(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, scheduleStart, reason: 'Schedule → Day: expected $scheduleStart but got $result');
       });
     });
@@ -226,37 +226,37 @@ void main() {
       final newConfig = ScheduleViewConfiguration.continuous(displayRange: range);
 
       test('from Month    → visible-range start', () {
-        final result = kDefaultToSchedule(oldViewController: buildMonth(), newViewConfiguration: newConfig);
+        final result = kDefaultToSchedule(oldViewController: buildMonth(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, monthOrWeekStart, reason: 'Month → Schedule: expected $monthOrWeekStart but got $result');
       });
 
       test('from Week     → visible-range start', () {
-        final result = kDefaultToSchedule(oldViewController: buildWeek(), newViewConfiguration: newConfig);
+        final result = kDefaultToSchedule(oldViewController: buildWeek(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, monthOrWeekStart, reason: 'Week → Schedule: expected $monthOrWeekStart but got $result');
       });
 
       test('from WorkWeek → visible-range start', () {
-        final result = kDefaultToSchedule(oldViewController: buildWorkWeek(), newViewConfiguration: newConfig);
+        final result = kDefaultToSchedule(oldViewController: buildWorkWeek(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, monthOrWeekStart, reason: 'WorkWeek → Schedule: expected $monthOrWeekStart but got $result');
       });
 
       test('from Day → visible-range start', () {
-        final result = kDefaultToSchedule(oldViewController: buildDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToSchedule(oldViewController: buildDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, dayStart, reason: 'Day → Schedule: expected $dayStart but got $result');
       });
 
       test('from Custom(3) → visible-range start', () {
-        final result = kDefaultToSchedule(oldViewController: buildCustomMultiDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToSchedule(oldViewController: buildCustomMultiDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, customMultiStart, reason: 'Custom(3) → Schedule: expected $customMultiStart but got $result');
       });
 
       test('from Custom(1) → visible-range start', () {
-        final result = kDefaultToSchedule(oldViewController: buildCustomSingleDay(), newViewConfiguration: newConfig);
+        final result = kDefaultToSchedule(oldViewController: buildCustomSingleDay(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, dayStart, reason: 'Custom(1) → Schedule: expected $dayStart but got $result');
       });
 
       test('from Schedule → visible-range start', () {
-        final result = kDefaultToSchedule(oldViewController: buildSchedule(), newViewConfiguration: newConfig);
+        final result = kDefaultToSchedule(oldViewController: buildSchedule(), newViewConfiguration: newConfig, lastVisibleDates: const {});
         expect(result, scheduleStart, reason: 'Schedule → Schedule: expected $scheduleStart but got $result');
       });
     });
@@ -275,56 +275,56 @@ void main() {
       test('→ MonthViewConfiguration routes to kDefaultToMonthly', () {
         final cfg = MonthViewConfiguration.singleMonth(displayRange: range);
         expect(
-          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg),
-          kDefaultToMonthly(oldViewController: src(), newViewConfiguration: cfg),
+          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
+          kDefaultToMonthly(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
         );
       });
 
       test('→ week MultiDayViewConfiguration routes to kDefaultToWeekly', () {
         final cfg = MultiDayViewConfiguration.week(displayRange: range);
         expect(
-          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg),
-          kDefaultToWeekly(oldViewController: src(), newViewConfiguration: cfg),
+          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
+          kDefaultToWeekly(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
         );
       });
 
       test('→ workWeek MultiDayViewConfiguration routes to kDefaultToWeekly', () {
         final cfg = MultiDayViewConfiguration.workWeek(displayRange: range);
         expect(
-          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg),
-          kDefaultToWeekly(oldViewController: src(), newViewConfiguration: cfg),
+          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
+          kDefaultToWeekly(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
         );
       });
 
       test('→ custom(3) MultiDayViewConfiguration routes to kDefaultToWeekly', () {
         final cfg = MultiDayViewConfiguration.custom(numberOfDays: 3, displayRange: range);
         expect(
-          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg),
-          kDefaultToWeekly(oldViewController: src(), newViewConfiguration: cfg),
+          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
+          kDefaultToWeekly(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
         );
       });
 
       test('→ singleDay MultiDayViewConfiguration routes to kDefaultToDaily', () {
         final cfg = MultiDayViewConfiguration.singleDay(displayRange: range);
         expect(
-          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg),
-          kDefaultToDaily(oldViewController: src(), newViewConfiguration: cfg),
+          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
+          kDefaultToDaily(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
         );
       });
 
       test('→ custom(1) MultiDayViewConfiguration routes to kDefaultToDaily', () {
         final cfg = MultiDayViewConfiguration.custom(numberOfDays: 1, displayRange: range);
         expect(
-          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg),
-          kDefaultToDaily(oldViewController: src(), newViewConfiguration: cfg),
+          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
+          kDefaultToDaily(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
         );
       });
 
       test('→ ScheduleViewConfiguration routes to kDefaultToSchedule', () {
         final cfg = ScheduleViewConfiguration.continuous(displayRange: range);
         expect(
-          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg),
-          kDefaultToSchedule(oldViewController: src(), newViewConfiguration: cfg),
+          kDefaultInitialDateSelectionStrategy(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
+          kDefaultToSchedule(oldViewController: src(), newViewConfiguration: cfg, lastVisibleDates: const {}),
         );
       });
     });


### PR DESCRIPTION
## Summary

Fixes #249 (the horizontal/date half — PR #277 shipped the vertical scroll/zoom half). The reporter asked: *"remember last visited day so when you switch from daily to monthly then back to daily, calendar opens the day of last visited one."*

**Stacked on #277** (base branch `249-preserve-vertical-scroll-on-view-switch`) — it edits the same `calendar_view.dart` region, so it can't cleanly branch off `main`. GitHub will retarget this to `main` automatically once #277 merges.

## Why the existing mechanism can't do it

`InitialDateSelectionStrategy` is a pure function of `(outgoing controller, new config)` — it only *carries the current focus* forward. It has no history, so it can't restore a view's own last date; the default month→day path even drops the specific day (`dominantMonthDate`).

## What changed

- **`InitialDateSelectionStrategy` now receives `lastVisibleDates`** — a `Map<String, InternalDateTime>` of the last visible date per view, keyed by configuration `name`. Maintained on `CalendarView` state so it survives view switches (same place PR #277's scroll memory lives). **Breaking**: custom strategies must add the parameter.
- **New `kRestoreLastVisitedDate` strategy** — each view restores the last date it displayed (matched by `name`), falling back to the default carry-focus strategy on a cache miss. Opt in per view via `initialDateSelectionStrategy: kRestoreLastVisitedDate`.

| Flow | Default (carry-focus) | `kRestoreLastVisitedDate` |
|---|---|---|
| Day(Jun 15) → Month → Day | Jun 1 (`dominantMonthDate`) | **Jun 15** |
| Day(Jun 15) → Month, nav to Aug → Day | ~Aug | **Jun 15** |

## Tests
Added a `Per-view date restore (#249)` group to `calendar_view_configuration_changes_test.dart`: restore after Day→Month→Day, independence from month navigation, first-visit fallback, and a regression guard that the default strategy is unchanged. Updated the existing strategy tests for the new signature. Mutation-verified (disabling the lookup fails the restore tests).

## Verification
- `flutter test` — full suite green (1180 tests)
- `dart analyze` — no issues

No `pubspec.yaml` bump. Breaking signature change + opt-in strategy documented in CHANGELOG/MIGRATION; README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
