### PR TITLE
fix!: single source for the multi-day timeline gutter width (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed the free-scroll multi-day header clipping days that have more events than the leading day; the header now sizes to the tallest day currently in view. [#283](https://github.com/werner-scholtz/kalender/pull/283)
 - Fixed the multi-day/week header drifting out of alignment with the body when the timeline used a custom `stringBuilder` or width; the gutter width now has a single source. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 - The timeline gutter width now accounts for the text scale factor, so it no longer under-sizes when text is enlarged. [#180](https://github.com/werner-scholtz/kalender/issues/180)
+- The timeline gutter now measures every label across the day rather than a single sample, so a custom label format whose widest entry is not at 23:59 no longer clips. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 - Replaced `ViewConfiguration.initialDateSelectionStrategy` with per-dimension view-transition options: `dateTransition` on all views, and `scrollTransition` / `zoomTransition` on `MultiDayViewConfiguration`, each with an optional resolver for custom logic. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - View switches now preserve the vertical scroll (time-of-day) and zoom by default instead of resetting to `initialTimeOfDay`; opt out with `ScrollTransition.reset` / `ZoomTransition.reset`. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Renamed `EmptyDayBehavior.showToday` to `EmptyDayBehavior.showOnlyToday`, since it shows only today among empty days. [#253](https://github.com/werner-scholtz/kalender/issues/253)
+- Replaced `MultiDayBodyComponents.prototypeTimeLine` with a `timelineWidth` builder that returns the gutter width directly (`double`). The multi-day body, header and drag overlay now share this one width, so customizing the timeline can no longer misalign the header. Removed the `PrototypeTimeline` widget and `PrototypeTimeLineBuilder`. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 
 ### Features
 
 - Added `restorePerView` transitions so each view can reopen its own last date, scroll, and zoom. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Added `CalendarController.visibleTimeOfDay` and the `CalendarCallbacks.onScrollPositionChanged` callback. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Added `ScheduleBodyConfiguration.leadingWidth` to control the schedule view's date-column width. [#253](https://github.com/werner-scholtz/kalender/issues/253)
+- Added `TimelineStyle.width` to set an explicit multi-day timeline gutter width. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 
 ### Fixes
 
@@ -19,6 +21,8 @@
 - Fixed the continuous schedule view scrolling to the wrong position when today has no events; the initial scroll and `animateToDateTime` now target today, or the nearest day when it is hidden. [#253](https://github.com/werner-scholtz/kalender/issues/253)
 - Fixed the free-scroll multi-day header "wobbling" (re-animating its height) whenever a calendar item changed; its paged content now keeps its state across rebuilds instead of being rebuilt from scratch. [#282](https://github.com/werner-scholtz/kalender/pull/282)
 - Fixed the free-scroll multi-day header clipping days that have more events than the leading day; the header now sizes to the tallest day currently in view. [#283](https://github.com/werner-scholtz/kalender/pull/283)
+- Fixed the multi-day/week header drifting out of alignment with the body when the timeline used a custom `stringBuilder` or width; the gutter width now has a single source. [#180](https://github.com/werner-scholtz/kalender/issues/180)
+- The timeline gutter width now accounts for the text scale factor, so it no longer under-sizes when text is enlarged. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 
 ### Tests
 
@@ -28,6 +32,7 @@
 - Added end-to-end month-view regression coverage for a custom `generateMultiDayLayoutFrame`. [#235](https://github.com/werner-scholtz/kalender/issues/235)
 - Added regression coverage that the free-scroll header keeps its paged content's state across rebuilds. [#282](https://github.com/werner-scholtz/kalender/pull/282)
 - Added regression coverage that the free-scroll header fits the tallest visible day rather than only the leading page. [#283](https://github.com/werner-scholtz/kalender/pull/283)
+- Added regression coverage that the multi-day header and body day columns stay aligned across custom label formats, explicit widths, and right-to-left. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 
 ## 0.18.7
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,37 @@
 
 ## v0.18.x → v0.19.0
 
+### Timeline gutter width is now a single value (`prototypeTimeLine` removed)
+
+The multi-day body, header and drag overlay previously worked out the left timeline gutter width in separate places, which could drift apart and misalign the header (see [#180](https://github.com/werner-scholtz/kalender/issues/180)). They now share one width, resolved by `MultiDayBodyComponents.timelineWidth`.
+
+`MultiDayBodyComponents.prototypeTimeLine`, the `PrototypeTimeline` widget, and the `PrototypeTimeLineBuilder` typedef have been removed.
+
+**If you only set `bodyStyles.timelineStyle`** (including a custom `stringBuilder`): no change needed — the header and body now always match.
+
+**If you overrode `prototypeTimeLine`:** return the width as a `double` from `timelineWidth` instead of building a widget.
+
+**Before:**
+```dart
+MultiDayBodyComponents(
+  prototypeTimeLine: (heightPerMinute, timeOfDayRange, style) => const SizedBox(width: 80),
+)
+```
+
+**After:**
+```dart
+MultiDayBodyComponents(
+  timelineWidth: (context, timeOfDayRange, style) => 80,
+)
+```
+
+**If you provide a fully custom `timeline` widget:** the body now fixes the gutter to `timelineWidth`, so you no longer need to make your widget's width match by hand. Build the timeline to fill the given width, and set the width with either `TimelineStyle(width: …)` or a `timelineWidth` builder.
+
+A new `TimelineStyle.width` field lets you set the gutter width directly without a builder:
+```dart
+MultiDayBodyComponentStyles(timelineStyle: TimelineStyle(width: 72))
+```
+
 ### `monthDayHeaderBuilder` receives a localized `DateTime`
 
 `monthDayHeaderBuilder` now provides a localized wall-clock `DateTime` (via `.forLocation()`), consistent with `dayHeaderBuilder`, instead of a UTC-flagged `InternalDateTime`. This fixes incorrect "today" comparisons against `DateTime.now()` in custom month-view day headers ([#248](https://github.com/werner-scholtz/kalender/issues/248)).

--- a/examples/advanced_example/lib/main.dart
+++ b/examples/advanced_example/lib/main.dart
@@ -90,7 +90,9 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Advanced Example',
-      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple)),
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+      ),
       home: const MyHomePage(),
     );
   }
@@ -126,11 +128,14 @@ class _MyHomePageState extends State<MyHomePage> {
         viewConfiguration: _viewConfiguration,
         components: CalendarComponents(),
         callbacks: CalendarCallbacks(
-          onEventTapped: (event, renderBox) => calendarController.selectEvent(event),
+          onEventTapped: (event, renderBox) =>
+              calendarController.selectEvent(event),
           onEventCreateWithDetail: Event.fromDetail,
           onEventCreated: (event) => eventsController.addEvent(event),
-          onEventChanged: (event, updatedEvent) =>
-              eventsController.updateEvent(event: event, updatedEvent: updatedEvent),
+          onEventChanged: (event, updatedEvent) => eventsController.updateEvent(
+            event: event,
+            updatedEvent: updatedEvent,
+          ),
         ),
         header: Column(
           children: [
@@ -155,7 +160,9 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             const SizedBox(height: 8),
             CalendarHeader(
-              multiDayHeaderConfiguration: MultiDayHeaderConfiguration(showTiles: false),
+              multiDayHeaderConfiguration: MultiDayHeaderConfiguration(
+                showTiles: false,
+              ),
             ),
             const Divider(),
             PeopleWidget(viewConfiguration: _viewConfiguration),
@@ -205,15 +212,23 @@ class PeopleWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        // Needed for proper spacing.
-        PrototypeTimeline.prototypeBuilder(0.7, TimeOfDayRange.allDay(), TimelineStyle()),
+        // Needed for proper spacing — matches the body's timeline gutter width.
+        SizedBox(
+          width: defaultTimelineWidth(
+            context,
+            TimeOfDayRange.allDay(),
+            const TimelineStyle(),
+          ),
+        ),
         ...List.generate(
           viewConfiguration.numberOfDays,
           (index) => Expanded(
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceAround,
               children: people
-                  .map((person) => Expanded(child: PersonWidget(person: person)))
+                  .map(
+                    (person) => Expanded(child: PersonWidget(person: person)),
+                  )
                   .toList(growable: false),
             ),
           ),

--- a/lib/src/models/components/multi_day_components.dart
+++ b/lib/src/models/components/multi_day_components.dart
@@ -60,13 +60,17 @@ class MultiDayBodyComponents {
 
   /// A function that builds the timeline widget.
   ///
-  /// If you override this, you must ensure that you also override the [prototypeTimeLine] builder,
-  /// and ensure that the two widgets resolve to the same width.
-  /// Otherwise, you might encounter alignment issues between the header and body.
+  /// The gutter width is decided by [timelineWidth] (not by this widget), so the
+  /// header, body and drag overlay always align. Build the timeline to fill the
+  /// width [timelineWidth] resolves to.
   final TimeLineBuilder timeline;
 
-  /// A function that builds the prototype timeline widget.
-  final PrototypeTimeLineBuilder prototypeTimeLine;
+  /// Resolves the width of the timeline gutter.
+  ///
+  /// This single value is used by the body, the header and the drag overlay, so
+  /// their day columns stay aligned regardless of how [timeline] is customized.
+  /// Defaults to [defaultTimelineWidth].
+  final TimelineWidthBuilder timelineWidth;
 
   /// A function that builds the day separator widget.
   final DaySeparatorBuilder daySeparator;
@@ -90,7 +94,7 @@ class MultiDayBodyComponents {
   const MultiDayBodyComponents({
     this.hourLines = HourLines.builder,
     this.timeline = TimeLine.builder,
-    this.prototypeTimeLine = PrototypeTimeline.prototypeBuilder,
+    this.timelineWidth = defaultTimelineWidth,
     this.daySeparator = DaySeparator.builder,
     this.timeIndicator = TimeIndicator.builder,
     this.leftTriggerBuilder,

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -31,26 +31,45 @@ typedef TimelineWidthBuilder = double Function(
 
 /// The default [TimelineWidthBuilder].
 ///
-/// Returns [TimelineStyle.width] when set, otherwise measures the width of the
-/// widest label ("23:59", or the result of [TimelineStyle.stringBuilder]) plus the
-/// horizontal text padding. Honors the ambient [MediaQuery.textScaler] so the
-/// gutter reserves enough room for scaled text.
+/// Returns [TimelineStyle.width] when set. Otherwise it measures every label the
+/// timeline can show across the day and uses the widest, plus the horizontal
+/// text padding. Measuring all labels (rather than a single sample) keeps the
+/// gutter correct regardless of the locale's time format, the hour's digit
+/// count, and any custom [TimelineStyle.stringBuilder]. Honors the ambient
+/// [MediaQuery.textScaler] so it reserves enough room for scaled text.
 double defaultTimelineWidth(BuildContext context, TimeOfDayRange timeOfDayRange, TimelineStyle style) {
   if (style.width != null) return style.width!;
 
   final textStyle = style.textStyle ?? Theme.of(context).textTheme.labelMedium!;
   final padding = style.textPadding ?? const EdgeInsets.symmetric(horizontal: 8, vertical: 36);
-  const displayTime = TimeOfDay(hour: 23, minute: 59);
-  final text = style.stringBuilder?.call(displayTime) ?? displayTime.format(context);
 
   final painter = TextPainter(
-    text: TextSpan(text: text, style: textStyle),
     maxLines: 1,
     textDirection: style.textDirection ?? TextDirection.ltr,
     textScaler: MediaQuery.textScalerOf(context),
-  )..layout();
+  );
 
-  return painter.width + padding.horizontal;
+  // With the default label the minute slot is always two digits, so one minute
+  // value per hour is representative. A custom stringBuilder can vary per
+  // minute, so sample every 5-minute mark the timeline can show (its finest
+  // segment is 5 minutes).
+  const defaultMinutes = [59];
+  const customMinutes = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
+  final minutes = style.stringBuilder == null ? defaultMinutes : customMinutes;
+
+  var widest = 0.0;
+  for (var hour = 0; hour < TimeOfDay.hoursPerDay; hour++) {
+    for (final minute in minutes) {
+      final time = TimeOfDay(hour: hour, minute: minute);
+      final text = style.stringBuilder?.call(time) ?? time.format(context);
+      painter.text = TextSpan(text: text, style: textStyle);
+      painter.layout();
+      if (painter.width > widest) widest = painter.width;
+    }
+  }
+  painter.dispose();
+
+  return widest + padding.horizontal;
 }
 
 /// The style of the [TimeLine] widget.

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -16,16 +16,42 @@ typedef TimeLineBuilder = Widget Function(
   ValueNotifier<DateTimeRange<DateTime>?> visibleDateTimeRange,
 );
 
-/// The prototype time line builder.
+/// Resolves the width of the timeline gutter.
 ///
-/// The [heightPerMinute] is the height of each minute.
-/// The [timeOfDayRange] is the range of time that the time line will be displayed for.
-/// The [style] is used to style the time line.
-typedef PrototypeTimeLineBuilder = Widget Function(
-  double heightPerMinute,
+/// The same width is used by the multi-day body, header and drag overlay, so that
+/// their day columns stay aligned. The [style] is the already-resolved (non-null)
+/// [TimelineStyle] from the component styles.
+///
+/// See [defaultTimelineWidth] for the default implementation.
+typedef TimelineWidthBuilder = double Function(
+  BuildContext context,
   TimeOfDayRange timeOfDayRange,
-  TimelineStyle? style,
+  TimelineStyle style,
 );
+
+/// The default [TimelineWidthBuilder].
+///
+/// Returns [TimelineStyle.width] when set, otherwise measures the width of the
+/// widest label ("23:59", or the result of [TimelineStyle.stringBuilder]) plus the
+/// horizontal text padding. Honors the ambient [MediaQuery.textScaler] so the
+/// gutter reserves enough room for scaled text.
+double defaultTimelineWidth(BuildContext context, TimeOfDayRange timeOfDayRange, TimelineStyle style) {
+  if (style.width != null) return style.width!;
+
+  final textStyle = style.textStyle ?? Theme.of(context).textTheme.labelMedium!;
+  final padding = style.textPadding ?? const EdgeInsets.symmetric(horizontal: 8, vertical: 36);
+  const displayTime = TimeOfDay(hour: 23, minute: 59);
+  final text = style.stringBuilder?.call(displayTime) ?? displayTime.format(context);
+
+  final painter = TextPainter(
+    text: TextSpan(text: text, style: textStyle),
+    maxLines: 1,
+    textDirection: style.textDirection ?? TextDirection.ltr,
+    textScaler: MediaQuery.textScalerOf(context),
+  )..layout();
+
+  return painter.width + padding.horizontal;
+}
 
 /// The style of the [TimeLine] widget.
 class TimelineStyle {
@@ -44,6 +70,12 @@ class TimelineStyle {
   /// The padding of the text.
   final EdgeInsets? textPadding;
 
+  /// An explicit width for the timeline gutter.
+  ///
+  /// When set, the gutter uses this width directly. When null, the width is
+  /// measured from the widest label plus [textPadding].
+  final double? width;
+
   /// The function that will be used to build the string.
   final String Function(TimeOfDay timeOfDay)? stringBuilder;
 
@@ -60,6 +92,7 @@ class TimelineStyle {
     this.textOverflow,
     this.stringBuilder,
     this.textPadding,
+    this.width,
     this.startDecoration,
     this.endDecoration,
   });
@@ -287,39 +320,5 @@ class TimeLine extends StatelessWidget with TimeLineUtils {
         ],
       ),
     );
-  }
-}
-
-/// A widget that displays a prototype time line.
-class PrototypeTimeline extends TimeLine {
-  const PrototypeTimeline({
-    super.key,
-    required super.timeOfDayRange,
-    required super.heightPerMinute,
-    required super.eventBeingDragged,
-    required super.visibleDateTimeRange,
-    required super.style,
-  });
-
-  static PrototypeTimeline prototypeBuilder(
-    double heightPerMinute,
-    TimeOfDayRange timeOfDayRange,
-    TimelineStyle? style,
-  ) {
-    return PrototypeTimeline(
-      heightPerMinute: heightPerMinute,
-      timeOfDayRange: timeOfDayRange,
-      style: style,
-      eventBeingDragged: ValueNotifier(null),
-      visibleDateTimeRange: ValueNotifier(DateTimeRange(start: DateTime(2024, 1, 1), end: DateTime(2024, 1, 2))),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final textStyle = this.textStyle(context);
-    final textPadding = this.textPadding(context);
-    final largestTextSize = this.largestTextSize(context, textStyle, textPadding);
-    return SizedBox(width: largestTextSize.width);
   }
 }

--- a/lib/src/widgets/internal_components/multi_day_header_layout.dart
+++ b/lib/src/widgets/internal_components/multi_day_header_layout.dart
@@ -5,8 +5,9 @@ import 'package:kalender/src/models/providers/calendar_provider.dart';
 
 /// The widget used for the MultiDayHeader.
 ///
-/// This widget uses the [TimeLine] to determine the size of the [leading].
-/// It uses the [content] and [leading] to determine the height of the [MultiDayHeaderWidget].
+/// It offsets the [content] by the timeline gutter width (resolved via
+/// [MultiDayBodyComponents.timelineWidth]) and sizes the [leading] to that width,
+/// so the header's day columns align with the body's day columns.
 class MultiDayHeaderWidget extends StatelessWidget {
   /// The content that will be displayed in the [MultiDayHeaderWidget].
   final Widget content;
@@ -14,8 +15,8 @@ class MultiDayHeaderWidget extends StatelessWidget {
   /// The leading widget that will be displayed in the [MultiDayHeaderWidget].
   final Widget leading;
 
-  /// The prototype timeline widget that will be used to display the timeline.
-  final Widget? prototypeTimelineOverride;
+  /// Overrides the resolved timeline gutter width. Intended for tests.
+  final double? timelineWidthOverride;
 
   /// Creates a MultiDayHeaderWidget.
   /// This widget is used to display the header of the MultiDayView.
@@ -23,41 +24,39 @@ class MultiDayHeaderWidget extends StatelessWidget {
     super.key,
     required this.content,
     required this.leading,
-    this.prototypeTimelineOverride,
+    this.timelineWidthOverride,
   });
 
   @override
   Widget build(BuildContext context) {
-    var timeline = prototypeTimelineOverride;
-    if (timeline == null) {
-      // Create the timeline widget.
+    final double timelineWidth;
+    final override = timelineWidthOverride;
+    if (override != null) {
+      timelineWidth = override;
+    } else {
       final calendarComponents = context.components;
       final bodyStyles = calendarComponents.multiDayComponentStyles.bodyStyles;
       final bodyComponents = calendarComponents.multiDayComponents.bodyComponents;
-      final timelineStyle = bodyStyles.timelineStyle;
-      const heightPerMinute = 1.0;
-      final timeOfDayRange = TimeOfDayRange.allDay();
-      timeline = bodyComponents.prototypeTimeLine.call(heightPerMinute, timeOfDayRange, timelineStyle);
+      timelineWidth = bodyComponents.timelineWidth(context, TimeOfDayRange.allDay(), bodyStyles.timelineStyle);
     }
 
     return _MultiDayHeaderWidget(
-      prototypeTimeLine: LayoutId(id: 1, child: timeline),
-      leading: LayoutId(id: 2, child: leading),
-      content: LayoutId(id: 3, child: content),
+      timelineWidth: timelineWidth,
+      leading: LayoutId(id: 1, child: leading),
+      content: LayoutId(id: 2, child: content),
     );
   }
 }
 
 class _MultiDayHeaderWidget extends MultiChildRenderObjectWidget {
   _MultiDayHeaderWidget({
-    required this.prototypeTimeLine,
+    required this.timelineWidth,
     required this.leading,
     required this.content,
-    // required this.maxHeight,
-  }) : super(children: [content, prototypeTimeLine, leading]);
+  }) : super(children: [content, leading]);
 
-  /// The widget that will be used to display the timeline.
-  final Widget prototypeTimeLine;
+  /// The width of the timeline gutter that the content is offset by.
+  final double timelineWidth;
 
   /// The widget that will be used to display the leading widget.
   final Widget leading;
@@ -67,12 +66,14 @@ class _MultiDayHeaderWidget extends MultiChildRenderObjectWidget {
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    return _RenderMultiDayHeaderWidget(Directionality.maybeOf(context));
+    return _RenderMultiDayHeaderWidget(Directionality.maybeOf(context), timelineWidth);
   }
 
   @override
   void updateRenderObject(context, covariant _RenderMultiDayHeaderWidget renderObject) {
-    renderObject.textDirection = Directionality.maybeOf(context);
+    renderObject
+      ..textDirection = Directionality.maybeOf(context)
+      ..timelineWidth = timelineWidth;
   }
 }
 
@@ -80,7 +81,9 @@ class _RenderMultiDayHeaderWidget extends RenderBox
     with
         ContainerRenderObjectMixin<RenderBox, MultiChildLayoutParentData>,
         RenderBoxContainerDefaultsMixin<RenderBox, MultiChildLayoutParentData> {
-  _RenderMultiDayHeaderWidget(TextDirection? textDirection) : _textDirection = textDirection;
+  _RenderMultiDayHeaderWidget(TextDirection? textDirection, double timelineWidth)
+      : _textDirection = textDirection,
+        _timelineWidth = timelineWidth;
 
   TextDirection? get textDirection => _textDirection;
   TextDirection? _textDirection;
@@ -89,6 +92,16 @@ class _RenderMultiDayHeaderWidget extends RenderBox
       return;
     }
     _textDirection = value;
+    markNeedsLayout();
+  }
+
+  double get timelineWidth => _timelineWidth;
+  double _timelineWidth;
+  set timelineWidth(double value) {
+    if (_timelineWidth == value) {
+      return;
+    }
+    _timelineWidth = value;
     markNeedsLayout();
   }
 
@@ -102,12 +115,8 @@ class _RenderMultiDayHeaderWidget extends RenderBox
   @override
   void performLayout() {
     final content = firstChild!;
-    final timeline = childAfter(content)!;
-    final leading = childAfter(timeline)!;
-
-    // Layout the timeline to get the width.
-    timeline.layout(const BoxConstraints(maxHeight: 10), parentUsesSize: true);
-    final timelineWidth = timeline.size.width;
+    final leading = childAfter(content)!;
+    final timelineWidth = this.timelineWidth;
 
     // Layout the content to get the height.
     content.layout(BoxConstraints(maxWidth: constraints.maxWidth - timelineWidth), parentUsesSize: true);
@@ -134,9 +143,9 @@ class _RenderMultiDayHeaderWidget extends RenderBox
       TextDirection.rtl => const Offset(0, 0),
     };
 
-    // Setup the parent data for the timeline.
-    final leadingContentParentData = (leading.parentData! as MultiChildLayoutParentData);
-    leadingContentParentData.offset = switch (textDirection!) {
+    // Setup the parent data for the leading.
+    final leadingParentData = (leading.parentData! as MultiChildLayoutParentData);
+    leadingParentData.offset = switch (textDirection!) {
       TextDirection.ltr => const Offset(0, 0),
       TextDirection.rtl => Offset(constraints.maxWidth - timelineWidth, 0),
     };
@@ -151,11 +160,8 @@ class _RenderMultiDayHeaderWidget extends RenderBox
     final contentParentData = content.parentData! as MultiChildLayoutParentData;
     content.paint(context, contentParentData.offset + offset);
 
-    // Do not paint the timeline.
-    final timeline = childAfter(content)!;
-
-    // Paint the timeline.
-    final leading = childAfter(timeline)!;
+    // Paint the leading.
+    final leading = childAfter(content)!;
     final leadingParentData = leading.parentData! as MultiChildLayoutParentData;
     leading.paint(context, leadingParentData.offset + offset);
   }

--- a/lib/src/widgets/internal_components/timeline_sizer.dart
+++ b/lib/src/widgets/internal_components/timeline_sizer.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
-/// A Widget that sizes the width of the [child] based on the [TimeLine].
+/// A widget that sizes the width of [child] to the timeline gutter width.
+///
+/// It resolves the width via [MultiDayBodyComponents.timelineWidth] — the same
+/// source the body and header use — so the drag overlay stays aligned with them.
 class TimelineSizer extends StatelessWidget {
   final Widget child;
   const TimelineSizer({
@@ -13,71 +15,11 @@ class TimelineSizer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Create the timeline widget.
     final calendarComponents = context.components;
     final bodyStyles = calendarComponents.multiDayComponentStyles.bodyStyles;
     final bodyComponents = calendarComponents.multiDayComponents.bodyComponents;
-    final timelineStyle = bodyStyles.timelineStyle;
-    const heightPerMinute = 1.0;
-    final timeOfDayRange = TimeOfDayRange.allDay();
-    final timeline = bodyComponents.prototypeTimeLine.call(heightPerMinute, timeOfDayRange, timelineStyle);
+    final width = bodyComponents.timelineWidth(context, TimeOfDayRange.allDay(), bodyStyles.timelineStyle);
 
-    return _TimelineSizer(
-      timelineWidget: LayoutId(id: 1, child: timeline),
-      child: LayoutId(id: 2, child: child),
-    );
-  }
-}
-
-class _TimelineSizer extends MultiChildRenderObjectWidget {
-  _TimelineSizer({
-    required this.timelineWidget,
-    required this.child,
-  }) : super(children: [timelineWidget, child]);
-
-  final Widget timelineWidget;
-  final Widget child;
-
-  @override
-  RenderObject createRenderObject(BuildContext context) {
-    return _RenderTimelineSizer();
-  }
-
-  @override
-  void updateRenderObject(context, covariant renderObject) {}
-}
-
-class _RenderTimelineSizer extends RenderBox
-    with
-        ContainerRenderObjectMixin<RenderBox, MultiChildLayoutParentData>,
-        RenderBoxContainerDefaultsMixin<RenderBox, MultiChildLayoutParentData> {
-  @override
-  void setupParentData(RenderBox child) {
-    if (child.parentData is! MultiChildLayoutParentData) {
-      child.parentData = MultiChildLayoutParentData();
-    }
-  }
-
-  @override
-  void performLayout() {
-    final timeline = firstChild!;
-    timeline.layout(const BoxConstraints(maxHeight: 1440), parentUsesSize: true);
-
-    final child = childAfter(timeline)!;
-    child.layout(constraints, parentUsesSize: true);
-
-    size = Size(timeline.size.width, child.size.height);
-  }
-
-  @override
-  void paint(PaintingContext context, Offset offset) {
-    final timeline = firstChild!;
-    final child = childAfter(timeline)!;
-    child.paint(context, offset);
-  }
-
-  @override
-  bool hitTest(BoxHitTestResult result, {required Offset position}) {
-    return defaultHitTestChildren(result, position: position);
+    return SizedBox(width: width, child: child);
   }
 }

--- a/lib/src/widgets/multi_day/multi_day_body.dart
+++ b/lib/src/widgets/multi_day/multi_day_body.dart
@@ -40,6 +40,9 @@ class MultiDayBody extends StatelessWidget {
   /// The key used to identify the [SingleChildScrollView] of the [MultiDayBody].
   static const singleChildScrollViewKey = ValueKey('singleChildScrollViewKey');
 
+  /// The key used to identify the timeline gutter of the [MultiDayBody].
+  static const timelineKey = ValueKey('MultiDayBody.timeline');
+
   @override
   Widget build(BuildContext context) {
     final controller = context.calendarController;
@@ -58,6 +61,12 @@ class MultiDayBody extends StatelessWidget {
     // Calculate the height of the page.
     final pageHeight = context.heightPerMinute * timeOfDayRange.duration.inMinutes;
 
+    // The single source of truth for the timeline gutter width, shared with the
+    // header and drag overlay so their day columns stay aligned.
+    final bodyStyles = context.components.multiDayComponentStyles.bodyStyles;
+    final bodyComponents = context.components.multiDayComponents.bodyComponents;
+    final timelineWidth = bodyComponents.timelineWidth(context, timeOfDayRange, bodyStyles.timelineStyle);
+
     return Stack(
       children: [
         Scrollbar(
@@ -71,7 +80,13 @@ class MultiDayBody extends StatelessWidget {
               child: Row(
                 children: [
                   // The timeline is always on the left side of the page, but should not scroll with the pageview.
-                  SizedBox(height: pageHeight, child: TimeLine.fromContext(context, timeOfDayRange)),
+                  // Its width is fixed to the shared timeline width so it aligns with the header and drag overlay.
+                  SizedBox(
+                    key: timelineKey,
+                    width: timelineWidth,
+                    height: pageHeight,
+                    child: TimeLine.fromContext(context, timeOfDayRange),
+                  ),
                   Expanded(
                     child: Stack(
                       children: [

--- a/test/widgets/multi_day_header_widget_test.dart
+++ b/test/widgets/multi_day_header_widget_test.dart
@@ -39,11 +39,14 @@ void main() {
           MultiDayHeaderWidget(
             content: SizedBox(height: check.contentHeight, key: const ValueKey('content')),
             leading: SizedBox(width: 48, height: check.leadingHeight, key: const ValueKey('leading')),
-            prototypeTimelineOverride: const SizedBox(width: 48),
+            timelineWidthOverride: 48,
           ),
         );
 
         _expectHeader(tester, check.expectedHeight);
+
+        // The content starts after the 48px gutter and the leading fills it.
+        expect(tester.getTopLeft(_contentFinder).dx, 48, reason: 'Content should be offset by the timeline width');
       });
     }
 
@@ -58,7 +61,7 @@ void main() {
             builder: (context, value, child) => SizedBox(height: value, key: const ValueKey('content')),
           ),
           leading: const SizedBox(width: 48, height: 48, key: ValueKey('leading')),
-          prototypeTimelineOverride: const SizedBox(width: 48),
+          timelineWidthOverride: 48,
         ),
       );
 

--- a/test/widgets/timeline_alignment_test.dart
+++ b/test/widgets/timeline_alignment_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/internal_components/expandable_page_view.dart' show ExpandablePageView;
+
+import '../utilities.dart';
+
+/// Regression coverage for #180: the multi-day header's day columns must line up
+/// with the body's day columns regardless of how the timeline gutter is
+/// customized. Both are driven by a single gutter width, so the body's day area
+/// (the [HourLines]) and the header's day area (the [ExpandablePageView] content)
+/// must occupy the same horizontal span.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  final tiles = TileComponents(tileBuilder: (event, tileRange) => const SizedBox());
+
+  Future<void> pumpWeek(
+    WidgetTester tester, {
+    CalendarComponents? components,
+    TextDirection textDirection = TextDirection.ltr,
+  }) async {
+    final view = CalendarView(
+      eventsController: eventsController,
+      calendarController: calendarController,
+      viewConfiguration: MultiDayViewConfiguration.week(
+        displayRange: DateTimeRange(start: DateTime(2025), end: DateTime(2025, 2)),
+      ),
+      components: components,
+      header: CalendarHeader(multiDayTileComponents: tiles),
+      body: CalendarBody(multiDayTileComponents: tiles),
+    );
+    await pumpAndSettleWithMaterialApp(tester, Directionality(textDirection: textDirection, child: view));
+  }
+
+  double gutterWidth(WidgetTester tester) => tester.getSize(find.byKey(MultiDayBody.timelineKey)).width;
+
+  /// Asserts the header's day area lines up with the body's day area.
+  void expectAligned(WidgetTester tester) {
+    final bodyDayArea = tester.getRect(find.byType(HourLines));
+    final headerDayArea = tester.getRect(find.byType(ExpandablePageView));
+    expect(
+      headerDayArea.left,
+      moreOrLessEquals(bodyDayArea.left, epsilon: 0.5),
+      reason: 'Header day columns must start where the body day columns start',
+    );
+    expect(
+      headerDayArea.right,
+      moreOrLessEquals(bodyDayArea.right, epsilon: 0.5),
+      reason: 'Header day columns must end where the body day columns end',
+    );
+  }
+
+  CalendarComponents withTimelineStyle(TimelineStyle style) => CalendarComponents(
+        multiDayComponentStyles: MultiDayComponentStyles(
+          bodyStyles: MultiDayBodyComponentStyles(timelineStyle: style),
+        ),
+      );
+
+  testWidgets('default timeline: header and body columns align', (tester) async {
+    await pumpWeek(tester);
+    expectAligned(tester);
+  });
+
+  testWidgets('custom stringBuilder shortening labels keeps columns aligned (#180)', (tester) async {
+    await pumpWeek(tester, components: withTimelineStyle(TimelineStyle(stringBuilder: (_) => 'X')));
+
+    // The gutter shrank to fit the short label ...
+    expect(gutterWidth(tester), lessThan(40), reason: 'Short labels should produce a narrow gutter');
+    // ... and the header still lines up with the body (this is what #180 broke).
+    expectAligned(tester);
+  });
+
+  testWidgets('explicit TimelineStyle.width drives the gutter and stays aligned', (tester) async {
+    await pumpWeek(tester, components: withTimelineStyle(const TimelineStyle(width: 100)));
+
+    expect(gutterWidth(tester), moreOrLessEquals(100, epsilon: 0.5));
+    expectAligned(tester);
+  });
+
+  testWidgets('custom timelineWidth builder drives the gutter and stays aligned', (tester) async {
+    await pumpWeek(
+      tester,
+      components: CalendarComponents(
+        multiDayComponents: MultiDayComponents(
+          bodyComponents: MultiDayBodyComponents(timelineWidth: (context, timeOfDayRange, style) => 100),
+        ),
+      ),
+    );
+
+    expect(gutterWidth(tester), moreOrLessEquals(100, epsilon: 0.5));
+    expectAligned(tester);
+  });
+
+  testWidgets('columns stay aligned in right-to-left', (tester) async {
+    await pumpWeek(
+      tester,
+      components: withTimelineStyle(TimelineStyle(stringBuilder: (_) => 'X')),
+      textDirection: TextDirection.rtl,
+    );
+    expectAligned(tester);
+  });
+}

--- a/test/widgets/timeline_alignment_test.dart
+++ b/test/widgets/timeline_alignment_test.dart
@@ -77,6 +77,23 @@ void main() {
     expectAligned(tester);
   });
 
+  testWidgets('measures every label, so the widest hour fits even when it is not 23:59', (tester) async {
+    // A stringBuilder whose widest output is at noon, not at 23:59. Sampling
+    // only 23:59 (which here returns the short 'x') would under-size the gutter
+    // and clip the noon label. Measuring all labels must accommodate it.
+    const wide = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'; // 40 chars
+    String labels(TimeOfDay time) => time.hour == 12 ? wide : 'x';
+
+    await pumpWeek(tester, components: withTimelineStyle(TimelineStyle(stringBuilder: labels)));
+
+    expect(
+      gutterWidth(tester),
+      greaterThan(150),
+      reason: 'Gutter must fit the widest label from any hour, not just the 23:59 sample',
+    );
+    expectAligned(tester);
+  });
+
   testWidgets('explicit TimelineStyle.width drives the gutter and stays aligned', (tester) async {
     await pumpWeek(tester, components: withTimelineStyle(const TimelineStyle(width: 100)));
 


### PR DESCRIPTION
Closes #180. **Version/release placement is intentionally left open** — CHANGELOG entries are under `0.19.0` for now; move them if this ships as its own release.

## The problem
In the week / multi-day view, the left timeline gutter (the hour labels) had its width worked out in **three separate places** — the visible strip in the body, an invisible measuring copy for the header, and another for the drag overlay. The body used the `timeline` builder; the header and overlay used a *separate* `prototypeTimeLine` builder. They only matched by coincidence, so customizing the timeline (a custom `stringBuilder`, a custom width, or a fully custom widget) left the header's day columns drifting out of line with the body's. The package even documented the hazard ("if you override `timeline` you must also override `prototypeTimeLine`").

## The fix — one shared width
The gutter width now has a single source: `MultiDayBodyComponents.timelineWidth`, a builder that returns the width as a `double`. The body, header and drag overlay all read it, and the body constrains the visible strip to that same width — so what's drawn always equals what the layout reserved. They can no longer disagree.

- The header render object no longer builds/measures an invisible copy; it takes the width as a number and offsets the content by it (also simpler).
- `TimelineSizer` collapses to a plain `SizedBox`.

## Breaking changes
- Removed `MultiDayBodyComponents.prototypeTimeLine`, the `PrototypeTimeline` widget, and `PrototypeTimeLineBuilder`.
- Added `MultiDayBodyComponents.timelineWidth` (`double` builder) and `TimelineStyle.width` (set the gutter width directly).
- The default width now honors `MediaQuery.textScaler`, fixing a latent case where the gutter under-sized with enlarged text (can slightly widen gutters at large text scales).

Migration is in `MIGRATION.md`. Summary:
- Only set `bodyStyles.timelineStyle` → **no change**, now provably aligned.
- Overrode `prototypeTimeLine` → return a `double` from `timelineWidth`.
- Fully custom timeline widget (e.g. trinket) → still compiles unchanged; you can now **delete** manual width workarounds and let the shared width drive alignment.

## Testing
- New `test/widgets/timeline_alignment_test.dart`: opens a real week view and asserts the header's day area lines up with the body's day area for (i) a custom `stringBuilder` that shortens labels, (ii) an explicit `TimelineStyle.width`, (iii) a custom `timelineWidth` builder, (iv) the default, and (v) right-to-left. I verified it **fails** if the body and header widths are desynced by even a few pixels.
- Updated `multi_day_header_widget_test.dart` for the new width parameter + added a gutter-offset assertion.
- `flutter analyze` clean (package + advanced example), `dart format` applied, **full suite green (1194)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)