### PR TITLE
ci: move GitHub actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/deploy_dashboard.yml
+++ b/.github/workflows/deploy_dashboard.yml
@@ -29,7 +29,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Deploy dashboard to gh-pages/dev/bench
         run: |

--- a/.github/workflows/flutter_analyze_and_test.yml
+++ b/.github/workflows/flutter_analyze_and_test.yml
@@ -15,7 +15,7 @@ jobs:
   analyze: # Separate job for analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
 
       - name: Remove examples folder.
@@ -51,7 +51,7 @@ jobs:
           'UTC'
         ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
 
       - name: Set Time Zone

--- a/.github/workflows/performance_profiling.yml
+++ b/.github/workflows/performance_profiling.yml
@@ -78,7 +78,7 @@ jobs:
             -d linux
 
       - name: Upload raw timelines
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: timelines-${{ github.run_number }}

--- a/.github/workflows/performance_profiling.yml
+++ b/.github/workflows/performance_profiling.yml
@@ -36,7 +36,7 @@ jobs:
       DISPLAY: :99
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
 
       - name: Install Linux dependencies
@@ -78,7 +78,7 @@ jobs:
             -d linux
 
       - name: Upload raw timelines
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: timelines-${{ github.run_number }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       # For Flutter package
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/web_demo.yml
+++ b/.github/workflows/web_demo.yml
@@ -15,7 +15,7 @@ jobs:
     if: contains(github.event.head_commit.message, 'web demo')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
       - run: flutter build web --release --wasm --base-href /kalender/
         shell: bash


### PR DESCRIPTION
## What

GitHub warns that some actions still run on the deprecated Node.js 20 runtime and are being forced onto Node.js 24:

> Warning: Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/upload-artifact@v4.

This bumps the GitHub-owned actions that triggered it to versions that run on Node.js 24 natively:

- `actions/checkout` to `v5` (workflows were a mix of `v3` and `v4`)
- `actions/upload-artifact` to `v6`

## Verifying it actually fixes the warning

I checked each action's `action.yml` runtime, not just the version number:

| Action | Runtime |
|--------|---------|
| `actions/checkout@v5` | `node24` |
| `actions/upload-artifact@v5` | `node20` |
| `actions/upload-artifact@v6` | `node24` |

`upload-artifact@v5` is still on Node.js 20, so it would not have cleared the warning. `v6` is the first release on Node.js 24, so the bump goes there.

Both are runtime-only changes. The `upload-artifact` inputs used here (`name`, `path`, `retention-days`) and the basic `checkout` have no breaking input changes, and the uploaded timelines artifact is only archived (30-day retention), not downloaded by a later step.

Third-party actions (`subosito/flutter-action`, `dart-lang/setup-dart`, `peaceiris/actions-gh-pages`, `benchmark-action/github-action-benchmark`) are left as they are. They were not named by the warning and have their own release cadences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
