### PR TITLE
perf: optional keep-alive for multi-day pages

### DIFF
--- a/lib/src/models/view_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_view_configuration.dart
@@ -347,6 +347,17 @@ class MultiDayViewConfiguration extends ViewConfiguration {
 ///
 /// TODO: Depricate this in 1.0.0 and use [VerticalConfiguration] instead.
 class MultiDayBodyConfiguration extends VerticalConfiguration {
+  /// Whether to keep visited pages alive so navigating back to them does not
+  /// rebuild their content.
+  ///
+  /// Off by default. When enabled, each page you navigate to is cached and
+  /// reused, so navigating back to it is close to free instead of rebuilding
+  /// every event tile. The trade-off is memory: cached pages stay in memory for
+  /// the lifetime of the view, so this grows with the number of distinct pages
+  /// visited. Prefer it for views where the user moves back and forth between a
+  /// small set of pages.
+  final bool keepPagesAlive;
+
   /// Creates a new [MultiDayHeaderConfiguration].
   const MultiDayBodyConfiguration({
     super.showMultiDayEvents,
@@ -357,6 +368,7 @@ class MultiDayBodyConfiguration extends VerticalConfiguration {
     super.minimumTileHeight,
     super.pageTriggerConfiguration,
     super.scrollTriggerConfiguration,
+    this.keepPagesAlive = false,
   });
 
   /// Creates a copy of this [MultiDayBodyConfiguration] with the given fields replaced by the new values.
@@ -369,6 +381,7 @@ class MultiDayBodyConfiguration extends VerticalConfiguration {
     ScrollPhysics? scrollPhysics,
     ScrollPhysics? pageScrollPhysics,
     double? minimumTileHeight,
+    bool? keepPagesAlive,
   }) {
     return MultiDayBodyConfiguration(
       showMultiDayEvents: showMultiDayEvents ?? this.showMultiDayEvents,
@@ -379,6 +392,7 @@ class MultiDayBodyConfiguration extends VerticalConfiguration {
       scrollPhysics: scrollPhysics ?? this.scrollPhysics,
       pageScrollPhysics: pageScrollPhysics ?? this.pageScrollPhysics,
       minimumTileHeight: minimumTileHeight ?? this.minimumTileHeight,
+      keepPagesAlive: keepPagesAlive ?? this.keepPagesAlive,
     );
   }
 }

--- a/lib/src/widgets/multi_day/multi_day_body.dart
+++ b/lib/src/widgets/multi_day/multi_day_body.dart
@@ -270,7 +270,7 @@ class _MultiDayPageState extends State<MultiDayPage> {
       itemBuilder: (context, index) {
         // Calculate the visible date time range for the current page index.
         final visibleRange = _pageNavigation.dateTimeRangeFromIndex(index, context.location);
-        return Stack(
+        final page = Stack(
           key: MultiDayPage.contentKey,
           clipBehavior: Clip.none,
           children: [
@@ -304,7 +304,33 @@ class _MultiDayPageState extends State<MultiDayPage> {
             ),
           ],
         );
+
+        // Optionally keep the page alive so navigating back to it reuses its
+        // built content instead of rebuilding every tile.
+        return widget.configuration.keepPagesAlive ? _KeepAlivePage(child: page) : page;
       },
     );
+  }
+}
+
+/// Keeps its [child] alive within a lazily-built page view, so a page that
+/// scrolls out of view is not disposed and rebuilt when it comes back.
+class _KeepAlivePage extends StatefulWidget {
+  const _KeepAlivePage({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_KeepAlivePage> createState() => _KeepAlivePageState();
+}
+
+class _KeepAlivePageState extends State<_KeepAlivePage> with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.child;
   }
 }

--- a/test/configuration/config_copywith_test.dart
+++ b/test/configuration/config_copywith_test.dart
@@ -40,6 +40,7 @@ void main() {
         horizontalPadding: EdgeInsets.all(5),
         showMultiDayEvents: false,
         minimumTileHeight: 12,
+        keepPagesAlive: true,
       );
 
       test('preserves untouched fields when copying another', () {
@@ -47,11 +48,17 @@ void main() {
         expect(copy.horizontalPadding, const EdgeInsets.all(5));
         expect(copy.showMultiDayEvents, false);
         expect(copy.minimumTileHeight, 12);
+        expect(copy.keepPagesAlive, true);
       });
 
       test('updates the copied field', () {
         expect(config.copyWith(horizontalPadding: const EdgeInsets.all(9)).horizontalPadding, const EdgeInsets.all(9));
         expect(config.copyWith(minimumTileHeight: 30).minimumTileHeight, 30);
+        expect(config.copyWith(keepPagesAlive: false).keepPagesAlive, false);
+      });
+
+      test('keepPagesAlive defaults to false', () {
+        expect(const MultiDayBodyConfiguration().keepPagesAlive, false);
       });
     });
 


### PR DESCRIPTION
Adds an opt-in that targets the biggest cost in the multi-day body: **navigating
between pages** (building a fresh page of event tiles each time).

## What

`MultiDayBodyConfiguration.keepPagesAlive` (default `false`). When enabled, each
page you navigate to is kept alive (standard `AutomaticKeepAliveClientMixin`, which
the page view's `SliverChildBuilderDelegate` already honours), so navigating
**back** to a page reuses its built content instead of rebuilding every tile,
running finalize, and allocating (the three things the profiling showed dominate
a page change).

## Why opt-in

Kept-alive pages stay in memory for the lifetime of the view, so memory grows
with the number of distinct pages visited. It's best for views where the user
moves back and forth between a small set of pages. Off by default preserves
current behaviour.

```dart
CalendarBody(
  multiDayBodyConfiguration: MultiDayBodyConfiguration(keepPagesAlive: true),
)
```

## Testing

- `flutter analyze` clean.
- `copyWith` round-trip + default-false covered; existing multi-day widget tests pass.

## Note

Independent of the culling PR (#292). If both land, a follow-up should make the
culling's per-column scroll listener skip kept-alive pages that aren't the
current page, so off-screen cached pages don't recompute on every scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
