### PR TITLE
test: verify the free-scroll overflow portal and clarify headerController

### DIFF
--- a/lib/src/models/controllers/view_controllers/multi_day_view_controller.dart
+++ b/lib/src/models/controllers/view_controllers/multi_day_view_controller.dart
@@ -68,7 +68,11 @@ class MultiDayViewController extends ViewController {
   /// The page controller used by the view.
   late final LinkedPageController pageController;
 
-  /// The page controller used by the header. (Linked to [pageController])
+  /// The page controller for the paged single-day and multi-day headers, linked
+  /// to [pageController] so the header and body scroll together.
+  ///
+  /// The free-scroll header does not use it. It renders one continuous band and
+  /// derives its position from [pageOffset] instead.
   late final LinkedPageController headerController;
 
   /// The scroll controller used by the view.

--- a/test/widgets/free_scroll_overflow_test.dart
+++ b/test/widgets/free_scroll_overflow_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+// The "+N more" overflow portal must work inside the free-scroll band, which is
+// translated and clipped, not just in the paged headers.
+void main() {
+  final start = DateTime(2025, 3, 24); // Monday
+  final displayRange = DateTimeRange(start: start, end: start.add(const Duration(days: 21)));
+
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  final components = TileComponents(
+    tileBuilder: (event, tileRange) => Container(key: ValueKey('inner-${event.id}'), color: Colors.red),
+  );
+
+  const headerConfiguration = MultiDayHeaderConfiguration(maximumNumberOfVerticalEvents: 1);
+
+  Future<void> pumpFreeScroll(WidgetTester tester) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: MultiDayViewConfiguration.freeScroll(
+          numberOfDays: 7,
+          displayRange: displayRange,
+          initialDateTime: start,
+          initialTimeOfDay: const TimeOfDay(hour: 0, minute: 0),
+        ),
+        header: CalendarHeader(multiDayTileComponents: components, multiDayHeaderConfiguration: headerConfiguration),
+        body: CalendarBody(multiDayTileComponents: components),
+      ),
+    );
+  }
+
+  testWidgets('overflowing days show the "+N more" portal, which opens on tap', (tester) async {
+    // Two overlapping 2-day events. With a one-row limit the second overflows,
+    // so Mon and Tue each get a "+N more" portal.
+    eventsController.addEvents([
+      CalendarEvent(dateTimeRange: DateTimeRange(start: start, end: start.add(const Duration(days: 2)))),
+      CalendarEvent(dateTimeRange: DateTimeRange(start: start, end: start.add(const Duration(days: 2)))),
+    ]);
+
+    await pumpFreeScroll(tester);
+
+    // One row of events is shown, and the overflow portal/button render.
+    expect(find.byType(MultiDayOverlayPortal), findsWidgets, reason: 'overflow portals should render in the band');
+    expect(find.byType(MultiDayPortalOverlayButton), findsWidgets);
+
+    // Tapping the button for Monday opens the overlay.
+    final monday = InternalDateTime.fromDateTime(start);
+    final button = find.byKey(MultiDayPortalOverlayButton.getKey(monday));
+    expect(button, findsOneWidget);
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MultiDayOverlay), findsOneWidget, reason: 'tapping the button should open the overlay');
+  });
+}


### PR DESCRIPTION
Cleanup and verification for the free-scroll band. **Stacked on #300 — merge
last, after #297, #298, #299, #300.**

## Overflow portal

The "+N more" overflow portal is driven by the header configuration's
`maximumNumberOfVerticalEvents` (the band passes a null per-widget limit, which
falls back to the config). Added coverage that it renders and opens on tap
inside the translated, clipped band. It works, no code change needed.

## headerController

Considered removing the `headerController` for free scroll since the band does
not use it, but it is needed by the paged single-day and multi-day headers
(linked to `pageController`). Making it conditional would turn a non-null public
field nullable for a negligible gain, so instead its doc comment now explains
its purpose and that the free-scroll header derives its position from
`pageOffset`.

## Tests

Full suite green (1231 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
