### PR TITLE
feat: viewport-anchored page-edge auto-scroll in the free-scroll header

### DIFF
--- a/lib/src/widgets/multi_day/multi_day_header.dart
+++ b/lib/src/widgets/multi_day/multi_day_header.dart
@@ -4,6 +4,7 @@ import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/drag_targets/horizontal_drag_target.dart';
 import 'package:kalender/src/widgets/draggable/multi_day_draggable.dart';
 import 'package:kalender/src/widgets/events_widgets/multi_day_events_widget.dart';
+import 'package:kalender/src/widgets/internal_components/cursor_navigation_trigger.dart';
 import 'package:kalender/src/widgets/internal_components/expandable_page_view.dart';
 import 'package:kalender/src/widgets/internal_components/multi_day_header_layout.dart';
 import 'package:kalender/src/widgets/internal_components/week_day_headers.dart';
@@ -419,8 +420,11 @@ class _FreeScrollMultiDayBandState extends State<_FreeScrollMultiDayBand> {
                       child: HorizontalDragTarget(
                         visibleDateTimeRange: windowRange,
                         configuration: widget.configuration,
-                        leftPageTrigger: headerComponents.leftTriggerBuilder,
-                        rightPageTrigger: headerComponents.rightTriggerBuilder,
+                        // The page-edge triggers are anchored to the viewport
+                        // below, not to this window-wide (translated) target,
+                        // so disable the built-in ones here.
+                        leftPageTrigger: (_) => const SizedBox.shrink(),
+                        rightPageTrigger: (_) => const SizedBox.shrink(),
                       ),
                     ),
                   ],
@@ -434,7 +438,7 @@ class _FreeScrollMultiDayBandState extends State<_FreeScrollMultiDayBand> {
         // parked at offset 0; the translate below does the windowing. Computing
         // the translate here (not in a post-frame callback) keeps it in lockstep
         // with a re-anchor so pages do not flicker.
-        return SingleChildScrollView(
+        final band = SingleChildScrollView(
           scrollDirection: Axis.horizontal,
           physics: const NeverScrollableScrollPhysics(),
           child: ValueListenableBuilder<double>(
@@ -447,6 +451,38 @@ class _FreeScrollMultiDayBandState extends State<_FreeScrollMultiDayBand> {
               return Transform.translate(offset: Offset(-translate, 0), child: child);
             },
           ),
+        );
+
+        if (!widget.configuration.showTiles) return band;
+
+        // Page-edge auto-scroll: while a drag hovers the viewport edge, advance
+        // to the adjacent day. These triggers are anchored to the viewport (not
+        // the translated strip), so they stay reachable at the visible edge.
+        final pageTrigger = widget.configuration.pageTriggerConfiguration;
+        final triggerWidth = pageWidth / 50;
+        Widget edgeTrigger({required bool leading}) {
+          final builder = leading ? headerComponents.leftTriggerBuilder : headerComponents.rightTriggerBuilder;
+          return CursorNavigationTrigger(
+            triggerDelay: pageTrigger.triggerDelay,
+            onTrigger: () => leading
+                ? viewController.animateToPreviousPage(
+                    duration: pageTrigger.animationDuration,
+                    curve: pageTrigger.animationCurve,
+                  )
+                : viewController.animateToNextPage(
+                    duration: pageTrigger.animationDuration,
+                    curve: pageTrigger.animationCurve,
+                  ),
+            child: builder?.call(pageWidth) ?? ConstrainedBox(constraints: BoxConstraints.expand(width: triggerWidth)),
+          );
+        }
+
+        return Stack(
+          children: [
+            band,
+            PositionedDirectional(start: 0, top: 0, bottom: 0, child: edgeTrigger(leading: true)),
+            PositionedDirectional(end: 0, top: 0, bottom: 0, child: edgeTrigger(leading: false)),
+          ],
         );
       },
     );

--- a/test/widgets/free_scroll_interaction_test.dart
+++ b/test/widgets/free_scroll_interaction_test.dart
@@ -30,6 +30,8 @@ void main() {
     modifyEventGesture: CreateEventGesture.tap,
   );
 
+  MultiDayViewController viewController() => calendarController.viewController as MultiDayViewController;
+
   Future<void> pumpFreeScroll(WidgetTester tester, CalendarCallbacks callbacks) {
     return pumpAndSettleWithMaterialApp(
       tester,
@@ -110,5 +112,43 @@ void main() {
 
     expect(changedBefore, isNotNull, reason: 'dragging a multi-day tile should reschedule it');
     expect(changedAfter, isNotNull, reason: 'the reschedule should be confirmed');
+  });
+
+  testWidgets('dragging an event to the viewport edge scrolls to adjacent days', (tester) async {
+    final id = eventsController.addEvent(
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 3))),
+      ),
+    );
+
+    await pumpFreeScroll(
+      tester,
+      CalendarCallbacks(
+        onEventChange: (event) => event,
+        onEventChanged: (_, __) {},
+      ),
+    );
+
+    final controller = viewController().pageController;
+    final pageBefore = controller.page ?? 0;
+
+    final tile = find.byKey(MultiDayEventTile.tileKey(id));
+    expect(tile, findsOneWidget);
+    final headerRect = tester.getRect(find.byType(CalendarHeader));
+    final tileCenter = tester.getCenter(tile);
+
+    // Start a reschedule drag and hold it over the right viewport edge.
+    final gesture = await tester.startGesture(tileCenter);
+    await tester.pump();
+    await gesture.moveTo(Offset(headerRect.right - 2, tileCenter.dy));
+    await tester.pump(); // the edge trigger's drag target starts its timer
+    // The trigger fires after its 750ms delay, then the page animates (300ms).
+    await tester.pump(const Duration(milliseconds: 800));
+    await tester.pump(const Duration(milliseconds: 350));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    final pageAfter = viewController().pageController.page ?? 0;
+    expect(pageAfter, greaterThan(pageBefore), reason: 'holding a drag at the edge should scroll toward it');
   });
 }


### PR DESCRIPTION
Follow-up on the free-scroll multi-day band. **Stacked on #298 (interaction) —
merge order #297, #298, then this.**

## The change

The multi-day drop target spans the rendered window (wider than the viewport),
so `HorizontalDragTarget`'s built-in page-edge triggers sat at the off-screen
window edges and never fired. Dragging an event to the visible edge did not
scroll to adjacent days.

- Disable the in-band triggers.
- Add viewport-anchored `CursorNavigationTrigger`s on top of the band (not
  translated with the strip), calling `animateToPreviousPage` / `animateToNextPage`.

Holding a drag at the visible edge now advances to the adjacent day, using the
same page-trigger configuration as the paged headers.

## Tests

- Dragging an event to the viewport edge scrolls the view toward it.
- Full suite green (1227 tests).

## Still pending

Right-to-left support (next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
