### PR TITLE
perf: only publish visibleEvents when it actually changes

### DIFF
--- a/lib/src/widgets/events_widgets/multi_day_events_widget.dart
+++ b/lib/src/widgets/events_widgets/multi_day_events_widget.dart
@@ -116,7 +116,13 @@ class _MultiDayEventWidgetState extends State<MultiDayEventWidget> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         final controller = context.calendarController;
-        controller.visibleEvents.value = {...controller.visibleEvents.value, ..._events};
+        // Only publish when the merged set actually adds something. Assigning a
+        // fresh set every build would notify listeners on every build (a
+        // ValueNotifier compares sets by identity), causing needless rebuilds.
+        final current = controller.visibleEvents.value;
+        if (_events.any((event) => !current.contains(event))) {
+          controller.visibleEvents.value = {...current, ..._events};
+        }
       }
     });
 

--- a/lib/src/widgets/schedule/schedule_body.dart
+++ b/lib/src/widgets/schedule/schedule_body.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/mixins/schedule_map.dart';
@@ -348,7 +349,14 @@ class _SchedulePositionListState extends State<SchedulePositionList> {
         return eventsController.byId(eventId);
       });
 
-      viewController.visibleEvents.value = events.nonNulls.toSet();
+      // Only publish when the set actually changed. A ValueNotifier compares
+      // sets by identity, so assigning a fresh set every scroll frame would
+      // notify listeners on every frame even when the visible events are the
+      // same, causing needless rebuilds during a scroll or page change.
+      final visibleEvents = events.nonNulls.toSet();
+      if (!const SetEquality<CalendarEvent>().equals(viewController.visibleEvents.value, visibleEvents)) {
+        viewController.visibleEvents.value = visibleEvents;
+      }
     }
   }
 


### PR DESCRIPTION
## What

Two widgets published a brand-new `Set` to `visibleEvents` on a hot path. A
`ValueNotifier` compares sets by identity, so a fresh set instance notifies
listeners even when the contents are identical. That woke `visibleEvents`
listeners (for example the drag-target snap-point recompute) needlessly.

- **Schedule position listener** ran on every scroll frame and published a new
  set each frame. It now only publishes when the visible set actually differs.
- **Multi-day events widget** merged and published a new set in a per-build
  post-frame callback. It now only publishes when the merge adds something.

## Note on impact

This is correctness hygiene, not a frame-time win. Frame profiling did not show
a measurable build-time change from it (the guards were split out of the
frame-generator work precisely so each PR's rationale stays clear). The value is
that it stops spurious notifications that made `visibleEvents` listeners do
unnecessary work.

## Testing

- `flutter analyze` clean.
- Multi-day/schedule widget tests pass. No visible behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
