### PR TITLE
fix!: schedule row alignment + no-events-today scrolling (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,24 @@
 - `monthDayHeaderBuilder` now receives a localized wall-clock `DateTime` instead of a UTC-flagged `InternalDateTime`, matching `dayHeaderBuilder`. [#248](https://github.com/werner-scholtz/kalender/issues/248)
 - Replaced `ViewConfiguration.initialDateSelectionStrategy` with per-dimension view-transition options: `dateTransition` on all views, and `scrollTransition` / `zoomTransition` on `MultiDayViewConfiguration`, each with an optional resolver for custom logic. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - View switches now preserve the vertical scroll (time-of-day) and zoom by default instead of resetting to `initialTimeOfDay`; opt out with `ScrollTransition.reset` / `ZoomTransition.reset`. [#249](https://github.com/werner-scholtz/kalender/issues/249)
+- Renamed `EmptyDayBehavior.showToday` to `EmptyDayBehavior.showOnlyToday`, since it shows only today among empty days. [#253](https://github.com/werner-scholtz/kalender/issues/253)
 
 ### Features
 
 - Added `restorePerView` transitions so each view can reopen its own last date, scroll, and zoom. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Added `CalendarController.visibleTimeOfDay` and the `CalendarCallbacks.onScrollPositionChanged` callback. [#249](https://github.com/werner-scholtz/kalender/issues/249)
+- Added `ScheduleBodyConfiguration.leadingWidth` to control the schedule view's date-column width. [#253](https://github.com/werner-scholtz/kalender/issues/253)
+
+### Fixes
+
+- Fixed schedule view event tiles not lining up; every row now shares a fixed-width leading column whether or not it shows a date. [#253](https://github.com/werner-scholtz/kalender/issues/253)
+- Fixed the continuous schedule view scrolling to the wrong position when today has no events; the initial scroll and `animateToDateTime` now target today, or the nearest day when it is hidden. [#253](https://github.com/werner-scholtz/kalender/issues/253)
 
 ### Tests
 
 - Added end-to-end `CalendarView` regression coverage for the time indicator, run across the timezone matrix. [#261](https://github.com/werner-scholtz/kalender/issues/261)
 - Added end-to-end `CalendarView` today-highlighting coverage, run across the timezone matrix. [#254](https://github.com/werner-scholtz/kalender/issues/254) [#251](https://github.com/werner-scholtz/kalender/issues/251)
+- Added continuous schedule regression coverage for row alignment and the no-events-today scroll target. [#253](https://github.com/werner-scholtz/kalender/issues/253)
 - Added end-to-end month-view regression coverage for a custom `generateMultiDayLayoutFrame`. [#235](https://github.com/werner-scholtz/kalender/issues/235)
 
 ## 0.18.7

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,6 +48,20 @@ MultiDayViewConfiguration.week(
 )
 ```
 
+### `EmptyDayBehavior.showToday` renamed to `showOnlyToday`
+
+`EmptyDayBehavior.showToday` has been renamed to `EmptyDayBehavior.showOnlyToday`. The behaviour is unchanged — among empty days, only today is shown — the new name just removes the ambiguity (it never showed *all* empty days plus today).
+
+**Before:**
+```dart
+ScheduleBodyConfiguration(emptyDay: EmptyDayBehavior.showToday)
+```
+
+**After:**
+```dart
+ScheduleBodyConfiguration(emptyDay: EmptyDayBehavior.showOnlyToday)
+```
+
 ### `initialDateSelectionStrategy` replaced by per-dimension view-transition controls
 
 `ViewConfiguration.initialDateSelectionStrategy` has been removed. How a view switch transfers state is now expressed per dimension:

--- a/README.md
+++ b/README.md
@@ -1065,7 +1065,7 @@ MultiDayViewConfiguration.week(
 The callback's return value is used for:
 - Positioning the time indicator on the calendar grid.
 - Determining which day is "today" for header highlighting (`DayHeader`, `MonthDayHeader`, `ScheduleDate`).
-- Evaluating `EmptyDayBehavior.showToday` in schedule views.
+- Evaluating `EmptyDayBehavior.showOnlyToday` in schedule views.
 
 Any `DateTime` subtype works — `DateTime.now()`, `DateTime.now().toUtc()`, or `TZDateTime.now(location)` for a specific timezone.
 

--- a/lib/src/models/controllers/view_controllers/schedule_view_controller.dart
+++ b/lib/src/models/controllers/view_controllers/schedule_view_controller.dart
@@ -63,9 +63,13 @@ abstract class ScheduleViewController extends ViewController with ScheduleMap {
   void clear() => clearPage(currentPage);
 
   /// Find the initial scroll index for the given date.
+  ///
+  /// Normalizes with the view's [location] (matching how the map is keyed and how
+  /// [indexFromDateTime]/[closestIndex] look up), and never writes a fallback back
+  /// into the authoritative date→index map.
   int initialScrollIndex(DateTime date) {
-    final asUtc = InternalDateTime.fromDateTime(date).startOfDay;
-    return dateTimeItemIndex(currentPage)[asUtc] ??= closestIndex(asUtc);
+    final normalized = InternalDateTime.fromExternal(date, location: location).startOfDay;
+    return dateTimeItemIndex(currentPage)[normalized] ?? closestIndex(normalized);
   }
 
   /// Animate to the given index.

--- a/lib/src/models/mixins/schedule_map.dart
+++ b/lib/src/models/mixins/schedule_map.dart
@@ -120,23 +120,27 @@ mixin ScheduleMap {
     return dateTimeFirstItemIndex[date];
   }
 
-  /// Find the index closest to the given date.
+  /// Find the index of the row whose date is closest to [date].
+  ///
+  /// Distances are measured against the first row of each date, so the result
+  /// points at the start of the nearest day rather than an arbitrary event
+  /// within it. This handles targets before the first day, after the last day,
+  /// and in between uniformly. Ties resolve to the earlier date.
   int closestIndexForPage(int pageIndex, DateTime date) {
-    date = InternalDateTime.fromExternal(date, location: location).startOfDay;
+    final target = InternalDateTime.fromExternal(date, location: location).startOfDay;
     final dateTimeFirstItemIndex = dateTimeItemIndex(pageIndex);
     if (dateTimeFirstItemIndex.isEmpty) return 0;
 
-    final itemIndexDateTimeForPage = itemIndexDateTime(pageIndex);
-    final lastDate = dateTimeFirstItemIndex.keys.last;
-    final firstDate = dateTimeFirstItemIndex.keys.first;
-    if (date.isAfter(lastDate)) {
-      return itemIndexDateTimeForPage.keys.last;
-    } else if (date.isBefore(firstDate)) {
-      return itemIndexDateTimeForPage.keys.first;
-    } else {
-      // If the date is in between, we need to find the closest index.
-      return itemIndexDateTimeForPage.entries.reduce((a, b) => (a.value.isBefore(b.value) ? a : b)).key;
+    var closestIndex = dateTimeFirstItemIndex.values.first;
+    Duration? closestDelta;
+    for (final entry in dateTimeFirstItemIndex.entries) {
+      final delta = entry.key.difference(target).abs();
+      if (closestDelta == null || delta < closestDelta) {
+        closestDelta = delta;
+        closestIndex = entry.value;
+      }
     }
+    return closestIndex;
   }
 
   /// A map of all the pageIndexes to MonthIndices.

--- a/lib/src/models/view_configurations/schedule_view_configuration.dart
+++ b/lib/src/models/view_configurations/schedule_view_configuration.dart
@@ -13,13 +13,13 @@ enum ScheduleViewType {
 
 /// The default behavior for empty days in the schedule view.
 enum EmptyDayBehavior {
-  /// Show empty days in the schedule view.
+  /// Show every empty day in the schedule view.
   show,
 
-  /// Show today in the schedule view, even if it does not have any events.
-  showToday,
+  /// Show only today when it has no events; all other empty days are hidden.
+  showOnlyToday,
 
-  /// Hide empty days in the schedule view.
+  /// Hide every empty day in the schedule view.
   hide,
 }
 
@@ -63,10 +63,18 @@ class ScheduleViewConfiguration extends ViewConfiguration {
         viewType = ScheduleViewType.paginated;
 }
 
+/// The default width of the leading (date) column in the schedule view.
+///
+/// A fixed width keeps every row's event tile aligned regardless of whether the
+/// row shows a date, and independent of the day name, day-number digits, locale,
+/// or text scale.
+const kDefaultScheduleLeadingWidth = 56.0;
+
 class ScheduleBodyConfiguration {
   /// Creates a new [ScheduleBodyConfiguration].
   ScheduleBodyConfiguration({
     this.emptyDay = kDefaultEmptyDayBehavior,
+    this.leadingWidth = kDefaultScheduleLeadingWidth,
     PageTriggerConfiguration? pageTriggerConfiguration,
     ScrollTriggerConfiguration? scrollTriggerConfiguration,
     this.scrollPhysics,
@@ -75,10 +83,14 @@ class ScheduleBodyConfiguration {
         scrollTriggerConfiguration = scrollTriggerConfiguration ?? ScrollTriggerConfiguration();
 
   /// The behavior of empty days in the schedule view.
-  /// - [EmptyDayBehavior.show]: Show empty days in the schedule view.
-  /// - [EmptyDayBehavior.showToday]: Show today in the schedule view.
-  /// - [EmptyDayBehavior.hide]: Hide empty days in the schedule view.
+  /// - [EmptyDayBehavior.show]: Show every empty day in the schedule view.
+  /// - [EmptyDayBehavior.showOnlyToday]: Show only today when it has no events.
+  /// - [EmptyDayBehavior.hide]: Hide every empty day in the schedule view.
   final EmptyDayBehavior emptyDay;
+
+  /// The width of the leading (date) column, shared by every row so the event
+  /// tiles line up. Defaults to [kDefaultScheduleLeadingWidth].
+  final double leadingWidth;
 
   /// The configuration for the page navigation triggers.
   final PageTriggerConfiguration pageTriggerConfiguration;
@@ -95,6 +107,7 @@ class ScheduleBodyConfiguration {
   /// Creates a copy of this [MultiDayHeaderConfiguration] with the given fields replaced by the new values.
   ScheduleBodyConfiguration copyWith({
     EmptyDayBehavior? emptyDay,
+    double? leadingWidth,
     PageTriggerConfiguration? pageTriggerConfiguration,
     ScrollTriggerConfiguration? scrollTriggerConfiguration,
     ScrollPhysics? scrollPhysics,
@@ -102,6 +115,7 @@ class ScheduleBodyConfiguration {
   }) {
     return ScheduleBodyConfiguration(
       emptyDay: emptyDay ?? this.emptyDay,
+      leadingWidth: leadingWidth ?? this.leadingWidth,
       pageTriggerConfiguration: pageTriggerConfiguration ?? this.pageTriggerConfiguration,
       scrollTriggerConfiguration: scrollTriggerConfiguration ?? this.scrollTriggerConfiguration,
       scrollPhysics: scrollPhysics ?? this.scrollPhysics,
@@ -115,6 +129,7 @@ class ScheduleBodyConfiguration {
 
     return other is ScheduleBodyConfiguration &&
         other.emptyDay == emptyDay &&
+        other.leadingWidth == leadingWidth &&
         other.pageTriggerConfiguration == pageTriggerConfiguration &&
         other.scrollTriggerConfiguration == scrollTriggerConfiguration &&
         other.scrollPhysics == scrollPhysics &&
@@ -125,6 +140,7 @@ class ScheduleBodyConfiguration {
   int get hashCode {
     return Object.hash(
       emptyDay,
+      leadingWidth,
       pageTriggerConfiguration,
       scrollTriggerConfiguration,
       scrollPhysics,

--- a/lib/src/models/view_configurations/view_configuration.dart
+++ b/lib/src/models/view_configurations/view_configuration.dart
@@ -15,7 +15,7 @@ export 'package:kalender/kalender_extensions.dart';
 /// - Position the time indicator on the calendar grid.
 /// - Determine which day is "today" for header highlighting
 ///   ([DayHeader], [MonthDayHeader], [ScheduleDate]).
-/// - Evaluate [EmptyDayBehavior.showToday] in schedule views.
+/// - Evaluate [EmptyDayBehavior.showOnlyToday] in schedule views.
 ///
 /// Any [DateTime] subtype works:
 /// - [DateTime.now] — uses the system's local wall-clock time.
@@ -66,7 +66,7 @@ abstract class ViewConfiguration {
   /// - **"Today" highlighting** — the default [DayHeader], [MonthDayHeader],
   ///   and [ScheduleDate] widgets use this to decide which day receives the
   ///   filled-button highlight.
-  /// - **Schedule empty-day logic** — [EmptyDayBehavior.showToday] uses this
+  /// - **Schedule empty-day logic** — [EmptyDayBehavior.showOnlyToday] uses this
   ///   to decide whether an empty day should still be shown.
   ///
   /// This is useful when the calendar displays events in UTC but should
@@ -254,7 +254,7 @@ const defaultHeightPerMinute = 0.7;
 const defaultHorizontalPadding = EdgeInsets.only(left: 0, right: 4);
 
 const kDefaultMultiDayEventPadding = EdgeInsets.only(left: 0, right: 4, bottom: 2);
-const kDefaultEmptyDayBehavior = EmptyDayBehavior.showToday;
+const kDefaultEmptyDayBehavior = EmptyDayBehavior.showOnlyToday;
 DateTimeRange kDefaultRange() {
   final now = DateTime.now();
   return DateTimeRange(start: DateTime(now.year - 2), end: DateTime(now.year + 2));

--- a/lib/src/widgets/schedule/schedule_body.dart
+++ b/lib/src/widgets/schedule/schedule_body.dart
@@ -276,14 +276,15 @@ class _SchedulePositionListState extends State<SchedulePositionList> {
 
         switch (widget.configuration.emptyDay) {
           case EmptyDayBehavior.show:
-            viewController.addItem(item: EmptyItem(), date: date);
+            // Record the empty day as the first (only) row of its date so it can
+            // be scrolled/animated to directly (#253).
+            viewController.addItem(item: EmptyItem(), date: date, isFirst: true);
             continue;
 
-          case EmptyDayBehavior.showToday:
-            // TODO: check that this works as expected.
+          case EmptyDayBehavior.showOnlyToday:
             final now = widget.viewController.viewConfiguration.nowCallback?.call();
             if (internalDate.isToday(location: widget.location, now: now)) {
-              viewController.addItem(item: EmptyItem(), date: date);
+              viewController.addItem(item: EmptyItem(), date: date, isFirst: true);
             }
             continue;
 
@@ -362,9 +363,14 @@ class _SchedulePositionListState extends State<SchedulePositionList> {
           initialScrollIndex: viewController.initialScrollIndex(viewController.initialDate),
           physics: widget.configuration.scrollPhysics,
           itemBuilder: (context, index) {
-            // TODO: Check that this is still working as expected.
             final item = viewController.item(index);
             final date = viewController.dateTimeFromIndex(index)!;
+
+            // A fixed-width leading slot shared by every row, so the event tiles
+            // line up regardless of whether the row shows a date (and independent
+            // of day name / digits / locale / text scale).
+            final leadingWidth = widget.configuration.leadingWidth;
+            Widget leadingSlot(Widget? child) => SizedBox(width: leadingWidth, child: child);
 
             late final leading =
                 components.leadingDateBuilder.call(InternalDateTime.fromDateTime(date), styles.scheduleDateStyle);
@@ -378,7 +384,8 @@ class _SchedulePositionListState extends State<SchedulePositionList> {
                   ListTile(title: Text(date.monthNameLocalized(locale)));
             } else if (item is EmptyItem) {
               final child = ListTile(
-                leading: leading,
+                minLeadingWidth: 0,
+                leading: leadingSlot(leading),
                 title: tileComponents.emptyItemBuilder?.call(InternalDateTime.fromDateTime(date).dayRange),
               );
               return highlightBuilder(date, viewController.highlightedDateTimeRange, highlightStyle, child);
@@ -387,7 +394,8 @@ class _SchedulePositionListState extends State<SchedulePositionList> {
               final event = eventsController.byId(item.eventId)!;
 
               final child = ListTile(
-                leading: showDate ? leading : const SizedBox(width: 32),
+                minLeadingWidth: 0,
+                leading: leadingSlot(showDate ? leading : null),
                 title: ScheduleEventTile(
                   key: ScheduleEventTile.tileKey(event.id),
                   event: event,

--- a/test/widgets/schedule/schedule_body_test.dart
+++ b/test/widgets/schedule/schedule_body_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/mixins/schedule_map.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/schedule_tile.dart';
+
+import '../../utilities.dart';
+
+/// Regression coverage for the continuous schedule view:
+///
+///   * Row alignment — every event tile shares one leading (date) column width,
+///     so first-of-day rows (which show the date) line up with the rows below
+///     them (which don't). Previously the date widget's intrinsic width and a
+///     hardcoded `SizedBox(width: 32)` placeholder disagreed.
+///   * #253 — when today has no events, `initialScrollIndex` /
+///     `animateToDateTime(now)` landed on the first item instead of today / the
+///     nearest day, and `initialScrollIndex` polluted the date→index map.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  // A one-hour event at [hour] on [day].
+  CalendarEvent eventAt(DateTime day, int hour) => CalendarEvent(
+        dateTimeRange: DateTimeRange(
+          start: DateTime(day.year, day.month, day.day, hour),
+          end: DateTime(day.year, day.month, day.day, hour + 1),
+        ),
+      );
+
+  CalendarView buildSchedule({
+    EmptyDayBehavior emptyDay = EmptyDayBehavior.showOnlyToday,
+    double leadingWidth = kDefaultScheduleLeadingWidth,
+    NowCallback? nowCallback,
+    DateTime? initialDate,
+    Location? location,
+  }) {
+    return CalendarView(
+      eventsController: eventsController,
+      calendarController: calendarController,
+      location: location,
+      viewConfiguration: ScheduleViewConfiguration.continuous(
+        displayRange: DateTimeRange(start: DateTime(2025), end: DateTime(2026)),
+        initialDateTime: initialDate,
+        nowCallback: nowCallback,
+      ),
+      body: CalendarBody(
+        scheduleBodyConfiguration: ScheduleBodyConfiguration(emptyDay: emptyDay, leadingWidth: leadingWidth),
+      ),
+    );
+  }
+
+  ScheduleViewController schedule() => calendarController.viewController as ScheduleViewController;
+
+  double tileLeft(WidgetTester tester, String id) =>
+      tester.getTopLeft(find.byKey(ScheduleEventTile.tileKey(id))).dx;
+
+  group('Row alignment', () {
+    testWidgets('event tiles on the same day share one left edge', (tester) async {
+      final ids = eventsController.addEvents([
+        eventAt(DateTime(2025, 1, 15), 9),
+        eventAt(DateTime(2025, 1, 15), 11),
+        eventAt(DateTime(2025, 1, 15), 13),
+      ]);
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        buildSchedule(initialDate: DateTime(2025, 1, 15), nowCallback: () => DateTime(2025, 1, 15, 10)),
+      );
+
+      // The first row shows the date, the rest don't — they must still line up.
+      final first = tileLeft(tester, ids[0]);
+      expect(tileLeft(tester, ids[1]), moreOrLessEquals(first, epsilon: 0.5));
+      expect(tileLeft(tester, ids[2]), moreOrLessEquals(first, epsilon: 0.5));
+    });
+
+    testWidgets('leadingWidth widens the leading column by exactly its delta', (tester) async {
+      final ids = eventsController.addEvents([eventAt(DateTime(2025, 1, 15), 9)]);
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        buildSchedule(initialDate: DateTime(2025, 1, 15), nowCallback: () => DateTime(2025, 1, 15, 10), leadingWidth: 56),
+      );
+      final narrow = tileLeft(tester, ids.first);
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        buildSchedule(initialDate: DateTime(2025, 1, 15), nowCallback: () => DateTime(2025, 1, 15, 10), leadingWidth: 120),
+      );
+      final wide = tileLeft(tester, ids.first);
+
+      expect(wide - narrow, moreOrLessEquals(64, epsilon: 1));
+    });
+  });
+
+  group('No events today (#253)', () {
+    testWidgets('showOnlyToday indexes today, so it is the scroll target', (tester) async {
+      eventsController.addEvents([eventAt(DateTime(2025, 1, 10), 9), eventAt(DateTime(2025, 1, 20), 9)]);
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        buildSchedule(
+          emptyDay: EmptyDayBehavior.showOnlyToday,
+          initialDate: DateTime(2025, 1, 15),
+          nowCallback: () => DateTime(2025, 1, 15, 10),
+        ),
+      );
+
+      final controller = schedule();
+      final todayIndex = controller.indexFromDateTime(DateTime(2025, 1, 15));
+      expect(todayIndex, isNotNull, reason: "today's empty row must be indexed");
+      expect(controller.item(todayIndex!), isA<EmptyItem>());
+      expect(controller.dateTimeFromIndex(todayIndex)!.isSameDay(InternalDateTime(2025, 1, 15)), isTrue);
+      expect(controller.initialScrollIndex(DateTime(2025, 1, 15)), todayIndex);
+
+      // Only today is shown among empty days.
+      expect(controller.indexFromDateTime(DateTime(2025, 1, 11)), isNull);
+    });
+
+    testWidgets('hide: closest picks the nearer past day, not the earliest', (tester) async {
+      eventsController.addEvents([eventAt(DateTime(2025, 1, 14), 9), eventAt(DateTime(2025, 1, 18), 9)]);
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        buildSchedule(
+          emptyDay: EmptyDayBehavior.hide,
+          initialDate: DateTime(2025, 1, 15),
+          nowCallback: () => DateTime(2025, 1, 15, 10),
+        ),
+      );
+
+      final controller = schedule();
+      final index = controller.closestIndex(DateTime(2025, 1, 15));
+      expect(
+        controller.dateTimeFromIndex(index)!.isSameDay(InternalDateTime(2025, 1, 14)),
+        isTrue,
+        reason: 'Jan 14 is 1 day away, Jan 18 is 3 — the nearer one wins',
+      );
+    });
+
+    testWidgets('hide: closest picks the nearer future day', (tester) async {
+      eventsController.addEvents([eventAt(DateTime(2025, 1, 12), 9), eventAt(DateTime(2025, 1, 16), 9)]);
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        buildSchedule(
+          emptyDay: EmptyDayBehavior.hide,
+          initialDate: DateTime(2025, 1, 15),
+          nowCallback: () => DateTime(2025, 1, 15, 10),
+        ),
+      );
+
+      final controller = schedule();
+      final index = controller.closestIndex(DateTime(2025, 1, 15));
+      expect(
+        controller.dateTimeFromIndex(index)!.isSameDay(InternalDateTime(2025, 1, 16)),
+        isTrue,
+        reason: 'Jan 16 is 1 day away, Jan 12 is 3 — the nearer one wins',
+      );
+    });
+
+    testWidgets('closest clamps to the first/last day for out-of-range targets', (tester) async {
+      eventsController.addEvents([eventAt(DateTime(2025, 6, 10), 9), eventAt(DateTime(2025, 6, 20), 9)]);
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        buildSchedule(emptyDay: EmptyDayBehavior.hide, initialDate: DateTime(2025, 6, 15)),
+      );
+
+      final controller = schedule();
+      final earliest = controller.closestIndex(DateTime(2025, 1, 1));
+      expect(controller.dateTimeFromIndex(earliest)!.isSameDay(InternalDateTime(2025, 6, 10)), isTrue);
+
+      final latest = controller.closestIndex(DateTime(2025, 12, 31));
+      expect(controller.dateTimeFromIndex(latest)!.isSameDay(InternalDateTime(2025, 6, 20)), isTrue);
+    });
+
+    testWidgets('initialScrollIndex does not pollute the date→index map', (tester) async {
+      eventsController.addEvents([eventAt(DateTime(2025, 1, 10), 9), eventAt(DateTime(2025, 1, 20), 9)]);
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        buildSchedule(
+          emptyDay: EmptyDayBehavior.hide,
+          initialDate: DateTime(2025, 1, 15),
+          nowCallback: () => DateTime(2025, 1, 15, 10),
+        ),
+      );
+
+      final controller = schedule();
+      // The build already resolved initialScrollIndex(Jan 15); it must not have
+      // written a fallback index back into the authoritative map.
+      expect(controller.indexFromDateTime(DateTime(2025, 1, 15)), isNull);
+      controller.initialScrollIndex(DateTime(2025, 1, 15));
+      expect(controller.indexFromDateTime(DateTime(2025, 1, 15)), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #253.

Two package-level schedule-view bugs, one PR.

## Row alignment
Every schedule row is a `ListTile`, but the leading (date) column width was inconsistent: the first event of a day rendered a variable-width `ScheduleDate` widget, while subsequent events used a hardcoded `SizedBox(width: 32)`. Since `ListTile` places the title after the leading width, the first-of-day row and the rows below it started at different x — so the event tiles didn't line up (width also shifted with day name / digit count / locale / text scale).

**Fix:** every row now shares a fixed-width leading column, configurable via the new `ScheduleBodyConfiguration.leadingWidth` (default `56`). Date rows, placeholder rows, and empty-day rows all align.

## No events today (#253's reported symptoms)
- **`closestIndex` was mathematically broken** — its "in between" branch reduced to the *earliest* item and ignored the target date entirely, so `animateToDateTime(now)` / the initial scroll landed at the top of the list. Rewritten to return the row nearest the target date.
- **Empty days weren't scroll-targetable** — only days with events were recorded in the date→index map, so today (under `showOnlyToday`, the default) had no entry when it had no events. Empty days are now recorded as the first row of their date.
- **`initialScrollIndex` polluted the map** (`??=`) and normalized inconsistently (`fromDateTime` vs the map's location-aware keys). Now compute-only (`??`) and location-consistent (`fromExternal`).

## Breaking
`EmptyDayBehavior.showToday` → **`EmptyDayBehavior.showOnlyToday`** (behaviour unchanged; the old name implied "all empty days plus today" when it only ever showed today). Migration note added.

## Tests
New `test/widgets/schedule/schedule_body_test.dart` (7 tests): row alignment, `leadingWidth` delta, `showOnlyToday` scroll target, `closestIndex` nearer-day in both directions + out-of-range clamping, and no map pollution. Each fix independently mutation-verified. Full suite: 1187 pass; `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)