### PR TITLE
fix: Use fixed key for FreeScrollHeader's `ExpandablePageView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@
 - Added `restorePerView` transitions so each view can reopen its own last date, scroll, and zoom. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Added `CalendarController.visibleTimeOfDay` and the `CalendarCallbacks.onScrollPositionChanged` callback. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 
+### Fixes
+
+- Fixed the free-scroll multi-day header "wobbling" (re-animating its height) whenever a calendar item changed; its paged content now keeps its state across rebuilds instead of being rebuilt from scratch. [#282](https://github.com/werner-scholtz/kalender/pull/282)
+
 ### Tests
 
 - Added end-to-end `CalendarView` regression coverage for the time indicator, run across the timezone matrix. [#261](https://github.com/werner-scholtz/kalender/issues/261)
 - Added end-to-end `CalendarView` today-highlighting coverage, run across the timezone matrix. [#254](https://github.com/werner-scholtz/kalender/issues/254) [#251](https://github.com/werner-scholtz/kalender/issues/251)
 - Added end-to-end month-view regression coverage for a custom `generateMultiDayLayoutFrame`. [#235](https://github.com/werner-scholtz/kalender/issues/235)
+- Added regression coverage that the free-scroll header keeps its paged content's state across rebuilds. [#282](https://github.com/werner-scholtz/kalender/pull/282)
 
 ## 0.18.7
 

--- a/lib/src/widgets/multi_day/multi_day_header.dart
+++ b/lib/src/widgets/multi_day/multi_day_header.dart
@@ -255,7 +255,7 @@ class _FreeScrollHeader extends StatelessWidget {
       ///
       /// To do this the header would need to display a single page and not multiple. see viewport fraction.
       content: ExpandablePageView(
-        key: UniqueKey(),
+        key: ObjectKey(viewController.headerController),
         controller: viewController.headerController,
         itemCount: viewController.numberOfPages,
         itemBuilder: (context, index) {

--- a/test/widgets/free_scroll_header_test.dart
+++ b/test/widgets/free_scroll_header_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/internal_components/expandable_page_view.dart' show ExpandablePageView;
+
+import '../utilities.dart';
+
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+  late CalendarCallbacks callbacks;
+
+  final tileComponents = TileComponents(
+    tileBuilder: (event, tileRange) => Container(key: ValueKey(event.id), color: Colors.red),
+  );
+  final scheduleTileComponents = ScheduleTileComponents(
+    tileBuilder: (event, tileRange) => Container(key: ValueKey(event.id), color: Colors.blue),
+  );
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+    callbacks = CalendarCallbacks(
+      onEventCreated: eventsController.addEvent,
+      onEventChanged: (event, updatedEvent) => eventsController.updateEvent(event: event, updatedEvent: updatedEvent),
+    );
+  });
+
+  group('FreeScroll header', () {
+    /// Rebuilds the [CalendarView] whenever [rebuild] changes so the test can
+    /// force the FreeScroll header to build again, mirroring what happens in a
+    /// real app whenever a calendar item changes.
+    Future<ValueNotifier<int>> pumpFreeScrollView(WidgetTester tester) async {
+      final rebuild = ValueNotifier(0);
+      addTearDown(rebuild.dispose);
+
+      // Kept stable across rebuilds (as a real app would cache it) so the view
+      // controller — and therefore the header controller — is not recreated;
+      // this isolates the header's own key handling as the only variable.
+      final viewConfiguration = MultiDayViewConfiguration.freeScroll(numberOfDays: 3);
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        ValueListenableBuilder(
+          valueListenable: rebuild,
+          builder: (context, _, __) => CalendarView(
+            eventsController: eventsController,
+            calendarController: calendarController,
+            viewConfiguration: viewConfiguration,
+            callbacks: callbacks,
+            header: CalendarHeader(multiDayTileComponents: tileComponents),
+            body: CalendarBody(
+              multiDayTileComponents: tileComponents,
+              monthTileComponents: tileComponents,
+              scheduleTileComponents: scheduleTileComponents,
+            ),
+          ),
+        ),
+      );
+
+      return rebuild;
+    }
+
+    // Regression for #282: the FreeScroll header used `key: UniqueKey()` on its
+    // `ExpandablePageView`, so every rebuild minted a new key and Flutter
+    // destroyed and recreated the page view's State — resetting its measured
+    // per-page heights and making the header visibly "wobble" whenever an item
+    // on the calendar changed. Keying on the stable header controller keeps the
+    // State alive across rebuilds.
+    testWidgets('preserves ExpandablePageView state across rebuilds', (tester) async {
+      final rebuild = await pumpFreeScrollView(tester);
+
+      final pageView = find.byType(ExpandablePageView);
+      expect(pageView, findsOneWidget, reason: 'FreeScroll header should render an ExpandablePageView');
+
+      final stateBefore = tester.state(pageView);
+
+      // Force the header to build again, as a calendar item change would.
+      rebuild.value++;
+      await tester.pumpAndSettle();
+
+      final stateAfter = tester.state(find.byType(ExpandablePageView));
+      expect(
+        identical(stateBefore, stateAfter),
+        isTrue,
+        reason: 'ExpandablePageView State must survive a header rebuild; a fresh '
+            'UniqueKey() each build would recreate it and reset measured heights.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description
We encountered a bug where the calendar `ViewConfiguration` needed to be cached to prevent the calendar header from being re-rendered in a wobbly fashion whenever we changed any item on the calendar. The fix worked on day view, 3-day view, and week view, but didn't work on the free scroll view. After some digging, the LLM determined that the key on FreeScrollHeader's `ExpandablePageView` would be regenerated every time, causing it to be deemed a different item instead of being kept consistent, and thus this change to `kalendar` itself was suggested. This indeed fixed our rendering issue, though let us know if this change makes sense at all, or if there should actually be a different way to do it, as we are not that familiar with the internals of `kalendar` 🙏 .

## Testing
<!-- Please describe the tests you ran to verify your changes -->
- [ ] Unit Tests Added/Updated
- [ ] Widget Tests Added/Updated (if applicable)

Didn't add tests for this.

## Checklist
- [ ] I have run `flutter analyze` and fixed any issues
- [ ] I have run `dart format .`

Tried to run `dart format` but it seems to change more files than just the file we touched. I believe the one-line change shouldn't break the formatting though let us know.

## Additional Notes
<!-- Add any additional notes about the PR here --> 