### PR TITLE
feat!: give monthGridBuilder the grid date range (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Replaced `ViewConfiguration.initialDateSelectionStrategy` with per-dimension view-transition options: `dateTransition` on all views, and `scrollTransition` / `zoomTransition` on `MultiDayViewConfiguration`, each with an optional resolver for custom logic. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - View switches now preserve the vertical scroll (time-of-day) and zoom by default instead of resetting to `initialTimeOfDay`; opt out with `ScrollTransition.reset` / `ZoomTransition.reset`. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Renamed `EmptyDayBehavior.showToday` to `EmptyDayBehavior.showOnlyToday`, since it shows only today among empty days. [#253](https://github.com/werner-scholtz/kalender/issues/253)
+- `monthGridBuilder` now receives the grid's `DateTimeRange` (a localized wall-clock range covering the full grid, including adjacent-month days) alongside `numberOfRows`, so custom grids can resolve each cell's date. [#140](https://github.com/werner-scholtz/kalender/issues/140)
 
 ### Features
 
@@ -28,6 +29,7 @@
 - Added end-to-end month-view regression coverage for a custom `generateMultiDayLayoutFrame`. [#235](https://github.com/werner-scholtz/kalender/issues/235)
 - Added regression coverage that the free-scroll header keeps its paged content's state across rebuilds. [#282](https://github.com/werner-scholtz/kalender/pull/282)
 - Added regression coverage that the free-scroll header fits the tallest visible day rather than only the leading page. [#283](https://github.com/werner-scholtz/kalender/pull/283)
+- Added coverage that `monthGridBuilder` receives the grid's date range and row count. [#140](https://github.com/werner-scholtz/kalender/issues/140)
 
 ## 0.18.7
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,6 +28,26 @@ MonthComponents(
 
 The received `date` is already in the calendar's configured location, so any manual `.forLocation()` conversion inside the builder is no longer needed.
 
+### `monthGridBuilder` receives the grid's `DateTimeRange`
+
+`monthGridBuilder` now takes a third parameter: the `DateTimeRange` the grid covers. It is a localized wall-clock range spanning the full grid — including the leading and trailing days from adjacent months — so, together with `numberOfRows` (7 columns per row), a custom grid can resolve the date of every cell (e.g. to gray out days outside the focused month). See [#140](https://github.com/werner-scholtz/kalender/issues/140).
+
+This only affects custom `monthGridBuilder` implementations. Add the parameter:
+
+**Before:**
+```dart
+MonthBodyComponents(
+  monthGridBuilder: (style, numberOfRows) => MyGrid(style, numberOfRows),
+)
+```
+
+**After:**
+```dart
+MonthBodyComponents(
+  monthGridBuilder: (style, numberOfRows, visibleDateTimeRange) => MyGrid(style, numberOfRows, visibleDateTimeRange),
+)
+```
+
 ### Default behaviour change: scroll & zoom are now preserved across view switches
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ Style classes: [`MultiDayComponentStyles`](https://github.com/werner-scholtz/kal
         ),
         bodyComponents: MonthBodyComponents(
           monthDayHeaderBuilder: (date, style) => SizedBox(),
-          monthGridBuilder: (style) => SizedBox(),
+          monthGridBuilder: (style, numberOfRows, visibleDateTimeRange) => SizedBox(),
           weekNumberBuilder: (visibleDateTimeRange, style) => SizedBox(),
           leftTriggerBuilder: (pageWidth) => SizedBox(),
           rightTriggerBuilder: (pageWidth) => SizedBox(),

--- a/lib/src/widgets/components/month_grid.dart
+++ b/lib/src/widgets/components/month_grid.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
 /// The month grid builder.
 ///
 /// The [style] is used to style the month grid.
+///
+/// The [visibleDateTimeRange] is the full range the grid covers — including the
+/// leading and trailing days from adjacent months — as a wall-clock
+/// [DateTimeRange] in the calendar's configured location (via `.forLocation()`).
+/// Together with [numberOfRows] (there are always 7 columns per row) it lets a
+/// builder resolve the date of every cell, e.g. to style days that fall outside
+/// the focused month. See #140.
 typedef MonthGridBuilder = Widget Function(
   MonthGridStyle? style,
   int numberOfRows,
+  DateTimeRange visibleDateTimeRange,
 );
 
 /// The [MonthGridStyle] class is used by the [MonthGrid] widget.
@@ -28,16 +37,25 @@ class MonthGrid extends StatelessWidget {
   final MonthGridStyle? style;
   final int numberOfRows;
 
-  const MonthGrid({super.key, this.style, required this.numberOfRows});
-  static MonthGrid builder(MonthGridStyle? style, int numberOfRows) {
-    return MonthGrid(style: style, numberOfRows: numberOfRows);
+  /// The full range the grid covers, including adjacent-month days. Exposed to
+  /// custom builders via [MonthGridBuilder]; the default grid does not use it.
+  final DateTimeRange visibleDateTimeRange;
+
+  const MonthGrid({
+    super.key,
+    this.style,
+    required this.numberOfRows,
+    required this.visibleDateTimeRange,
+  });
+  static MonthGrid builder(MonthGridStyle? style, int numberOfRows, DateTimeRange visibleDateTimeRange) {
+    return MonthGrid(style: style, numberOfRows: numberOfRows, visibleDateTimeRange: visibleDateTimeRange);
   }
 
-  static Widget fromContext(BuildContext context, int numberOfRows) {
+  static Widget fromContext(BuildContext context, int numberOfRows, InternalDateTimeRange visibleDateTimeRange) {
     final components = context.components;
     final component = components.monthComponents.bodyComponents.monthGridBuilder;
     final style = components.monthComponentStyles.bodyStyles.monthGridStyle;
-    return component.call(style, numberOfRows);
+    return component.call(style, numberOfRows, visibleDateTimeRange.forLocation(location: context.location));
   }
 
   @override

--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -58,7 +58,7 @@ class MonthBody extends StatelessWidget {
       itemBuilder: (context, index) {
         final visibleRange = pageNavigation.dateTimeRangeFromIndex(index, context.location);
         final numberOfRows = pageNavigation.numberOfRowsForRange(visibleRange);
-        final grid = MonthGrid.fromContext(context, numberOfRows);
+        final grid = MonthGrid.fromContext(context, numberOfRows, visibleRange);
         final content = Column(
           children: List.generate(
             numberOfRows,

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -79,6 +79,44 @@ void main() {
     }
 
     // ---------------------------------------------------------------------------
+    // #140: the MonthGridBuilder receives the grid's date range so a builder can
+    // resolve each cell's date (e.g. to style adjacent-month days). The range is
+    // a localized DateTimeRange covering the full grid, including leading/trailing
+    // days from neighbouring months.
+    // ---------------------------------------------------------------------------
+
+    testWidgets('MonthGridBuilder receives the grid date range and row count', (tester) async {
+      int? rows;
+      DateTimeRange? range;
+
+      final components = CalendarComponents(
+        monthComponents: MonthComponents(
+          bodyComponents: MonthBodyComponents(
+            monthGridBuilder: (style, numberOfRows, visibleDateTimeRange) {
+              rows = numberOfRows;
+              range = visibleDateTimeRange;
+              return MonthGrid(style: style, numberOfRows: numberOfRows, visibleDateTimeRange: visibleDateTimeRange);
+            },
+          ),
+        ),
+      );
+
+      // January 2025: Jan 1 is a Wednesday, so the grid starts on Monday Dec 30
+      // 2024 (a leading adjacent-month day) and spans 5 rows = 35 days.
+      await pumpMonthView(tester, DateTime(2025, 1), components: components);
+
+      expect(rows, 5, reason: 'January 2025 is a 5-row month');
+      expect(range, isNotNull);
+      expect(
+        (range!.start.year, range!.start.month, range!.start.day),
+        (2024, 12, 30),
+        reason: 'Grid should start on the Monday of the week containing Jan 1, in the previous month',
+      );
+      expect(range!.duration.inDays, 35, reason: 'Grid spans numberOfRows * 7 days');
+      expect(range!.end.month, 2, reason: 'Grid should extend into the following month (trailing days)');
+    });
+
+    // ---------------------------------------------------------------------------
     // Regression: https://github.com/werner-scholtz/kalender/issues/266
     //
     // A displayRange that spans exactly one calendar month must still render a
@@ -215,8 +253,7 @@ void main() {
     // A tileHeight far larger than any week-row height guarantees max == 0.
     const tallTileHeight = 1000.0;
 
-    Future<void> pumpShortCellMonthView(WidgetTester tester, DateTime initialDateTime) =>
-        pumpAndSettleWithMaterialApp(
+    Future<void> pumpShortCellMonthView(WidgetTester tester, DateTime initialDateTime) => pumpAndSettleWithMaterialApp(
           tester,
           CalendarView(
             eventsController: eventsController,
@@ -299,8 +336,7 @@ void main() {
         );
       }
 
-      Future<void> pumpWithCustomFrame(WidgetTester tester, DateTime initialDateTime) =>
-          pumpAndSettleWithMaterialApp(
+      Future<void> pumpWithCustomFrame(WidgetTester tester, DateTime initialDateTime) => pumpAndSettleWithMaterialApp(
             tester,
             CalendarView(
               eventsController: eventsController,


### PR DESCRIPTION
## Description

Closes #140.

`MonthGridBuilder` previously received only `(MonthGridStyle? style, int numberOfRows)` — with no date information, a custom grid couldn't tell which cell mapped to which date. The reporter wanted to gray out the leading/trailing adjacent-month days, which was impossible.

The builder now also receives the grid's **`DateTimeRange`** — a localized wall-clock range covering the full grid, including the leading/trailing days from adjacent months. Combined with `numberOfRows` (7 columns per row), a builder can resolve the date of every cell.

This mirrors the #248 approach: the range is handed over already localized via `InternalDateTimeRange.forLocation()`, so consumer comparisons against `DateTime.now()` behave correctly.

### Breaking change

Custom `monthGridBuilder` implementations gain a third parameter:

```dart
// before
monthGridBuilder: (style, numberOfRows) => ...
// after
monthGridBuilder: (style, numberOfRows, visibleDateTimeRange) => ...
```

The default grid (`MonthGrid.builder`) is unaffected — it doesn't use the range.

## Docs

- **CHANGELOG** — breaking-change + test entries under 0.19.0.
- **MIGRATION.md** — v0.18.x → v0.19.0 section with before/after.
- **README** — updated the `monthGridBuilder` example (also fixed a pre-existing staleness: it showed `(style)`, missing even the existing `numberOfRows`).

## Testing

- [x] Widget test added (`month_body_test.dart`): asserts the builder receives `numberOfRows == 5` and the localized grid range for January 2025 (starts Mon Dec 30 2024, spans 35 days into February) — proving adjacent-month days are included.
- [x] `flutter analyze` clean, `dart format` applied.
- [x] Full suite green (1190 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)