### PR TITLE
fix: size free-scroll header to the tallest visible day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,8 @@
 
 - Fixed schedule view event tiles not lining up; every row now shares a fixed-width leading column whether or not it shows a date. [#253](https://github.com/werner-scholtz/kalender/issues/253)
 - Fixed the continuous schedule view scrolling to the wrong position when today has no events; the initial scroll and `animateToDateTime` now target today, or the nearest day when it is hidden. [#253](https://github.com/werner-scholtz/kalender/issues/253)
-
-### Fixes
-
 - Fixed the free-scroll multi-day header "wobbling" (re-animating its height) whenever a calendar item changed; its paged content now keeps its state across rebuilds instead of being rebuilt from scratch. [#282](https://github.com/werner-scholtz/kalender/pull/282)
+- Fixed the free-scroll multi-day header clipping days that have more events than the leading day; the header now sizes to the tallest day currently in view. [#283](https://github.com/werner-scholtz/kalender/pull/283)
 
 ### Tests
 
@@ -29,6 +27,7 @@
 - Added continuous schedule regression coverage for row alignment and the no-events-today scroll target. [#253](https://github.com/werner-scholtz/kalender/issues/253)
 - Added end-to-end month-view regression coverage for a custom `generateMultiDayLayoutFrame`. [#235](https://github.com/werner-scholtz/kalender/issues/235)
 - Added regression coverage that the free-scroll header keeps its paged content's state across rebuilds. [#282](https://github.com/werner-scholtz/kalender/pull/282)
+- Added regression coverage that the free-scroll header fits the tallest visible day rather than only the leading page. [#283](https://github.com/werner-scholtz/kalender/pull/283)
 
 ## 0.18.7
 

--- a/lib/src/widgets/internal_components/expandable_page_view.dart
+++ b/lib/src/widgets/internal_components/expandable_page_view.dart
@@ -20,43 +20,85 @@ class ExpandablePageView extends StatefulWidget {
   State<ExpandablePageView> createState() => _ExpandablePageViewState();
 }
 
+/// The height used for an item until its real height has been measured.
+const double _defaultItemHeight = 80;
+
 class _ExpandablePageViewState extends State<ExpandablePageView> {
   /// The heights of the items in the page view.
   late List<double> _heights;
 
-  /// The current page of the page view.
-  late int _currentPage;
+  /// The index of the first page currently within the viewport.
+  late int _firstVisiblePage;
 
-  /// The current height of the page view.
-  double get _currentHeight => _heights.elementAtOrNull(_currentPage) ?? 80;
+  /// The index of the last page currently within the viewport.
+  ///
+  /// When [LinkedPageController.viewportFraction] is `1.0` this equals
+  /// [_firstVisiblePage] while settled, so only the current page drives the
+  /// height. For a fractional viewport (e.g. free-scroll, where several days
+  /// are visible at once) it spans every page in view, so the tallest of them
+  /// sets the height instead of the header clipping the busier days.
+  late int _lastVisiblePage;
+
+  /// The height needed to fit the tallest page currently in the viewport.
+  ///
+  /// Seeded from the first visible page's own height (not the default) so a
+  /// single visible page shorter than [_defaultItemHeight] keeps its measured
+  /// height rather than being floored up to the placeholder value.
+  double get _visibleHeight {
+    if (_heights.isEmpty) return _defaultItemHeight;
+    final lo = _firstVisiblePage.clamp(0, _heights.length - 1);
+    final hi = _lastVisiblePage.clamp(0, _heights.length - 1);
+    var height = _heights[lo];
+    for (var i = lo + 1; i <= hi; i++) {
+      if (_heights[i] > height) height = _heights[i];
+    }
+    return height;
+  }
+
+  /// Computes the inclusive range of page indices currently in the viewport.
+  ///
+  /// A fractional page position means a transition is in progress, so one extra
+  /// trailing page is partially visible and must be included.
+  (int, int) _computeVisibleRange() {
+    final visibleCount = (1 / widget.controller.viewportFraction).round().clamp(1, widget.itemCount);
+    final page = widget.controller.hasClients ? widget.controller.page : null;
+    final basePage = page ?? widget.controller.initialPage.toDouble();
+    final first = basePage.floor();
+    final transitioning = basePage != basePage.floorToDouble();
+    final last = first + visibleCount - 1 + (transitioning ? 1 : 0);
+    return (first, last);
+  }
 
   @override
   void initState() {
     super.initState();
     // Initialize the heights with a default value.
-    _heights = List.filled(widget.itemCount, 80, growable: true);
+    _heights = List.filled(widget.itemCount, _defaultItemHeight, growable: true);
 
-    _currentPage = widget.controller.initialPage;
-    widget.controller.addListener(_updatePage);
+    final (first, last) = _computeVisibleRange();
+    _firstVisiblePage = first;
+    _lastVisiblePage = last;
+    widget.controller.addListener(_onScroll);
   }
 
   @override
   void didUpdateWidget(covariant ExpandablePageView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.controller != widget.controller) {
-      oldWidget.controller.removeListener(_updatePage);
-      _currentPage = widget.controller.initialPage;
-      widget.controller.addListener(_updatePage);
+      oldWidget.controller.removeListener(_onScroll);
+      widget.controller.addListener(_onScroll);
     }
     if (oldWidget.itemCount != widget.itemCount) {
-      _heights = List.filled(widget.itemCount, 80, growable: true);
-      _currentPage = widget.controller.initialPage;
+      _heights = List.filled(widget.itemCount, _defaultItemHeight, growable: true);
     }
+    final (first, last) = _computeVisibleRange();
+    _firstVisiblePage = first;
+    _lastVisiblePage = last;
   }
 
   @override
   void dispose() {
-    widget.controller.removeListener(_updatePage);
+    widget.controller.removeListener(_onScroll);
     super.dispose();
   }
 
@@ -64,7 +106,7 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
   Widget build(BuildContext context) {
     return TweenAnimationBuilder<double>(
       curve: Curves.easeInOutCubic,
-      tween: Tween<double>(begin: _heights.first, end: _currentHeight),
+      tween: Tween<double>(begin: _visibleHeight, end: _visibleHeight),
       duration: const Duration(milliseconds: 100),
       builder: (context, value, child) => SizedBox(height: value, child: child),
       child: LinkedPageView.builder(
@@ -95,11 +137,14 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
     );
   }
 
-  void _updatePage() {
-    final newPage = widget.controller.page!.round();
-    if (_currentPage != newPage) {
+  /// Rebuilds when the set of pages in the viewport changes so [_visibleHeight]
+  /// tracks the tallest visible page as the user scrolls.
+  void _onScroll() {
+    final (first, last) = _computeVisibleRange();
+    if (first != _firstVisiblePage || last != _lastVisiblePage) {
       setState(() {
-        _currentPage = newPage;
+        _firstVisiblePage = first;
+        _lastVisiblePage = last;
       });
     }
   }

--- a/test/widgets/free_scroll_header_test.dart
+++ b/test/widgets/free_scroll_header_test.dart
@@ -103,11 +103,17 @@ void main() {
       // rows (both events), and 27 Mar a single row.
       eventsController.addEvents([
         CalendarEvent(
-            dateTimeRange:
-                DateTimeRange(start: base.add(const Duration(days: 1)), end: base.add(const Duration(days: 3)))),
+          dateTimeRange: DateTimeRange(
+            start: base.add(const Duration(days: 1)),
+            end: base.add(const Duration(days: 3)),
+          ),
+        ),
         CalendarEvent(
-            dateTimeRange:
-                DateTimeRange(start: base.add(const Duration(days: 2)), end: base.add(const Duration(days: 4)))),
+          dateTimeRange: DateTimeRange(
+            start: base.add(const Duration(days: 2)),
+            end: base.add(const Duration(days: 4)),
+          ),
+        ),
       ]);
 
       await pumpAndSettleWithMaterialApp(

--- a/test/widgets/free_scroll_header_test.dart
+++ b/test/widgets/free_scroll_header_test.dart
@@ -87,5 +87,72 @@ void main() {
             'UniqueKey() each build would recreate it and reset measured heights.',
       );
     });
+
+    // Regression for the FreeScroll header clipping busier days: each day is its
+    // own page (viewportFraction 1/numberOfDays) and several are visible at once,
+    // but the header used to size itself to the *current* page only. A day with
+    // two stacked multi-day events was clipped whenever it was not the leading
+    // page. The header must instead fit the tallest day currently in view.
+    Future<double> pumpAndMeasureHeader(WidgetTester tester, DateTime initialDate) async {
+      // Fresh controllers per pump so each starts at its own initial date.
+      eventsController = DefaultEventsController();
+      calendarController = CalendarController();
+
+      final base = DateTime(2025, 3, 24); // Monday
+      // Two overlapping multi-day events give 25 Mar a single row, 26 Mar two
+      // rows (both events), and 27 Mar a single row.
+      eventsController.addEvents([
+        CalendarEvent(
+            dateTimeRange:
+                DateTimeRange(start: base.add(const Duration(days: 1)), end: base.add(const Duration(days: 3)))),
+        CalendarEvent(
+            dateTimeRange:
+                DateTimeRange(start: base.add(const Duration(days: 2)), end: base.add(const Duration(days: 4)))),
+      ]);
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        CalendarView(
+          eventsController: eventsController,
+          calendarController: calendarController,
+          viewConfiguration: MultiDayViewConfiguration.freeScroll(
+            numberOfDays: 3,
+            initialDateTime: initialDate,
+            displayRange: DateTimeRange(start: base, end: base.add(const Duration(days: 21))),
+          ),
+          callbacks: callbacks,
+          header: CalendarHeader(multiDayTileComponents: tileComponents),
+          body: CalendarBody(
+            multiDayTileComponents: tileComponents,
+            monthTileComponents: tileComponents,
+            scheduleTileComponents: scheduleTileComponents,
+          ),
+        ),
+      );
+
+      return tester.getSize(find.byType(ExpandablePageView)).height;
+    }
+
+    testWidgets('fits the tallest visible day, not just the leading page', (tester) async {
+      final base = DateTime(2025, 3, 24);
+      // 26 Mar (two rows) as the leading page.
+      final heightAsLeading = await pumpAndMeasureHeader(tester, base.add(const Duration(days: 2)));
+      // 26 Mar visible as a trailing page (leading is 25 Mar, a single row).
+      final heightAsTrailing = await pumpAndMeasureHeader(tester, base.add(const Duration(days: 1)));
+      // A window of empty days for a single-row baseline.
+      final heightEmpty = await pumpAndMeasureHeader(tester, base.add(const Duration(days: 12)));
+
+      expect(
+        heightAsTrailing,
+        greaterThan(heightEmpty),
+        reason: 'The header should grow to fit the two-row day while it is in view.',
+      );
+      expect(
+        heightAsTrailing,
+        closeTo(heightAsLeading, 0.5),
+        reason: 'Header height must not depend on whether the tallest visible day '
+            'is the leading page; sizing to the current page only clips trailing days.',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Description

Follow-up to #282. While the wobble fix in #282 stopped the free-scroll header from being rebuilt from scratch, a separate, pre-existing bug remained: the header **clips days that have more events than the leading day**.

The free-scroll header renders each day as its own page (`viewportFraction = 1/numberOfDays`) with several days visible at once, but `ExpandablePageView` sized the strip to the **current page only** (`_heights[_currentPage]`). So a day with two stacked multi-day events was clipped whenever it wasn't the leading page:

- Day is the leading page → header is tall enough, events show.
- Same day scrolled to a trailing (still-visible) slot → header stays short, the lower event row is cut off.

### Fix

`ExpandablePageView` now tracks the **range of pages currently in the viewport** and sizes to the tallest of them. For the single-page headers (single-day / multi-day, `viewportFraction 1.0`) the visible range is a single page, so behavior is unchanged — verified by the existing suite (single-day header stays 48px, week header 80px).

This is scoped to the free-scroll header, which is still marked WIP in the source.

## Testing

- [x] Widget Tests Added — `test/widgets/free_scroll_header_test.dart`: asserts the header height is the same whether the two-row day is the leading page or a trailing visible page, and that it grows beyond an empty baseline. Verified the test fails on the old current-page-only behavior.
- [x] `flutter analyze` clean, `dart format` applied.
- [x] Full suite green (1189 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)