### PR TITLE
feat: add monthDayCellBuilder for per-day month cell styling (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `restorePerView` transitions so each view can reopen its own last date, scroll, and zoom. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Added `CalendarController.visibleTimeOfDay` and the `CalendarCallbacks.onScrollPositionChanged` callback. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Added `ScheduleBodyConfiguration.leadingWidth` to control the schedule view's date-column width. [#253](https://github.com/werner-scholtz/kalender/issues/253)
+- Added `MonthBodyComponents.monthDayCellBuilder` to style individual month-view day cells; each call reports the cell's date, whether it is today, and whether it falls in the focused month (so adjacent-month days can be styled differently). [#140](https://github.com/werner-scholtz/kalender/issues/140)
 
 ### Fixes
 
@@ -28,6 +29,7 @@
 - Added end-to-end month-view regression coverage for a custom `generateMultiDayLayoutFrame`. [#235](https://github.com/werner-scholtz/kalender/issues/235)
 - Added regression coverage that the free-scroll header keeps its paged content's state across rebuilds. [#282](https://github.com/werner-scholtz/kalender/pull/282)
 - Added regression coverage that the free-scroll header fits the tallest visible day rather than only the leading page. [#283](https://github.com/werner-scholtz/kalender/pull/283)
+- Added coverage that `monthDayCellBuilder` is invoked per day with the correct focused-month flags. [#140](https://github.com/werner-scholtz/kalender/issues/140)
 
 ## 0.18.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Added `restorePerView` transitions so each view can reopen its own last date, scroll, and zoom. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Added `CalendarController.visibleTimeOfDay` and the `CalendarCallbacks.onScrollPositionChanged` callback. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Added `ScheduleBodyConfiguration.leadingWidth` to control the schedule view's date-column width. [#253](https://github.com/werner-scholtz/kalender/issues/253)
-- Added `MonthBodyComponents.monthDayCellBuilder` to style individual month-view day cells; each call reports the cell's date, whether it is today, and whether it falls in the focused month (so adjacent-month days can be styled differently). [#140](https://github.com/werner-scholtz/kalender/issues/140)
+- Added `MonthBodyComponents.monthDayCellBuilder` to style individual month-view day cells. Each call reports the cell's date, whether it is today, and whether it falls in the focused month (so adjacent-month days can be styled differently). Also added the ready-made `MonthDayCell.shadeAdjacentMonths()` builder, which shades leading/trailing adjacent-month days. Pass a `color` or let it default to a low-opacity `onSurface` overlay that greys them out. [#140](https://github.com/werner-scholtz/kalender/issues/140)
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -847,7 +847,8 @@ Style classes: [`MultiDayComponentStyles`](https://github.com/werner-scholtz/kal
         ),
         bodyComponents: MonthBodyComponents(
           monthDayHeaderBuilder: (date, style) => SizedBox(),
-          monthGridBuilder: (style) => SizedBox(),
+          monthDayCellBuilder: (details) => SizedBox(),
+          monthGridBuilder: (style, numberOfRows) => SizedBox(),
           weekNumberBuilder: (visibleDateTimeRange, style) => SizedBox(),
           leftTriggerBuilder: (pageWidth) => SizedBox(),
           rightTriggerBuilder: (pageWidth) => SizedBox(),

--- a/README.md
+++ b/README.md
@@ -847,6 +847,8 @@ Style classes: [`MultiDayComponentStyles`](https://github.com/werner-scholtz/kal
         ),
         bodyComponents: MonthBodyComponents(
           monthDayHeaderBuilder: (date, style) => SizedBox(),
+          // Custom per-cell background, or use the ready-made
+          // MonthDayCell.shadeAdjacentMonths() to shade adjacent-month days.
           monthDayCellBuilder: (details) => SizedBox(),
           monthGridBuilder: (style, numberOfRows) => SizedBox(),
           weekNumberBuilder: (visibleDateTimeRange, style) => SizedBox(),

--- a/examples/web_demo/lib/models/demo_configuration.dart
+++ b/examples/web_demo/lib/models/demo_configuration.dart
@@ -98,6 +98,16 @@ class DemoConfiguration extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Whether to shade the leading/trailing adjacent-month days in month view,
+  /// demonstrating `MonthBodyComponents.monthDayCellBuilder`.
+  ValueNotifier<bool> shadeAdjacentMonthNotifier = ValueNotifier(true);
+  bool get shadeAdjacentMonth => shadeAdjacentMonthNotifier.value;
+  set shadeAdjacentMonth(bool value) {
+    if (shadeAdjacentMonthNotifier.value == value) return;
+    shadeAdjacentMonthNotifier.value = value;
+    notifyListeners();
+  }
+
   bool get isMobile => defaultTargetPlatform == TargetPlatform.iOS || defaultTargetPlatform == TargetPlatform.android;
 
   @override

--- a/examples/web_demo/lib/widgets/calendar/calendar.dart
+++ b/examples/web_demo/lib/widgets/calendar/calendar.dart
@@ -182,7 +182,8 @@ class _CalendarContentState extends State<CalendarContent> {
       monthComponents: MonthComponents(
         bodyComponents: MonthBodyComponents(
           weekNumberBuilder: _buildWeekNumberText,
-          monthDayCellBuilder: context.configuration.shadeAdjacentMonth ? _buildMonthDayCell(cs) : MonthDayCell.builder,
+          monthDayCellBuilder:
+              context.configuration.shadeAdjacentMonth ? MonthDayCell.shadeAdjacentMonths() : MonthDayCell.builder,
         ),
       ),
       monthComponentStyles: MonthComponentStyles(
@@ -191,15 +192,6 @@ class _CalendarContentState extends State<CalendarContent> {
         ),
       ),
     );
-  }
-
-  /// Shades adjacent-month days and tints today, demonstrating #140.
-  MonthDayCellBuilder _buildMonthDayCell(ColorScheme cs) {
-    return (details) {
-      if (details.isToday) return ColoredBox(color: cs.primary.withAlpha(30));
-      if (!details.isInFocusedMonth) return ColoredBox(color: cs.onSurface.withAlpha(12));
-      return const SizedBox.shrink();
-    };
   }
 
   Widget _buildWeekNumberText(DateTimeRange visibleDateTimeRange, WeekNumberStyle? style) {

--- a/examples/web_demo/lib/widgets/calendar/calendar.dart
+++ b/examples/web_demo/lib/widgets/calendar/calendar.dart
@@ -54,6 +54,7 @@ class _CalendarContentState extends State<CalendarContent> {
                 child: ListenableBuilder(
                   listenable: Listenable.merge([
                     context.configuration.viewConfigurationNotifier,
+                    context.configuration.shadeAdjacentMonthNotifier,
                     context.location,
                   ]),
                   builder: (context, _) => CalendarView(
@@ -181,6 +182,7 @@ class _CalendarContentState extends State<CalendarContent> {
       monthComponents: MonthComponents(
         bodyComponents: MonthBodyComponents(
           weekNumberBuilder: _buildWeekNumberText,
+          monthDayCellBuilder: context.configuration.shadeAdjacentMonth ? _buildMonthDayCell(cs) : MonthDayCell.builder,
         ),
       ),
       monthComponentStyles: MonthComponentStyles(
@@ -189,6 +191,15 @@ class _CalendarContentState extends State<CalendarContent> {
         ),
       ),
     );
+  }
+
+  /// Shades adjacent-month days and tints today, demonstrating #140.
+  MonthDayCellBuilder _buildMonthDayCell(ColorScheme cs) {
+    return (details) {
+      if (details.isToday) return ColoredBox(color: cs.primary.withAlpha(30));
+      if (!details.isInFocusedMonth) return ColoredBox(color: cs.onSurface.withAlpha(12));
+      return const SizedBox.shrink();
+    };
   }
 
   Widget _buildWeekNumberText(DateTimeRange visibleDateTimeRange, WeekNumberStyle? style) {

--- a/examples/web_demo/lib/widgets/configuration/body_editors.dart
+++ b/examples/web_demo/lib/widgets/configuration/body_editors.dart
@@ -107,6 +107,14 @@ class MonthBodyEditor extends StatelessWidget {
           itemToString: (value) =>
               "L: ${value.left.toInt()}, R: ${value.right.toInt()}, T: ${value.top.toInt()}, B: ${value.bottom.toInt()}",
         ),
+        ValueListenableBuilder<bool>(
+          valueListenable: demoConfiguration.shadeAdjacentMonthNotifier,
+          builder: (context, value, _) => SwitchListTile.adaptive(
+            title: const Text('Shade adjacent-month days'),
+            value: value,
+            onChanged: (value) => demoConfiguration.shadeAdjacentMonth = value,
+          ),
+        ),
         InteractionEditorWidget(interaction: interaction),
       ],
     );

--- a/lib/kalender.dart
+++ b/lib/kalender.dart
@@ -48,6 +48,7 @@ export 'package:kalender/src/widgets/components/schedule_tile_highlight.dart';
 export 'package:kalender/src/widgets/components/day_header.dart';
 export 'package:kalender/src/widgets/components/day_separator.dart';
 export 'package:kalender/src/widgets/components/hour_lines.dart';
+export 'package:kalender/src/widgets/components/month_day_cell.dart';
 export 'package:kalender/src/widgets/components/month_day_header.dart';
 export 'package:kalender/src/widgets/components/month_grid.dart';
 export 'package:kalender/src/widgets/components/multi_day_overlay.dart';

--- a/lib/src/layout_delegates/month_week_number_layout_delegate.dart
+++ b/lib/src/layout_delegates/month_week_number_layout_delegate.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 
 class MonthWeekNumberBodyLayoutDelegate extends MultiChildLayoutDelegate {
   final int? gutterId;
+  final int? backgroundId;
   final int gridId;
   final int contentId;
 
   MonthWeekNumberBodyLayoutDelegate({
     required this.gutterId,
+    this.backgroundId,
     required this.gridId,
     required this.contentId,
   });
@@ -32,6 +34,13 @@ class MonthWeekNumberBodyLayoutDelegate extends MultiChildLayoutDelegate {
     final contentConstraints =
         BoxConstraints.tight(Size((size.width - gutterWidth).clamp(0.0, size.width), size.height));
 
+    // The background occupies the same rect as the content but is painted first,
+    // so it sits below the grid lines and the day content.
+    if (backgroundId != null && hasChild(backgroundId!)) {
+      layoutChild(backgroundId!, contentConstraints);
+      positionChild(backgroundId!, Offset(gutterWidth, 0));
+    }
+
     layoutChild(gridId, contentConstraints);
     positionChild(gridId, Offset(gutterWidth, 0));
 
@@ -41,7 +50,10 @@ class MonthWeekNumberBodyLayoutDelegate extends MultiChildLayoutDelegate {
 
   @override
   bool shouldRelayout(covariant MonthWeekNumberBodyLayoutDelegate oldDelegate) {
-    return gutterId != oldDelegate.gutterId || gridId != oldDelegate.gridId || contentId != oldDelegate.contentId;
+    return gutterId != oldDelegate.gutterId ||
+        backgroundId != oldDelegate.backgroundId ||
+        gridId != oldDelegate.gridId ||
+        contentId != oldDelegate.contentId;
   }
 }
 

--- a/lib/src/models/components/month_components.dart
+++ b/lib/src/models/components/month_components.dart
@@ -1,4 +1,5 @@
 import 'package:kalender/src/models/components/components.dart';
+import 'package:kalender/src/widgets/components/month_day_cell.dart';
 import 'package:kalender/src/widgets/components/month_day_header.dart';
 import 'package:kalender/src/widgets/components/month_grid.dart';
 import 'package:kalender/src/widgets/components/week_day_header.dart';
@@ -30,6 +31,12 @@ class MonthBodyComponents {
   /// A function that builds the month day header widget.
   final MonthDayHeaderBuilder monthDayHeaderBuilder;
 
+  /// A function that builds the background of each day cell.
+  ///
+  /// Called once per cell; use it to style individual days, e.g. to gray out
+  /// days that fall outside the focused month. Defaults to an empty cell.
+  final MonthDayCellBuilder monthDayCellBuilder;
+
   /// A function that builds the week number widget.
   final WeekNumberBuilder weekNumberBuilder;
 
@@ -46,6 +53,7 @@ class MonthBodyComponents {
   const MonthBodyComponents({
     this.monthGridBuilder = MonthGrid.builder,
     this.monthDayHeaderBuilder = MonthDayHeader.builder,
+    this.monthDayCellBuilder = MonthDayCell.builder,
     this.weekNumberBuilder = WeekNumber.builder,
     this.leftTriggerBuilder,
     this.rightTriggerBuilder,

--- a/lib/src/models/providers/calendar_provider.dart
+++ b/lib/src/models/providers/calendar_provider.dart
@@ -220,4 +220,11 @@ extension ProviderContext on BuildContext {
   Location? get location => LocationProvider.of(this);
   ValueNotifier<Location?> get locationNotifier => LocationProvider.ofNotifier(this);
   bool get hasLocation => location != null;
+
+  /// Whether [date] is today, honouring the view's `nowCallback` when set and
+  /// otherwise the calendar's [location].
+  bool isToday(InternalDateTime date) {
+    final now = calendarController.viewController?.viewConfiguration.nowCallback?.call();
+    return now != null ? date.isToday(now: now) : date.isToday(location: location);
+  }
 }

--- a/lib/src/models/view_configurations/page_index_calculator.dart
+++ b/lib/src/models/view_configurations/page_index_calculator.dart
@@ -323,11 +323,18 @@ class MonthIndexCalculator extends PageIndexCalculator {
   /// Creates a [MonthIndexCalculator] with the given [dateTimeRange] and [firstDayOfWeek].
   MonthIndexCalculator({required super.dateTimeRange, required this.firstDayOfWeek});
 
+  /// The first day of the focused month shown on the page at [index].
+  ///
+  /// This is the month the page represents; the grid also renders leading and
+  /// trailing days from the adjacent months around it.
+  InternalDateTime monthStartFromIndex(int index, Location? location) {
+    final internalStart = internalRange(location).start;
+    return InternalDateTime.fromDateTime(internalStart.copyWith(month: internalStart.month + index));
+  }
+
   @override
   InternalDateTimeRange dateTimeRangeFromIndex(int index, Location? location) {
-    final internalRange = this.internalRange(location);
-    final internalStart = internalRange.start;
-    final startOfMonth = InternalDateTime.fromDateTime(internalStart.copyWith(month: internalStart.month + index));
+    final startOfMonth = monthStartFromIndex(index, location);
 
     var start = startOfMonth.startOfWeek(firstDayOfWeek: firstDayOfWeek);
     if (start.isAfter(startOfMonth)) start = InternalDateTime.fromDateTime(start.subtract(const Duration(days: 7)));

--- a/lib/src/widgets/components/day_header.dart
+++ b/lib/src/widgets/components/day_header.dart
@@ -78,9 +78,8 @@ class DayHeader extends StatelessWidget {
       style: style?.numberTextStyle ?? Theme.of(context).textTheme.bodyMedium,
     );
 
-    final now = context.calendarController.viewController?.viewConfiguration.nowCallback?.call();
     final localDate = InternalDateTime.fromExternal(date, location: context.location);
-    final isToday = now != null ? localDate.isToday(now: now) : localDate.isToday(location: context.location);
+    final isToday = context.isToday(localDate);
     final button = isToday
         ? IconButton.filled(key: todayKey, onPressed: null, icon: numberText, visualDensity: VisualDensity.compact)
         : IconButton(onPressed: null, icon: numberText, visualDensity: VisualDensity.compact);

--- a/lib/src/widgets/components/month_day_cell.dart
+++ b/lib/src/widgets/components/month_day_cell.dart
@@ -8,10 +8,10 @@ import 'package:kalender/src/models/providers/calendar_provider.dart';
 /// cell's date, whether it is today, and whether it belongs to the focused month
 /// (as opposed to a leading/trailing day from an adjacent month). The returned
 /// widget is painted behind the grid, the day's number and the events, so it is
-/// well suited to styling the cell background — for example graying out
-/// adjacent-month days. See [#140](https://github.com/werner-scholtz/kalender/issues/140).
+/// well suited to styling the cell background, for example graying out
+/// adjacent-month days.
 ///
-/// This is a background layer and does not receive pointer events — the event
+/// This is a background layer and does not receive pointer events. The event
 /// and drag layers sit above it. The default builder renders nothing, leaving
 /// the cell background unchanged.
 typedef MonthDayCellBuilder = Widget Function(MonthDayCellDetails details);
@@ -41,13 +41,28 @@ class MonthDayCellDetails {
 
 /// Renders the background of a single day cell in the month body.
 ///
-/// The default is an empty cell; provide a [MonthDayCellBuilder] via
+/// The default is an empty cell. Provide a [MonthDayCellBuilder] via
 /// [MonthBodyComponents.monthDayCellBuilder] to customize it.
 class MonthDayCell extends StatelessWidget {
   const MonthDayCell({super.key});
 
-  /// The default [MonthDayCellBuilder] — renders nothing.
+  /// The default [MonthDayCellBuilder] renders nothing.
   static Widget builder(MonthDayCellDetails details) => const MonthDayCell();
+
+  /// A ready-made [MonthDayCellBuilder] that shades the leading and trailing
+  /// adjacent-month days, leaving the focused month's days unchanged.
+  ///
+  /// Pass [color] to set the shade. When omitted it defaults to a low-opacity
+  /// [ColorScheme.onSurface] overlay (the Material 3 way to express a greyed-out
+  /// or de-emphasized surface), read from the ambient theme, so it adapts to
+  /// light and dark modes and to any custom [ColorScheme]. Enable it with:
+  ///
+  /// ```dart
+  /// MonthBodyComponents(monthDayCellBuilder: MonthDayCell.shadeAdjacentMonths())
+  /// ```
+  static MonthDayCellBuilder shadeAdjacentMonths({Color? color}) {
+    return (details) => details.isInFocusedMonth ? const MonthDayCell() : _AdjacentMonthShade(color: color);
+  }
 
   /// Builds the day cell for [date] using the configured [MonthDayCellBuilder].
   static Widget fromContext(
@@ -67,4 +82,20 @@ class MonthDayCell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+/// Background shade for an adjacent-month day, used by
+/// [MonthDayCell.shadeAdjacentMonths]. Falls back to a low-opacity
+/// [ColorScheme.onSurface] overlay, read at build time, so the default shade
+/// reads as "greyed out" and follows the active [ColorScheme] in light and
+/// dark modes.
+class _AdjacentMonthShade extends StatelessWidget {
+  const _AdjacentMonthShade({this.color});
+
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(color: color ?? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.08));
+  }
 }

--- a/lib/src/widgets/components/month_day_cell.dart
+++ b/lib/src/widgets/components/month_day_cell.dart
@@ -7,11 +7,13 @@ import 'package:kalender/src/models/providers/calendar_provider.dart';
 /// The builder is called once per cell with [MonthDayCellDetails] describing the
 /// cell's date, whether it is today, and whether it belongs to the focused month
 /// (as opposed to a leading/trailing day from an adjacent month). The returned
-/// widget is painted behind the day's number and events, so it is well suited to
-/// styling the cell background — for example graying out adjacent-month days. See
-/// [#140](https://github.com/werner-scholtz/kalender/issues/140).
+/// widget is painted behind the grid, the day's number and the events, so it is
+/// well suited to styling the cell background — for example graying out
+/// adjacent-month days. See [#140](https://github.com/werner-scholtz/kalender/issues/140).
 ///
-/// The default builder renders nothing, leaving the cell background unchanged.
+/// This is a background layer and does not receive pointer events — the event
+/// and drag layers sit above it. The default builder renders nothing, leaving
+/// the cell background unchanged.
 typedef MonthDayCellBuilder = Widget Function(MonthDayCellDetails details);
 
 /// Details describing a single day cell, passed to a [MonthDayCellBuilder].
@@ -54,12 +56,10 @@ class MonthDayCell extends StatelessWidget {
     required bool isInFocusedMonth,
   }) {
     final builder = context.components.monthComponents.bodyComponents.monthDayCellBuilder;
-    final now = context.calendarController.viewController?.viewConfiguration.nowCallback?.call();
-    final isToday = now != null ? date.isToday(now: now) : date.isToday(location: context.location);
     return builder(
       MonthDayCellDetails(
         date: date.forLocation(location: context.location),
-        isToday: isToday,
+        isToday: context.isToday(date),
         isInFocusedMonth: isInFocusedMonth,
       ),
     );

--- a/lib/src/widgets/components/month_day_cell.dart
+++ b/lib/src/widgets/components/month_day_cell.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/providers/calendar_provider.dart';
+
+/// Builds the background of a single day cell in the month body.
+///
+/// The builder is called once per cell with [MonthDayCellDetails] describing the
+/// cell's date, whether it is today, and whether it belongs to the focused month
+/// (as opposed to a leading/trailing day from an adjacent month). The returned
+/// widget is painted behind the day's number and events, so it is well suited to
+/// styling the cell background — for example graying out adjacent-month days. See
+/// [#140](https://github.com/werner-scholtz/kalender/issues/140).
+///
+/// The default builder renders nothing, leaving the cell background unchanged.
+typedef MonthDayCellBuilder = Widget Function(MonthDayCellDetails details);
+
+/// Details describing a single day cell, passed to a [MonthDayCellBuilder].
+class MonthDayCellDetails {
+  const MonthDayCellDetails({
+    required this.date,
+    required this.isToday,
+    required this.isInFocusedMonth,
+  });
+
+  /// The cell's date, as a wall-clock [DateTime] in the calendar's configured
+  /// location (via `.forLocation()`), so comparisons against `DateTime.now()`
+  /// behave correctly.
+  final DateTime date;
+
+  /// Whether [date] is today.
+  final bool isToday;
+
+  /// Whether [date] falls within the focused month.
+  ///
+  /// `false` for the leading and trailing days that belong to the previous or
+  /// next month but are shown to fill out the grid.
+  final bool isInFocusedMonth;
+}
+
+/// Renders the background of a single day cell in the month body.
+///
+/// The default is an empty cell; provide a [MonthDayCellBuilder] via
+/// [MonthBodyComponents.monthDayCellBuilder] to customize it.
+class MonthDayCell extends StatelessWidget {
+  const MonthDayCell({super.key});
+
+  /// The default [MonthDayCellBuilder] — renders nothing.
+  static Widget builder(MonthDayCellDetails details) => const MonthDayCell();
+
+  /// Builds the day cell for [date] using the configured [MonthDayCellBuilder].
+  static Widget fromContext(
+    BuildContext context,
+    InternalDateTime date, {
+    required bool isInFocusedMonth,
+  }) {
+    final builder = context.components.monthComponents.bodyComponents.monthDayCellBuilder;
+    final now = context.calendarController.viewController?.viewConfiguration.nowCallback?.call();
+    final isToday = now != null ? date.isToday(now: now) : date.isToday(location: context.location);
+    return builder(
+      MonthDayCellDetails(
+        date: date.forLocation(location: context.location),
+        isToday: isToday,
+        isInFocusedMonth: isInFocusedMonth,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -53,9 +53,8 @@ class MonthDayHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final now = context.calendarController.viewController?.viewConfiguration.nowCallback?.call();
     final localDate = InternalDateTime.fromExternal(date, location: context.location);
-    final isToday = now != null ? localDate.isToday(now: now) : localDate.isToday(location: context.location);
+    final isToday = context.isToday(localDate);
     final button = isToday
         ? IconButton.filled(
             key: todayKey,

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -56,8 +56,7 @@ class ScheduleDate extends StatelessWidget {
       style: style?.textStyle ?? Theme.of(context).textTheme.bodySmall,
     );
 
-    final now = context.calendarController.viewController?.viewConfiguration.nowCallback?.call();
-    final isToday = now != null ? date.isToday(now: now) : date.isToday(location: context.location);
+    final isToday = context.isToday(date);
     final button = isToday
         ? IconButton.filled(
             key: todayKey,

--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -58,6 +58,7 @@ class MonthBody extends StatelessWidget {
       itemBuilder: (context, index) {
         final visibleRange = pageNavigation.dateTimeRangeFromIndex(index, context.location);
         final numberOfRows = pageNavigation.numberOfRowsForRange(visibleRange);
+        final focusMonthStart = pageNavigation.monthStartFromIndex(index, context.location);
         final grid = MonthGrid.fromContext(context, numberOfRows);
         final content = Column(
           children: List.generate(
@@ -75,6 +76,7 @@ class MonthBody extends StatelessWidget {
                   internalRange: visibleDateTimeRange,
                   configuration: configuration,
                   viewController: viewController,
+                  focusMonthStart: focusMonthStart,
                 ),
               );
             },
@@ -115,11 +117,17 @@ class MonthWeek extends StatelessWidget {
   final InternalDateTimeRange internalRange;
   final HorizontalConfiguration configuration;
   final ViewController viewController;
+
+  /// The first day of the focused month, used to determine which cells belong
+  /// to an adjacent month.
+  final InternalDateTime focusMonthStart;
+
   const MonthWeek({
     super.key,
     required this.internalRange,
     required this.configuration,
     required this.viewController,
+    required this.focusMonthStart,
   });
 
   @override
@@ -129,6 +137,22 @@ class MonthWeek extends StatelessWidget {
 
     return Stack(
       children: [
+        // Background layer: one cell per day, behind the day numbers and events.
+        Positioned.fill(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (final date in internalRange.dates())
+                Expanded(
+                  child: MonthDayCell.fromContext(
+                    context,
+                    date,
+                    isInFocusedMonth: date.month == focusMonthStart.month && date.year == focusMonthStart.year,
+                  ),
+                ),
+            ],
+          ),
+        ),
         Positioned.fill(
           child: MultiDayDraggable(
             key: ValueKey('MultiDayDraggable-${internalRange.start.toIso8601String()}'),

--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -58,34 +58,44 @@ class MonthBody extends StatelessWidget {
       itemBuilder: (context, index) {
         final visibleRange = pageNavigation.dateTimeRangeFromIndex(index, context.location);
         final numberOfRows = pageNavigation.numberOfRowsForRange(visibleRange);
-        final focusMonthStart = pageNavigation.monthStartFromIndex(index, context.location);
         final grid = MonthGrid.fromContext(context, numberOfRows);
-        final content = Column(
-          children: List.generate(
-            numberOfRows,
-            (index) {
-              final start = visibleRange.start.add(Duration(days: index * DateTime.daysPerWeek));
-              final visibleDateTimeRange = InternalDateTimeRange(
-                start: start,
-                end: start.add(const Duration(days: DateTime.daysPerWeek)),
-              );
 
-              return Expanded(
+        // The date range of each week row, shared by the content and background.
+        final weekRanges = List.generate(numberOfRows, (row) {
+          final start = visibleRange.start.add(Duration(days: row * DateTime.daysPerWeek));
+          return InternalDateTimeRange(start: start, end: start.add(const Duration(days: DateTime.daysPerWeek)));
+        });
+
+        final content = Column(
+          children: [
+            for (final weekRange in weekRanges)
+              Expanded(
                 child: MonthWeek(
-                  key: ValueKey('MonthWeek-${visibleDateTimeRange.start.toIso8601String()}'),
-                  internalRange: visibleDateTimeRange,
+                  key: ValueKey('MonthWeek-${weekRange.start.toIso8601String()}'),
+                  internalRange: weekRange,
                   configuration: configuration,
                   viewController: viewController,
-                  focusMonthStart: focusMonthStart,
                 ),
-              );
-            },
-          ),
+              ),
+          ],
         );
+
+        // Only build the per-day background when a custom cell builder is set, so
+        // the default month view does no extra per-cell work. It is painted below
+        // the grid (see the layout delegate) so cell backgrounds do not cover the
+        // grid lines.
+        final hasCellBuilder = monthComponents.bodyComponents.monthDayCellBuilder != MonthDayCell.builder;
+        final background = hasCellBuilder
+            ? _MonthDayCellBackground(
+                weekRanges: weekRanges,
+                focusMonthStart: pageNavigation.monthStartFromIndex(index, context.location),
+              )
+            : null;
 
         return CustomMultiChildLayout(
           delegate: MonthWeekNumberBodyLayoutDelegate(
             gutterId: showWeekNumbers ? 0 : null,
+            backgroundId: background != null ? 3 : null,
             gridId: 1,
             contentId: 2,
           ),
@@ -101,6 +111,7 @@ class MonthBody extends StatelessWidget {
                   dividerSide: dividerSide,
                 ),
               ),
+            if (background != null) LayoutId(id: 3, child: background),
             LayoutId(id: 1, child: grid),
             LayoutId(id: 2, child: content),
           ],
@@ -117,17 +128,11 @@ class MonthWeek extends StatelessWidget {
   final InternalDateTimeRange internalRange;
   final HorizontalConfiguration configuration;
   final ViewController viewController;
-
-  /// The first day of the focused month, used to determine which cells belong
-  /// to an adjacent month.
-  final InternalDateTime focusMonthStart;
-
   const MonthWeek({
     super.key,
     required this.internalRange,
     required this.configuration,
     required this.viewController,
-    required this.focusMonthStart,
   });
 
   @override
@@ -137,22 +142,6 @@ class MonthWeek extends StatelessWidget {
 
     return Stack(
       children: [
-        // Background layer: one cell per day, behind the day numbers and events.
-        Positioned.fill(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              for (final date in internalRange.dates())
-                Expanded(
-                  child: MonthDayCell.fromContext(
-                    context,
-                    date,
-                    isInFocusedMonth: date.month == focusMonthStart.month && date.year == focusMonthStart.year,
-                  ),
-                ),
-            ],
-          ),
-        ),
         Positioned.fill(
           child: MultiDayDraggable(
             key: ValueKey('MultiDayDraggable-${internalRange.start.toIso8601String()}'),
@@ -200,6 +189,41 @@ class MonthWeek extends StatelessWidget {
             rightPageTrigger: components.monthComponents.bodyComponents.rightTriggerBuilder,
           ),
         ),
+      ],
+    );
+  }
+}
+
+/// A non-interactive background layer that renders one [MonthDayCell] per day.
+///
+/// Built only when a custom [MonthBodyComponents.monthDayCellBuilder] is set, and
+/// painted below the grid and the day content so cell styling sits behind them.
+class _MonthDayCellBackground extends StatelessWidget {
+  final List<InternalDateTimeRange> weekRanges;
+  final InternalDateTime focusMonthStart;
+
+  const _MonthDayCellBackground({required this.weekRanges, required this.focusMonthStart});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (final weekRange in weekRanges)
+          Expanded(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (final date in weekRange.dates())
+                  Expanded(
+                    child: MonthDayCell.fromContext(
+                      context,
+                      date,
+                      isInFocusedMonth: date.month == focusMonthStart.month && date.year == focusMonthStart.year,
+                    ),
+                  ),
+              ],
+            ),
+          ),
       ],
     );
   }

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -128,6 +128,41 @@ void main() {
       expect(find.byType(MonthDayCell), findsNothing);
     });
 
+    testWidgets('shadeAdjacentMonths shades only adjacent-month days', (tester) async {
+      // MonthDayCell.shadeAdjacentMonths() paints the 4 adjacent-month days
+      // (2 leading Dec + 2 trailing Feb) with a low-opacity onSurface overlay by
+      // default and leaves the 31 focused days as the empty MonthDayCell.
+      final components = CalendarComponents(
+        monthComponents: MonthComponents(
+          bodyComponents: MonthBodyComponents(monthDayCellBuilder: MonthDayCell.shadeAdjacentMonths()),
+        ),
+      );
+
+      await pumpMonthView(tester, DateTime(2025, 1), components: components);
+
+      final shade =
+          Theme.of(tester.element(find.byType(MonthDayCell).first)).colorScheme.onSurface.withValues(alpha: 0.08);
+      final shaded = tester.widgetList<ColoredBox>(find.byType(ColoredBox)).where((box) => box.color == shade).length;
+
+      expect(shaded, 4, reason: '2 leading + 2 trailing adjacent-month days are shaded');
+      expect(find.byType(MonthDayCell), findsNWidgets(31), reason: 'Focused days render the empty MonthDayCell');
+    });
+
+    testWidgets('shadeAdjacentMonths uses a custom color when given', (tester) async {
+      const custom = Color(0xFF123456);
+      final components = CalendarComponents(
+        monthComponents: MonthComponents(
+          bodyComponents: MonthBodyComponents(monthDayCellBuilder: MonthDayCell.shadeAdjacentMonths(color: custom)),
+        ),
+      );
+
+      await pumpMonthView(tester, DateTime(2025, 1), components: components);
+
+      final shaded = tester.widgetList<ColoredBox>(find.byType(ColoredBox)).where((box) => box.color == custom).length;
+
+      expect(shaded, 4, reason: 'The 4 adjacent-month days use the provided color');
+    });
+
     // ---------------------------------------------------------------------------
     // Regression: https://github.com/werner-scholtz/kalender/issues/266
     //

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -120,6 +120,14 @@ void main() {
       );
     });
 
+    testWidgets('builds no day-cell background layer without a custom builder', (tester) async {
+      // Default components: the background layer is skipped entirely, so no
+      // MonthDayCell widgets (and no per-cell today/localization work) are built.
+      await pumpMonthView(tester, DateTime(2025, 1));
+
+      expect(find.byType(MonthDayCell), findsNothing);
+    });
+
     // ---------------------------------------------------------------------------
     // Regression: https://github.com/werner-scholtz/kalender/issues/266
     //

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -79,6 +79,48 @@ void main() {
     }
 
     // ---------------------------------------------------------------------------
+    // #140: a monthDayCellBuilder is invoked once per day cell so consumers can
+    // style individual days (e.g. gray out days outside the focused month). Each
+    // call reports the cell's date and whether it belongs to the focused month.
+    // ---------------------------------------------------------------------------
+
+    testWidgets('monthDayCellBuilder is called per day with focused-month flags', (tester) async {
+      final byDate = <DateTime, MonthDayCellDetails>{};
+
+      final components = CalendarComponents(
+        monthComponents: MonthComponents(
+          bodyComponents: MonthBodyComponents(
+            monthDayCellBuilder: (details) {
+              byDate[DateTime(details.date.year, details.date.month, details.date.day)] = details;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // January 2025 grid: Mon Dec 30 2024 → 35 cells = 2 leading (Dec 30, 31),
+      // 31 focused (all of January), 2 trailing (Feb 1, 2).
+      await pumpMonthView(tester, DateTime(2025, 1), components: components);
+
+      expect(byDate.length, 35, reason: 'One call per cell in the 5-row grid');
+      expect(byDate[DateTime(2024, 12, 30)]?.isInFocusedMonth, isFalse, reason: 'Leading adjacent-month day');
+      expect(byDate[DateTime(2024, 12, 31)]?.isInFocusedMonth, isFalse);
+      expect(byDate[DateTime(2025, 1, 1)]?.isInFocusedMonth, isTrue);
+      expect(byDate[DateTime(2025, 1, 31)]?.isInFocusedMonth, isTrue);
+      expect(byDate[DateTime(2025, 2, 1)]?.isInFocusedMonth, isFalse, reason: 'Trailing adjacent-month day');
+      expect(
+        byDate.values.where((d) => !d.isInFocusedMonth).length,
+        4,
+        reason: '2 leading + 2 trailing days fall outside the focused month',
+      );
+      expect(
+        byDate.values.where((d) => d.isInFocusedMonth).length,
+        31,
+        reason: 'All 31 days of January are in the focused month',
+      );
+    });
+
+    // ---------------------------------------------------------------------------
     // Regression: https://github.com/werner-scholtz/kalender/issues/266
     //
     // A displayRange that spans exactly one calendar month must still render a
@@ -215,8 +257,7 @@ void main() {
     // A tileHeight far larger than any week-row height guarantees max == 0.
     const tallTileHeight = 1000.0;
 
-    Future<void> pumpShortCellMonthView(WidgetTester tester, DateTime initialDateTime) =>
-        pumpAndSettleWithMaterialApp(
+    Future<void> pumpShortCellMonthView(WidgetTester tester, DateTime initialDateTime) => pumpAndSettleWithMaterialApp(
           tester,
           CalendarView(
             eventsController: eventsController,
@@ -299,8 +340,7 @@ void main() {
         );
       }
 
-      Future<void> pumpWithCustomFrame(WidgetTester tester, DateTime initialDateTime) =>
-          pumpAndSettleWithMaterialApp(
+      Future<void> pumpWithCustomFrame(WidgetTester tester, DateTime initialDateTime) => pumpAndSettleWithMaterialApp(
             tester,
             CalendarView(
               eventsController: eventsController,


### PR DESCRIPTION
## Description

Addresses #140.

The month view had no way to style an **individual day cell**. The reporter wanted to gray out the leading/trailing days that belong to adjacent months. `monthGridBuilder` renders the grid as one widget for the whole body (a `Stack` of divider lines), and `monthDayHeaderBuilder` only styles the day *number* — neither lets you paint a per-day background.

This adds **`MonthBodyComponents.monthDayCellBuilder`**: a builder invoked once per day cell, rendered as a background layer behind the day numbers and events. Each call receives:

```dart
class MonthDayCellDetails {
  final DateTime date;          // localized wall-clock (via .forLocation())
  final bool isToday;
  final bool isInFocusedMonth;  // false for adjacent-month days
}
```

Graying out adjacent-month days becomes:

```dart
MonthBodyComponents(
  monthDayCellBuilder: (details) => details.isInFocusedMonth
      ? const SizedBox.shrink()
      : ColoredBox(color: Colors.black12),
)
```

### Why this shape (vs the earlier #284)

The first attempt (#284, now closed) added the grid's date range to `monthGridBuilder` — a **breaking** change that only handed over data, still requiring consumers to reimplement the whole grid. This is the ergonomic hook instead, and it's **additive / non-breaking**: the default builder renders nothing, so nothing changes unless you opt in. It therefore doesn't need to be gated on the 0.19.0 breaking release.

`#140` is left open (not auto-closed) for you to judge whether this fully satisfies the request.

## Implementation notes

- Background layer added at the bottom of the `MonthWeek` `Stack` (a `Row` of 7 stretched cells), so events and drag targets still sit on top.
- The focused month is derived from the page via a new `MonthIndexCalculator.monthStartFromIndex` (also DRYs up `dateTimeRangeFromIndex`).
- `MonthDayCell` / `MonthDayCellDetails` / `MonthDayCellBuilder` exported from `kalender.dart`.

## Docs

- **CHANGELOG** — Features + Tests entries under 0.19.0.
- **README** — added `monthDayCellBuilder` to the `MonthComponents` example (and fixed a pre-existing stale `monthGridBuilder` signature there).
- **MIGRATION** — intentionally none: additive/non-breaking, nothing to migrate.

## Testing

- [x] Widget test (`month_body_test.dart`): asserts the builder is called once per cell (35 for Jan 2025) with correct `isInFocusedMonth` — 2 leading Dec + 2 trailing Feb days `false`, all 31 January days `true`.
- [x] `flutter analyze` clean, `dart format` applied.
- [x] Full suite green (1190 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update: `MonthDayCell.shadeAdjacentMonths()`

Added a ready-made builder so shading adjacent-month days is a one-liner instead of custom code:

```dart
MonthBodyComponents(monthDayCellBuilder: MonthDayCell.shadeAdjacentMonths())
```

- Shades leading/trailing adjacent-month days only. It does not touch today (that stays a separate concern).
- Takes an optional `color`. The default is a low-opacity `onSurface` overlay, the Material 3 way to grey out a surface, so it adapts to light and dark themes and any custom `ColorScheme`.
- The web demo's "shade adjacent-month days" toggle now uses this builder instead of hardcoded colors.
- New tests cover the default shade and a custom color. Full suite green (1193 tests).
