### PR TITLE
feat: render free-scroll multi-day events as a continuous band

### DIFF
--- a/lib/src/widgets/multi_day/multi_day_header.dart
+++ b/lib/src/widgets/multi_day/multi_day_header.dart
@@ -11,9 +11,12 @@ import 'package:kalender/src/widgets/internal_components/week_day_headers.dart';
 /// The multi-day header decides which header to display the:
 /// - [_SingleDayHeader] this is used for a body that only displays a single day.
 /// - [_MultiDayHeader] this is used for a body that displays multiple days.
-/// - [_FreeScrollHeader] this is a special case for a body that scrolls freely (WIP/Not working)
+/// - [_FreeScrollHeader] this is used for a body that scrolls freely.
 ///
-/// All Header widgets make use of the [ExpandablePageView] to set the Height of the header, this is so they can resize dynamically.
+/// The single-day and multi-day headers use an [ExpandablePageView] to size the
+/// header to the current page. The free-scroll header instead renders one
+/// continuous band (see [_FreeScrollMultiDayBand]) so multi-day events can span
+/// day columns.
 class MultiDayHeader extends StatelessWidget {
   /// The [MultiDayHeaderConfiguration] that will be used by the [MultiDayHeader].
   final HorizontalConfiguration? configuration;
@@ -218,7 +221,11 @@ class _MultiDayHeader extends StatelessWidget {
   }
 }
 
-/// TODO: Fix and Ensure this works.
+/// A header for the free-scroll body.
+///
+/// Unlike the paged headers, the multi-day events here are drawn as one
+/// continuous band (see [_FreeScrollMultiDayBand]) so an event spanning several
+/// days renders as a single tile instead of being split across per-day pages.
 class _FreeScrollHeader extends StatelessWidget {
   final MultiDayViewController viewController;
   final HorizontalConfiguration configuration;
@@ -233,8 +240,6 @@ class _FreeScrollHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final viewConfiguration = viewController.viewConfiguration;
-    final pageNavigation = viewConfiguration.pageIndexCalculator;
     final headerComponents = components.multiDayComponents.headerComponents;
     final componentStyles = components.multiDayComponentStyles.headerStyles;
 
@@ -242,63 +247,192 @@ class _FreeScrollHeader extends StatelessWidget {
     final weekNumberWidget = ValueListenableBuilder(
       valueListenable: context.calendarController.internalDateTimeRange,
       builder: (context, value, child) {
-        if (value == null) {
-          debugPrint('Warning: The visibleDateTimeRange is null in FreeScrollHeader.');
-          return const SizedBox.shrink();
-        }
+        if (value == null) return const SizedBox.shrink();
         return headerComponents.weekNumberBuilder.call(value.forLocation(location: context.location), weekNumberStyle);
       },
     );
 
     return MultiDayHeaderWidget(
-      /// TODO: figure out how to get multi-day events to work with FreeScroll.
-      ///
-      /// To do this the header would need to display a single page and not multiple. see viewport fraction.
-      content: ExpandablePageView(
-        key: ObjectKey(viewController.headerController),
-        controller: viewController.headerController,
-        itemCount: viewController.numberOfPages,
-        itemBuilder: (context, index) {
-          final visibleRange = pageNavigation.dateTimeRangeFromIndex(index, context.location);
-          final visibleDates = visibleRange.dates();
-
-          return Column(
-            children: [
-              WeekDayHeaders(
-                dates: visibleDates,
-                dayHeaderBuilder: DayHeader.fromContext,
-              ),
-              if (configuration.showTiles)
-                Stack(
-                  children: [
-                    Positioned.fill(child: MultiDayDraggable(internalRange: visibleRange)),
-                    ConstrainedBox(
-                      constraints: BoxConstraints(minHeight: configuration.tileHeight),
-                      child: MultiDayEventWidget(
-                        eventsController: context.eventsController,
-                        internalDateTimeRange: visibleRange,
-                        configuration: configuration,
-                        multiDayCache: viewController.multiDayCache,
-                        maxNumberOfVerticalEvents: null,
-                        overlayBuilders: headerComponents.overlayBuilders ?? components.overlayBuilders,
-                        overlayStyles: componentStyles.overlayStyles ?? components.overlayStyles,
-                      ),
-                    ),
-                    Positioned.fill(
-                      child: HorizontalDragTarget(
-                        visibleDateTimeRange: visibleRange,
-                        configuration: configuration,
-                        leftPageTrigger: headerComponents.leftTriggerBuilder,
-                        rightPageTrigger: headerComponents.rightTriggerBuilder,
-                      ),
-                    ),
-                  ],
-                ),
-            ],
-          );
-        },
+      content: _FreeScrollMultiDayBand(
+        viewController: viewController,
+        configuration: configuration,
+        components: components,
       ),
       leading: weekNumberWidget,
+    );
+  }
+}
+
+/// The continuous weekday-label and multi-day-event band for the free-scroll
+/// header.
+///
+/// The free-scroll body pages one day at a time (viewport fraction
+/// `1 / numberOfDays`), so a per-page multi-day band would clip each day and
+/// split a spanning event. Instead this renders the visible days (plus a buffer
+/// on each side) as one strip and slides it to follow the body's scroll, so a
+/// multi-day event is a single tile positioned across its day columns.
+///
+/// Only the visible window is rendered, so the strip stays small regardless of
+/// how large the display range is. The horizontal position is derived from
+/// [MultiDayViewController.pageOffset] and applied synchronously in [build], so
+/// re-anchoring the window and its offset compensation happen on the same frame
+/// (no visible jump).
+class _FreeScrollMultiDayBand extends StatefulWidget {
+  final MultiDayViewController viewController;
+  final HorizontalConfiguration configuration;
+  final CalendarComponents components;
+
+  const _FreeScrollMultiDayBand({
+    required this.viewController,
+    required this.configuration,
+    required this.components,
+  });
+
+  @override
+  State<_FreeScrollMultiDayBand> createState() => _FreeScrollMultiDayBandState();
+}
+
+class _FreeScrollMultiDayBandState extends State<_FreeScrollMultiDayBand> {
+  double _dayWidth = 0;
+  int _numberOfDays = 1;
+  int _numberOfPages = 1;
+
+  /// The absolute day index of the first day of the currently rendered window.
+  int? _domainStart;
+
+  /// Extra days rendered on each side of the visible window so tiles that scroll
+  /// in are already laid out.
+  int get _bufferDays => _numberOfDays;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.viewController.pageOffset.addListener(_maybeReanchor);
+  }
+
+  @override
+  void didUpdateWidget(covariant _FreeScrollMultiDayBand oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.viewController != widget.viewController) {
+      oldWidget.viewController.pageOffset.removeListener(_maybeReanchor);
+      widget.viewController.pageOffset.addListener(_maybeReanchor);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.viewController.pageOffset.removeListener(_maybeReanchor);
+    super.dispose();
+  }
+
+  /// The current leftmost visible day as a fractional absolute day index.
+  ///
+  /// Falls back to the view's initial page until the page controller is
+  /// attached, because it does not notify [MultiDayViewController.pageOffset] on
+  /// first attach.
+  double _currentPage() {
+    final controller = widget.viewController.pageController;
+    if (controller.hasClients && controller.positions.length == 1 && controller.position.hasPixels) {
+      return controller.page ?? widget.viewController.initialPage.toDouble();
+    }
+    return widget.viewController.initialPage.toDouble();
+  }
+
+  int _clampStart(int start) {
+    if (start < 0) return 0;
+    final maxStart = _numberOfPages - 1;
+    return start > maxStart ? maxStart : start;
+  }
+
+  /// Re-anchors the rendered window when the leftmost visible day changes. The
+  /// continuous motion itself is applied in [build], so there is nothing to
+  /// correct afterwards.
+  void _maybeReanchor() {
+    if (_dayWidth == 0) return;
+    final desiredStart = _clampStart(_currentPage().floor() - _bufferDays);
+    if (_domainStart == null || desiredStart != _domainStart) {
+      setState(() => _domainStart = desiredStart);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final viewController = widget.viewController;
+    final viewConfiguration = viewController.viewConfiguration;
+    final pageNavigation = viewConfiguration.pageIndexCalculator;
+    _numberOfDays = viewConfiguration.numberOfDays;
+    _numberOfPages = viewController.numberOfPages;
+
+    final headerComponents = widget.components.multiDayComponents.headerComponents;
+    final componentStyles = widget.components.multiDayComponentStyles.headerStyles;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final pageWidth = constraints.maxWidth;
+        final dayWidth = pageWidth / _numberOfDays;
+        _dayWidth = dayWidth;
+
+        final start = _domainStart ??= _clampStart(_currentPage().floor() - _bufferDays);
+        final maxCount = _numberOfPages - start;
+        final requested = _numberOfDays + 2 * _bufferDays;
+        final domainCount = requested > maxCount ? maxCount : (requested < 1 ? 1 : requested);
+
+        final rangeStart = pageNavigation.dateTimeRangeFromIndex(start, context.location).start;
+        final rangeEnd = pageNavigation.dateTimeRangeFromIndex(start + domainCount - 1, context.location).end;
+        final windowRange = InternalDateTimeRange(start: rangeStart, end: rangeEnd);
+        final windowDates = windowRange.dates();
+        final bandWidth = domainCount * dayWidth;
+
+        // Re-anchor once the real scroll position is known (the page controller
+        // may not be attached on the first frames).
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _maybeReanchor();
+        });
+
+        // Built once per window, not on every scroll frame.
+        final content = SizedBox(
+          width: bandWidth,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              WeekDayHeaders(dates: windowDates, dayHeaderBuilder: DayHeader.fromContext),
+              if (widget.configuration.showTiles)
+                ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: widget.configuration.tileHeight),
+                  child: MultiDayEventWidget(
+                    eventsController: context.eventsController,
+                    internalDateTimeRange: windowRange,
+                    configuration: widget.configuration,
+                    multiDayCache: viewController.multiDayCache,
+                    maxNumberOfVerticalEvents: null,
+                    overlayBuilders: headerComponents.overlayBuilders ?? widget.components.overlayBuilders,
+                    overlayStyles: componentStyles.overlayStyles ?? widget.components.overlayStyles,
+                  ),
+                ),
+            ],
+          ),
+        );
+
+        // A non-scrolling horizontal viewport sizes its height to the content,
+        // lets the strip exceed the viewport width, and clips. The strip is
+        // parked at offset 0; the translate below does the windowing. Computing
+        // the translate here (not in a post-frame callback) keeps it in lockstep
+        // with a re-anchor so pages do not flicker.
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          physics: const NeverScrollableScrollPhysics(),
+          child: ValueListenableBuilder<double>(
+            valueListenable: viewController.pageOffset,
+            child: content,
+            builder: (context, _, child) {
+              final maxTranslate = bandWidth - pageWidth;
+              final raw = (_currentPage() - start) * dayWidth;
+              final translate = maxTranslate <= 0 ? 0.0 : raw.clamp(0.0, maxTranslate);
+              return Transform.translate(offset: Offset(-translate, 0), child: child);
+            },
+          ),
+        );
+      },
     );
   }
 }

--- a/test/widgets/free_scroll_band_test.dart
+++ b/test/widgets/free_scroll_band_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/multi_day_tile.dart' show MultiDayEventTile;
+
+import '../utilities.dart';
+
+// The free-scroll header draws multi-day events as one continuous band. A
+// multi-day event should render as ONE tile spanning several day columns, and
+// stay a single tile that moves as the view scrolls, rather than being split
+// into one tile per day.
+void main() {
+  final start = DateTime(2025, 3, 24); // Monday
+  final displayRange = DateTimeRange(start: start, end: start.add(const Duration(days: 21)));
+
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  final components = TileComponents(
+    tileBuilder: (event, tileRange) => Container(key: ValueKey('inner-${event.id}')),
+  );
+
+  Future<void> pumpFreeScroll(WidgetTester tester) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: MultiDayViewConfiguration.freeScroll(
+          numberOfDays: 7,
+          displayRange: displayRange,
+          initialDateTime: start,
+          initialTimeOfDay: const TimeOfDay(hour: 0, minute: 0),
+        ),
+        header: CalendarHeader(multiDayTileComponents: components),
+        body: CalendarBody(multiDayTileComponents: components),
+      ),
+    );
+  }
+
+  MultiDayViewController viewController() => calendarController.viewController as MultiDayViewController;
+
+  testWidgets('a multi-day event renders as one continuous spanning tile', (tester) async {
+    // Monday 00:00 -> Friday 00:00, a 4-day span inside the first visible week.
+    final id = eventsController.addEvent(
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(start: start, end: start.add(const Duration(days: 4))),
+      ),
+    );
+
+    await pumpFreeScroll(tester);
+
+    final tile = find.byKey(MultiDayEventTile.tileKey(id));
+    final calWidth = tester.getSize(find.byType(CalendarView)).width;
+
+    expect(tile, findsOneWidget, reason: 'the multi-day event should be a single continuous tile');
+    final tileWidth = tester.getSize(tile).width;
+    // A single day column is ~calWidth/7. A spanning tile is clearly wider.
+    expect(tileWidth, greaterThan(calWidth * 0.22), reason: 'the tile should span more than one day column');
+    expect(tileWidth, lessThan(calWidth), reason: 'the tile should not fill the whole strip');
+  });
+
+  testWidgets('the spanning tile stays one tile and moves as the view scrolls', (tester) async {
+    final id = eventsController.addEvent(
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 4))),
+      ),
+    );
+
+    await pumpFreeScroll(tester);
+
+    final tile = find.byKey(MultiDayEventTile.tileKey(id));
+    expect(tile, findsOneWidget);
+    final leftBefore = tester.getTopLeft(tile).dx;
+
+    // Scroll the body forward by one day.
+    final pageController = viewController().pageController;
+    pageController.jumpToPage((pageController.page ?? 0).round() + 1);
+    await tester.pumpAndSettle();
+
+    expect(tile, findsOneWidget, reason: 'still a single tile after scrolling');
+    final leftAfter = tester.getTopLeft(tile).dx;
+    expect(leftAfter, lessThan(leftBefore), reason: 'the tile should move left as the view scrolls forward');
+  });
+
+  testWidgets('renders without blowing up on a multi-year display range', (tester) async {
+    // A large range would make a whole-range strip millions of pixels wide, so
+    // the band must window the days it renders.
+    final bigRange = DateTimeRange(start: DateTime(2018), end: DateTime(2036));
+    final id = eventsController.addEvent(
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(start: DateTime(2026, 7, 6), end: DateTime(2026, 7, 9)),
+      ),
+    );
+
+    await pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: MultiDayViewConfiguration.freeScroll(
+          numberOfDays: 3,
+          displayRange: bigRange,
+          initialDateTime: DateTime(2026, 7, 6),
+          initialTimeOfDay: const TimeOfDay(hour: 0, minute: 0),
+        ),
+        header: CalendarHeader(multiDayTileComponents: components),
+        body: CalendarBody(multiDayTileComponents: components),
+      ),
+    );
+
+    // No exception during layout, and the event near the initial date is built.
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(MultiDayEventTile.tileKey(id)), findsOneWidget);
+  });
+}

--- a/test/widgets/free_scroll_header_test.dart
+++ b/test/widgets/free_scroll_header_test.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
-import 'package:kalender/src/widgets/internal_components/expandable_page_view.dart' show ExpandablePageView;
 
 import '../utilities.dart';
 
+// The free-scroll header renders its multi-day events as one continuous band
+// (not a per-day page view). These regressions cover the two behaviours the old
+// paged header had to fight for and the band should get for free:
+//  - the header does not wobble (change height) when it rebuilds (#282), and
+//  - the header fits the tallest day currently in view, not just the leading
+//    day (#283).
 void main() {
   late DefaultEventsController eventsController;
   late CalendarController calendarController;
@@ -12,9 +17,6 @@ void main() {
 
   final tileComponents = TileComponents(
     tileBuilder: (event, tileRange) => Container(key: ValueKey(event.id), color: Colors.red),
-  );
-  final scheduleTileComponents = ScheduleTileComponents(
-    tileBuilder: (event, tileRange) => Container(key: ValueKey(event.id), color: Colors.blue),
   );
 
   setUp(() {
@@ -26,124 +28,75 @@ void main() {
     );
   });
 
+  final base = DateTime(2025, 3, 24); // Monday
+
+  // Two overlapping multi-day events: 26 Mar is a two-row day, its neighbours
+  // are single-row.
+  void addTwoRowDay() {
+    eventsController.addEvents([
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(start: base.add(const Duration(days: 1)), end: base.add(const Duration(days: 3))),
+      ),
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(start: base.add(const Duration(days: 2)), end: base.add(const Duration(days: 4))),
+      ),
+    ]);
+  }
+
+  Widget freeScrollView({DateTime? initialDate}) => CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: MultiDayViewConfiguration.freeScroll(
+          numberOfDays: 3,
+          initialDateTime: initialDate,
+          displayRange: DateTimeRange(start: base, end: base.add(const Duration(days: 21))),
+        ),
+        callbacks: callbacks,
+        header: CalendarHeader(multiDayTileComponents: tileComponents),
+        body: CalendarBody(multiDayTileComponents: tileComponents),
+      );
+
   group('FreeScroll header', () {
-    /// Rebuilds the [CalendarView] whenever [rebuild] changes so the test can
-    /// force the FreeScroll header to build again, mirroring what happens in a
-    /// real app whenever a calendar item changes.
-    Future<ValueNotifier<int>> pumpFreeScrollView(WidgetTester tester) async {
+    // Regression for #282: the old header reset its measured per-page heights on
+    // rebuild and visibly wobbled. The band's height is deterministic, so a
+    // rebuild must not change it.
+    testWidgets('does not change height when it rebuilds', (tester) async {
+      addTwoRowDay();
       final rebuild = ValueNotifier(0);
       addTearDown(rebuild.dispose);
-
-      // Kept stable across rebuilds (as a real app would cache it) so the view
-      // controller — and therefore the header controller — is not recreated;
-      // this isolates the header's own key handling as the only variable.
-      final viewConfiguration = MultiDayViewConfiguration.freeScroll(numberOfDays: 3);
 
       await pumpAndSettleWithMaterialApp(
         tester,
         ValueListenableBuilder(
           valueListenable: rebuild,
-          builder: (context, _, __) => CalendarView(
-            eventsController: eventsController,
-            calendarController: calendarController,
-            viewConfiguration: viewConfiguration,
-            callbacks: callbacks,
-            header: CalendarHeader(multiDayTileComponents: tileComponents),
-            body: CalendarBody(
-              multiDayTileComponents: tileComponents,
-              monthTileComponents: tileComponents,
-              scheduleTileComponents: scheduleTileComponents,
-            ),
-          ),
+          builder: (context, _, __) => freeScrollView(initialDate: base.add(const Duration(days: 2))),
         ),
       );
 
-      return rebuild;
-    }
-
-    // Regression for #282: the FreeScroll header used `key: UniqueKey()` on its
-    // `ExpandablePageView`, so every rebuild minted a new key and Flutter
-    // destroyed and recreated the page view's State — resetting its measured
-    // per-page heights and making the header visibly "wobble" whenever an item
-    // on the calendar changed. Keying on the stable header controller keeps the
-    // State alive across rebuilds.
-    testWidgets('preserves ExpandablePageView state across rebuilds', (tester) async {
-      final rebuild = await pumpFreeScrollView(tester);
-
-      final pageView = find.byType(ExpandablePageView);
-      expect(pageView, findsOneWidget, reason: 'FreeScroll header should render an ExpandablePageView');
-
-      final stateBefore = tester.state(pageView);
+      final heightBefore = tester.getSize(find.byType(CalendarHeader)).height;
 
       // Force the header to build again, as a calendar item change would.
       rebuild.value++;
       await tester.pumpAndSettle();
 
-      final stateAfter = tester.state(find.byType(ExpandablePageView));
-      expect(
-        identical(stateBefore, stateAfter),
-        isTrue,
-        reason: 'ExpandablePageView State must survive a header rebuild; a fresh '
-            'UniqueKey() each build would recreate it and reset measured heights.',
-      );
+      final heightAfter = tester.getSize(find.byType(CalendarHeader)).height;
+      expect(heightAfter, closeTo(heightBefore, 0.5), reason: 'the header must not wobble on rebuild');
     });
 
-    // Regression for the FreeScroll header clipping busier days: each day is its
-    // own page (viewportFraction 1/numberOfDays) and several are visible at once,
-    // but the header used to size itself to the *current* page only. A day with
-    // two stacked multi-day events was clipped whenever it was not the leading
-    // page. The header must instead fit the tallest day currently in view.
+    // Regression for #283: the header must fit the tallest day currently in
+    // view, regardless of whether it is the leading day.
     Future<double> pumpAndMeasureHeader(WidgetTester tester, DateTime initialDate) async {
-      // Fresh controllers per pump so each starts at its own initial date.
       eventsController = DefaultEventsController();
       calendarController = CalendarController();
-
-      final base = DateTime(2025, 3, 24); // Monday
-      // Two overlapping multi-day events give 25 Mar a single row, 26 Mar two
-      // rows (both events), and 27 Mar a single row.
-      eventsController.addEvents([
-        CalendarEvent(
-          dateTimeRange: DateTimeRange(
-            start: base.add(const Duration(days: 1)),
-            end: base.add(const Duration(days: 3)),
-          ),
-        ),
-        CalendarEvent(
-          dateTimeRange: DateTimeRange(
-            start: base.add(const Duration(days: 2)),
-            end: base.add(const Duration(days: 4)),
-          ),
-        ),
-      ]);
-
-      await pumpAndSettleWithMaterialApp(
-        tester,
-        CalendarView(
-          eventsController: eventsController,
-          calendarController: calendarController,
-          viewConfiguration: MultiDayViewConfiguration.freeScroll(
-            numberOfDays: 3,
-            initialDateTime: initialDate,
-            displayRange: DateTimeRange(start: base, end: base.add(const Duration(days: 21))),
-          ),
-          callbacks: callbacks,
-          header: CalendarHeader(multiDayTileComponents: tileComponents),
-          body: CalendarBody(
-            multiDayTileComponents: tileComponents,
-            monthTileComponents: tileComponents,
-            scheduleTileComponents: scheduleTileComponents,
-          ),
-        ),
-      );
-
-      return tester.getSize(find.byType(ExpandablePageView)).height;
+      addTwoRowDay();
+      await pumpAndSettleWithMaterialApp(tester, freeScrollView(initialDate: initialDate));
+      return tester.getSize(find.byType(CalendarHeader)).height;
     }
 
-    testWidgets('fits the tallest visible day, not just the leading page', (tester) async {
-      final base = DateTime(2025, 3, 24);
-      // 26 Mar (two rows) as the leading page.
+    testWidgets('fits the tallest visible day, not just the leading day', (tester) async {
+      // 26 Mar (two rows) as the leading day.
       final heightAsLeading = await pumpAndMeasureHeader(tester, base.add(const Duration(days: 2)));
-      // 26 Mar visible as a trailing page (leading is 25 Mar, a single row).
+      // 26 Mar visible as a trailing day (leading is 25 Mar, a single row).
       final heightAsTrailing = await pumpAndMeasureHeader(tester, base.add(const Duration(days: 1)));
       // A window of empty days for a single-row baseline.
       final heightEmpty = await pumpAndMeasureHeader(tester, base.add(const Duration(days: 12)));
@@ -151,13 +104,12 @@ void main() {
       expect(
         heightAsTrailing,
         greaterThan(heightEmpty),
-        reason: 'The header should grow to fit the two-row day while it is in view.',
+        reason: 'the header should grow to fit the two-row day while it is in view',
       );
       expect(
         heightAsTrailing,
         closeTo(heightAsLeading, 0.5),
-        reason: 'Header height must not depend on whether the tallest visible day '
-            'is the leading page; sizing to the current page only clips trailing days.',
+        reason: 'header height must not depend on whether the tallest visible day is the leading day',
       );
     });
   });


### PR DESCRIPTION
Makes multi-day events work in the free-scroll view (#78, #86). This is the
rendering half.

## The problem

The free-scroll header drew multi-day events inside a per-day page view. A
PageView clips each page, so an event spanning several days was cut at every day
boundary and split into separate tiles. The header was marked WIP and unusable
for multi-day events.

## The change

Render the weekday labels and the multi-day band as one continuous strip that
follows the body's scroll, reusing the existing multi-day layout delegate. A
spanning event is now a single tile positioned across its day columns.

- **Windowed.** Only the visible days plus a buffer are rendered, so the strip
  stays small no matter how large the display range is (the demo's ~18-year
  range would otherwise be millions of pixels wide).
- **No flicker.** The horizontal offset comes from the page offset and is applied
  in `build`, so re-anchoring the window and its offset compensation happen on
  the same frame. There is no post-frame correction to lag behind.
- **Correct initial position.** The band anchors to the view's `initialPage`
  until the page controller attaches, since it does not notify the page offset
  on first attach.

## Not in this PR (follow-up)

- Creating, dragging and resizing multi-day events in the header (the drag
  targets are not re-homed yet).
- Right-to-left support.

## Tests

- New `free_scroll_band_test.dart`: a multi-day event renders as one spanning
  tile, stays a single tile as the view scrolls, and a multi-year range does not
  blow up.
- `free_scroll_header_test.dart` rewritten for the band: no wobble on rebuild
  (#282) and fits the tallest visible day (#283).
- Full suite green (1224 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
