### PR TITLE
docs: add 0.19.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 0.19.1
+
+### Features
+
+- Added `MultiDayBodyConfiguration.keepPagesAlive` (default `false`). When enabled, each visited multi-day page is kept alive and reused, so navigating back to it skips rebuilding every event tile. It is opt-in because cached pages stay in memory for the lifetime of the view. [#293](https://github.com/werner-scholtz/kalender/pull/293)
+
+### Fixes
+
+- Fixed back-to-back events (one ending exactly when the next begins) rendering as overlapping at some zoom levels. An event's top and bottom now come from one shared time-to-pixel conversion, so touching tiles line up exactly instead of splitting on a rounding difference. [#291](https://github.com/werner-scholtz/kalender/pull/291)
+
+### Performance
+
+- Sped up multi-day frame generation. [#289](https://github.com/werner-scholtz/kalender/pull/289)
+- The `visibleEvents` notifier now only publishes when the set of visible events actually changes, avoiding redundant work for listeners. [#290](https://github.com/werner-scholtz/kalender/pull/290)
+- The day view now builds only the event tiles within the visible scroll window (plus an overscan margin) instead of every event of the day, and skips the resize-handle scaffolding when resizing is disabled. [#292](https://github.com/werner-scholtz/kalender/pull/292)
+
+### Tests
+
+- Added a regression sweep that back-to-back events stay in separate groups across a wide range of zoom levels, start offsets and durations. [#291](https://github.com/werner-scholtz/kalender/pull/291)
+- Added coverage that off-screen day tiles are culled and rebuilt when scrolled into view, and that a partially visible tile stays built. [#292](https://github.com/werner-scholtz/kalender/pull/292)
+
+### Internal
+
+- Removed the 60/120 fps budget lines from the benchmark dashboard, since the frame numbers come from a shared CI runner of unknown and varying spec. The millisecond charts now read as relative trends between commits. [#294](https://github.com/werner-scholtz/kalender/pull/294)
+- The demo-site deploy now preserves the `dev/bench` benchmark data.
+
 ## 0.19.0
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,6 @@
 - Added a regression sweep that back-to-back events stay in separate groups across a wide range of zoom levels, start offsets and durations. [#291](https://github.com/werner-scholtz/kalender/pull/291)
 - Added coverage that off-screen day tiles are culled and rebuilt when scrolled into view, and that a partially visible tile stays built. [#292](https://github.com/werner-scholtz/kalender/pull/292)
 
-### Internal
-
-- Removed the 60/120 fps budget lines from the benchmark dashboard, since the frame numbers come from a shared CI runner of unknown and varying spec. The millisecond charts now read as relative trends between commits. [#294](https://github.com/werner-scholtz/kalender/pull/294)
-- The demo-site deploy now preserves the `dev/bench` benchmark data.
-
 ## 0.19.0
 
 ### Breaking Changes


### PR DESCRIPTION
Adds the `## 0.19.1` changelog section covering the user-facing work merged
since the `v0.19.0` tag. Changelog only, no pubspec bump.

## What each entry covers

**Features**
- #293 keep-alive: `MultiDayBodyConfiguration.keepPagesAlive`

**Fixes**
- #291 back-to-back events no longer render as overlapping at some zooms

**Performance**
- #289 faster multi-day frame generation
- #290 `visibleEvents` only publishes when it changes
- #292 cull off-screen day tiles, skip resize handles when disabled

**Tests**
- #291 overlap-rounding regression sweep
- #292 off-screen tile culling coverage

## Notes

- Version is `0.19.1`, per this project's convention of patch bumps for
  additive features and fixes (breaking changes get the minor bump). Nothing
  here is breaking.
- The pubspec bump to 0.19.1 and the `v0.19.1` tag are a separate release step,
  matching how v0.19.0 was cut.
- Internal-only changes (benchmark dashboard #294, the `dev/bench` deploy) are
  left out on purpose, since pub.dev users do not need them.
- Issue #222 (performance when swiping) is deliberately not listed as fixed. It
  has been labeled `needs confirmation` pending a repro measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
