### PR TITLE
feat: expose eventPadding on MonthBodyConfiguration (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added `ScheduleBodyConfiguration.leadingWidth` to control the schedule view's date-column width. [#253](https://github.com/werner-scholtz/kalender/issues/253)
 - Added `TimelineStyle.width` to set an explicit multi-day timeline gutter width. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 - Added `MonthBodyComponents.monthDayCellBuilder` to style individual month-view day cells. Each call reports the cell's date, whether it is today, and whether it falls in the focused month (so adjacent-month days can be styled differently). Also added the ready-made `MonthDayCell.shadeAdjacentMonths()` builder, which shades leading/trailing adjacent-month days. Pass a `color` or let it default to a low-opacity `onSurface` overlay that greys them out. [#140](https://github.com/werner-scholtz/kalender/issues/140)
+- Added `eventPadding` to `MonthBodyConfiguration` (forwarded from the constructor and through `copyWith`), so month event tiles can be spaced like `MultiDayHeaderConfiguration` already allows. [#252](https://github.com/werner-scholtz/kalender/issues/252)
 
 ### Fixes
 

--- a/lib/src/models/view_configurations/month_view_configuration.dart
+++ b/lib/src/models/view_configurations/month_view_configuration.dart
@@ -85,6 +85,7 @@ class MonthBodyConfiguration extends HorizontalConfiguration {
     super.generateMultiDayLayoutFrame,
     super.pageTriggerConfiguration,
     super.tileHeight,
+    super.eventPadding,
   }) : super(showTiles: true, maximumNumberOfVerticalEvents: null, allowSingleDayEvents: true);
 
   @override
@@ -100,6 +101,7 @@ class MonthBodyConfiguration extends HorizontalConfiguration {
     return MonthBodyConfiguration(
       tileHeight: tileHeight ?? this.tileHeight,
       generateMultiDayLayoutFrame: generateMultiDayLayoutFrame ?? this.generateMultiDayLayoutFrame,
+      eventPadding: eventPadding ?? this.eventPadding,
       pageTriggerConfiguration: pageTriggerConfiguration ?? this.pageTriggerConfiguration,
     );
   }

--- a/test/configuration/config_copywith_test.dart
+++ b/test/configuration/config_copywith_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+// Regression net: every view-configuration copyWith must round-trip its fields
+// rather than silently dropping them. A dropped field in copyWith is a silent
+// no-op bug, which is what #252 turned out to be (MonthBodyConfiguration.copyWith
+// dropped eventPadding). Each type gets a "preserve untouched fields" test and an
+// "update the copied field" test.
+void main() {
+  group('view configuration copyWith round-trips', () {
+    group('MonthBodyConfiguration', () {
+      const config = MonthBodyConfiguration(eventPadding: EdgeInsets.all(7), tileHeight: 40);
+
+      test('preserves eventPadding when copying another field', () {
+        expect(config.copyWith(tileHeight: 30).eventPadding, const EdgeInsets.all(7));
+      });
+
+      test('updates the copied field', () {
+        expect(config.copyWith(eventPadding: const EdgeInsets.all(9)).eventPadding, const EdgeInsets.all(9));
+        expect(config.copyWith(tileHeight: 30).tileHeight, 30);
+      });
+    });
+
+    group('MultiDayHeaderConfiguration', () {
+      const config = MultiDayHeaderConfiguration(eventPadding: EdgeInsets.all(7), tileHeight: 40);
+
+      test('preserves eventPadding when copying another field', () {
+        expect(config.copyWith(tileHeight: 30).eventPadding, const EdgeInsets.all(7));
+      });
+
+      test('updates the copied field', () {
+        expect(config.copyWith(eventPadding: const EdgeInsets.all(9)).eventPadding, const EdgeInsets.all(9));
+        expect(config.copyWith(tileHeight: 30).tileHeight, 30);
+      });
+    });
+
+    group('MultiDayBodyConfiguration', () {
+      const config = MultiDayBodyConfiguration(
+        horizontalPadding: EdgeInsets.all(5),
+        showMultiDayEvents: false,
+        minimumTileHeight: 12,
+      );
+
+      test('preserves untouched fields when copying another', () {
+        final copy = config.copyWith(pageScrollPhysics: const BouncingScrollPhysics());
+        expect(copy.horizontalPadding, const EdgeInsets.all(5));
+        expect(copy.showMultiDayEvents, false);
+        expect(copy.minimumTileHeight, 12);
+      });
+
+      test('updates the copied field', () {
+        expect(config.copyWith(horizontalPadding: const EdgeInsets.all(9)).horizontalPadding, const EdgeInsets.all(9));
+        expect(config.copyWith(minimumTileHeight: 30).minimumTileHeight, 30);
+      });
+    });
+
+    group('ScheduleBodyConfiguration', () {
+      final config = ScheduleBodyConfiguration(leadingWidth: 80, emptyDay: EmptyDayBehavior.hide);
+
+      test('preserves untouched fields when copying another', () {
+        final copy = config.copyWith(pageScrollPhysics: const BouncingScrollPhysics());
+        expect(copy.leadingWidth, 80);
+        expect(copy.emptyDay, EmptyDayBehavior.hide);
+      });
+
+      test('updates the copied field', () {
+        expect(config.copyWith(leadingWidth: 120).leadingWidth, 120);
+      });
+    });
+
+    group('MultiDayViewConfiguration.custom', () {
+      final config = MultiDayViewConfiguration.custom(numberOfDays: 3, name: 'Custom 3');
+
+      test('preserves numberOfDays when copying another field', () {
+        expect(config.copyWith(name: 'Renamed').numberOfDays, 3);
+      });
+
+      test('updates numberOfDays', () {
+        expect(config.copyWith(numberOfDays: 5).numberOfDays, 5);
+      });
+    });
+  });
+}

--- a/test/widgets/month_body_event_padding_test.dart
+++ b/test/widgets/month_body_event_padding_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/multi_day_tile.dart' show MultiDayEventTile;
+
+import '../utilities.dart';
+
+// Coverage for #252: MonthBodyConfiguration should expose eventPadding, forward
+// it to the shared HorizontalConfiguration, and carry it through copyWith, so
+// month event tiles can be spaced like the multi-day header already allows.
+void main() {
+  group('MonthBodyConfiguration eventPadding (#252)', () {
+    test('constructor exposes eventPadding', () {
+      const padding = EdgeInsets.fromLTRB(1, 2, 3, 4);
+      expect(const MonthBodyConfiguration(eventPadding: padding).eventPadding, padding);
+    });
+
+    test('defaults to kDefaultMultiDayEventPadding', () {
+      expect(const MonthBodyConfiguration().eventPadding, kDefaultMultiDayEventPadding);
+    });
+
+    test('copyWith updates eventPadding', () {
+      const updated = EdgeInsets.all(9);
+      final config = const MonthBodyConfiguration(eventPadding: EdgeInsets.all(1)).copyWith(eventPadding: updated);
+      expect(config.eventPadding, updated);
+    });
+
+    test('copyWith preserves eventPadding when it is not passed', () {
+      const padding = EdgeInsets.all(4);
+      final config = const MonthBodyConfiguration(eventPadding: padding).copyWith(tileHeight: 30);
+      expect(config.eventPadding, padding);
+    });
+
+    testWidgets('applies the configured eventPadding to month event tiles', (tester) async {
+      const padding = EdgeInsets.fromLTRB(11, 12, 13, 14);
+      final eventsController = DefaultEventsController();
+      final calendarController = CalendarController();
+
+      eventsController.addEvent(
+        CalendarEvent(
+          dateTimeRange: DateTimeRange(start: DateTime(2025, 1, 15, 9), end: DateTime(2025, 1, 15, 10)),
+        ),
+      );
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        CalendarView(
+          eventsController: eventsController,
+          calendarController: calendarController,
+          viewConfiguration: MonthViewConfiguration.singleMonth(
+            displayRange: DateTimeRange(start: DateTime(2024, 12), end: DateTime(2025, 3)),
+            initialDateTime: DateTime(2025, 1),
+          ),
+          body: const CalendarBody(
+            monthBodyConfiguration: MonthBodyConfiguration(eventPadding: padding),
+          ),
+        ),
+      );
+
+      expect(find.byType(MultiDayEventTile), findsWidgets, reason: 'The event should render a tile');
+      expect(
+        find.ancestor(
+          of: find.byType(MultiDayEventTile),
+          matching: find.byWidgetPredicate((widget) => widget is Padding && widget.padding == padding),
+        ),
+        findsWidgets,
+        reason: 'Each month event tile should be wrapped in the configured eventPadding',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

Closes #252.

`MonthBodyConfiguration` did not expose `eventPadding`, so month event tiles could not be spaced the way `MultiDayHeaderConfiguration` already allows. What looked like partial support was actually a latent bug: `copyWith` *listed* `eventPadding` (and a few other params) but silently dropped it.

### Changes

- **Constructor** now accepts `eventPadding` and forwards it to the shared `HorizontalConfiguration` (same as `MultiDayHeaderConfiguration`). The month body already reads `configuration.eventPadding` when spacing tiles, so no rendering change was needed.
- **`copyWith`** now carries `eventPadding` through instead of dropping it.

### Tests (added first, TDD)

- `month_body_event_padding_test.dart` — constructor exposes it, defaults to `kDefaultMultiDayEventPadding`, `copyWith` updates and preserves it, and a widget test asserts the configured padding actually wraps the rendered month event tiles.
- `config_copywith_test.dart` — a cross-type regression net: a `copyWith` round-trip test for every view-configuration type, since a dropped field in `copyWith` is a silent no-op. The audit found the month body was the only offender; the others already round-trip, and this locks that in.

Full suite green (1215 tests), `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
