### PR TITLE
test: cover month-view event focus row alignment (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Added end-to-end month-view regression coverage for a custom `generateMultiDayLayoutFrame`. [#235](https://github.com/werner-scholtz/kalender/issues/235)
 - Added regression coverage that the free-scroll header keeps its paged content's state across rebuilds. [#282](https://github.com/werner-scholtz/kalender/pull/282)
 - Added regression coverage that the free-scroll header fits the tallest visible day rather than only the leading page. [#283](https://github.com/werner-scholtz/kalender/pull/283)
+- Added regression coverage that a selected month-view event's focus aligns to its own row. [#233](https://github.com/werner-scholtz/kalender/issues/233)
 
 ## 0.18.7
 

--- a/test/widgets/month_event_focus_test.dart
+++ b/test/widgets/month_event_focus_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+void main() {
+  // Regression for #233: selecting a month-view event that sits on the second
+  // row must project the focus/drop-target onto that same row, not the first.
+  testWidgets('#233 selected event focus lands on the event row', (tester) async {
+    final eventsController = DefaultEventsController();
+    final calendarController = CalendarController();
+
+    // Two events covering the same days (Tue–Thu of the first full week) so they
+    // stack: one on row 0, one on row 1.
+    final range = DateTimeRange(start: DateTime(2025, 1, 7), end: DateTime(2025, 1, 10));
+    final eventA = CalendarEvent(dateTimeRange: range);
+    final eventB = CalendarEvent(dateTimeRange: range);
+    eventsController.addEvent(eventA);
+    eventsController.addEvent(eventB);
+
+    final tiles = TileComponents(
+      tileBuilder: (event, tileRange) => SizedBox.expand(key: ValueKey('tile-${event.id}')),
+      dropTargetTile: (event) => SizedBox.expand(key: ValueKey('drop-${event.id}')),
+    );
+
+    await pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: MonthViewConfiguration.singleMonth(
+          displayRange: DateTimeRange(start: DateTime(2024, 12), end: DateTime(2025, 3)),
+          initialDateTime: DateTime(2025, 1),
+        ),
+        body: CalendarBody(monthTileComponents: tiles),
+      ),
+    );
+
+    final topA = tester.getRect(find.byKey(ValueKey('tile-${eventA.id}'))).top;
+    final topB = tester.getRect(find.byKey(ValueKey('tile-${eventB.id}'))).top;
+    expect(topA, isNot(moreOrLessEquals(topB, epsilon: 1.0)), reason: 'The two events should stack on separate rows');
+
+    // Selecting either event must project the focus onto that event's own row —
+    // the bug in #233 was that it always landed on the first row.
+    Future<double> dropTopFor(CalendarEvent event) async {
+      calendarController.selectEvent(event);
+      await tester.pumpAndSettle();
+      return tester.getRect(find.byKey(ValueKey('drop-${event.id}'))).top;
+    }
+
+    expect(await dropTopFor(eventA), moreOrLessEquals(topA, epsilon: 1.0), reason: 'Focus must align with event A row');
+    expect(await dropTopFor(eventB), moreOrLessEquals(topB, epsilon: 1.0), reason: 'Focus must align with event B row');
+  });
+}


### PR DESCRIPTION
## Description

Relates to #233 (does not auto-close — your call).

**#233 turned out to be already fixed.** The report — selecting a month-view event on the second row projected the focus/drop-target onto the *first* row — was resolved by `1766047f` ("fix(month): render resize drop target from live selected event", v0.18.x), which rebuilds the drop-target layout frame with the live selected event replaced in place, so the highlight uses the event's real row.

That fix's test (`multi_day_event_layout_test.dart`) only covers the drop target's **horizontal** resize span, not the **vertical** row — the exact dimension #233 was about. This PR adds that missing coverage.

## What it does

`month_event_focus_test.dart`: renders a month view with two events stacked on separate rows, selects each, and asserts the focus/drop-target aligns with that event's own row (not row 0).

I verified the fix commit's diff is the mechanism, and that this test passes on current `main`.

## Testing

- [x] New widget test passes; full suite green (1190).
- [x] `flutter analyze` clean, `dart format` applied.

**Suggested follow-up:** close #233 (fixed by `1766047f`) once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)