### PR TITLE
chore: release v0.19.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: This Flutter package offers a Calendar Widget featuring Day, MultiDay, Month and Schedule views. Moreover, it empowers you to tailor the visual aspects of the calendar widget.
-version: 0.19.0
+version: 0.19.1
 repository: https://github.com/werner-scholtz/kalender.git
 topics: 
   - calendar


### PR DESCRIPTION
Bumps `pubspec.yaml` from 0.19.0 to 0.19.1 for the release. The `## 0.19.1`
changelog section already landed in #295.

## How the publish works

Pushing a `v0.19.1` tag triggers `.github/workflows/publish.yml`, which runs
`flutter pub publish --force`. So the release happens in two steps:

1. Merge this PR so the bump is on `main`.
2. Tag `v0.19.1` on the resulting `main` commit and push the tag.

## Checks

- `flutter pub publish --dry-run` passes. The only warning was the uncommitted
  pubspec edit, which this commit resolves.

Publishing to pub.dev cannot be undone (a version number cannot be reused), so
I have not created or pushed the tag. Tell me once this is merged and I will
push the tag, or you can push it yourself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
