### PR TITLE
refactor: share one scroll trigger helper

### DIFF
--- a/lib/src/widgets/drag_targets/schedule_drag_target.dart
+++ b/lib/src/widgets/drag_targets/schedule_drag_target.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/calendar_events/draggable_event.dart';
@@ -116,47 +118,36 @@ class _ScheduleDragTargetState extends State<ScheduleDragTarget> with DragTarget
         );
 
         final triggerHeight = scrollTrigger.triggerHeight?.call(viewPortHeight) ?? viewPortHeight / 20;
-        final topScrollTrigger = CursorNavigationTrigger(
-          triggerDelay: scrollTrigger.triggerDelay,
-          onTrigger: () {
-            if (!viewController.hasInitialized) return;
+        CursorNavigationTrigger scrollTrig(bool forward, VerticalTriggerWidgetBuilder? builder) {
+          return CursorNavigationTrigger.scroll(
+            configuration: scrollTrigger,
+            onTrigger: () {
+              if (!viewController.hasInitialized) return;
 
-            final positions = viewController.itemPositionsListener!.itemPositions.value;
-            if (positions.isEmpty) return;
-            final first = positions.reduce((value, element) => value.index < element.index ? value : element).index;
+              final positions = viewController.itemPositionsListener!.itemPositions.value;
+              if (positions.isEmpty) return;
 
-            final targetIndex = first - 1;
-            if (targetIndex < 0) return;
+              // The item nearest the edge we are scrolling toward, then one past it.
+              final indices = positions.map((position) => position.index);
+              final edge = forward ? indices.reduce(max) : indices.reduce(min);
+              final targetIndex = forward ? edge + 1 : edge - 1;
+              if (targetIndex < 0 || targetIndex >= viewController.itemCount) return;
 
-            viewController.itemScrollController!.scrollTo(
-              index: targetIndex,
-              duration: scrollTrigger.animationDuration,
-              curve: scrollTrigger.animationCurve,
-            );
-          },
-          child: widget.topScrollTrigger?.call(viewPortHeight) ?? SizedBox(height: triggerHeight, width: pageWidth),
-        );
+              viewController.itemScrollController!.scrollTo(
+                index: targetIndex,
+                duration: scrollTrigger.animationDuration,
+                curve: scrollTrigger.animationCurve,
+              );
+            },
+            viewPortHeight: viewPortHeight,
+            triggerHeight: triggerHeight,
+            width: pageWidth,
+            builder: builder,
+          );
+        }
 
-        final bottomScrollTrigger = CursorNavigationTrigger(
-          triggerDelay: scrollTrigger.triggerDelay,
-          onTrigger: () {
-            if (!viewController.hasInitialized) return;
-
-            final positions = viewController.itemPositionsListener!.itemPositions.value;
-            if (positions.isEmpty) return;
-
-            final last = positions.reduce((value, element) => value.index > element.index ? value : element).index;
-            final targetIndex = last + 1;
-            if (targetIndex >= viewController.itemCount) return;
-
-            viewController.itemScrollController!.scrollTo(
-              index: targetIndex,
-              duration: scrollTrigger.animationDuration,
-              curve: scrollTrigger.animationCurve,
-            );
-          },
-          child: widget.bottomScrollTrigger?.call(viewPortHeight) ?? SizedBox(height: triggerHeight, width: pageWidth),
-        );
+        final topScrollTrigger = scrollTrig(false, widget.topScrollTrigger);
+        final bottomScrollTrigger = scrollTrig(true, widget.bottomScrollTrigger);
 
         return Stack(
           children: [

--- a/lib/src/widgets/drag_targets/vertical_drag_target.dart
+++ b/lib/src/widgets/drag_targets/vertical_drag_target.dart
@@ -225,27 +225,23 @@ class _VerticalDragTargetState extends State<VerticalDragTarget> with SnapPoints
 
         final triggerHeight = scrollTrigger.triggerHeight?.call(viewPortHeight) ?? viewPortHeight / 20;
         final scrollAmount = scrollTrigger.scrollAmount?.call(viewPortHeight) ?? viewPortHeight / 2.5;
-        final topScrollTrigger = CursorNavigationTrigger(
-          triggerDelay: scrollTrigger.triggerDelay,
-          onTrigger: () => scrollController.animateTo(
-            scrollController.offset - scrollAmount,
-            duration: scrollTrigger.animationDuration,
-            curve: scrollTrigger.animationCurve,
-          ),
-          child:
-              components.topTriggerBuilder?.call(viewPortHeight) ?? SizedBox(height: triggerHeight, width: pageWidth),
-        );
+        CursorNavigationTrigger scrollTrig(bool forward, VerticalTriggerWidgetBuilder? builder) {
+          return CursorNavigationTrigger.scroll(
+            configuration: scrollTrigger,
+            onTrigger: () => scrollController.animateTo(
+              scrollController.offset + (forward ? scrollAmount : -scrollAmount),
+              duration: scrollTrigger.animationDuration,
+              curve: scrollTrigger.animationCurve,
+            ),
+            viewPortHeight: viewPortHeight,
+            triggerHeight: triggerHeight,
+            width: pageWidth,
+            builder: builder,
+          );
+        }
 
-        final bottomScrollTrigger = CursorNavigationTrigger(
-          triggerDelay: scrollTrigger.triggerDelay,
-          onTrigger: () => scrollController.animateTo(
-            scrollController.offset + scrollAmount,
-            duration: scrollTrigger.animationDuration,
-            curve: scrollTrigger.animationCurve,
-          ),
-          child: components.bottomTriggerBuilder?.call(viewPortHeight) ??
-              SizedBox(height: triggerHeight, width: pageWidth),
-        );
+        final topScrollTrigger = scrollTrig(false, components.topTriggerBuilder);
+        final bottomScrollTrigger = scrollTrig(true, components.bottomTriggerBuilder);
 
         return Stack(
           children: [

--- a/lib/src/widgets/internal_components/cursor_navigation_trigger.dart
+++ b/lib/src/widgets/internal_components/cursor_navigation_trigger.dart
@@ -55,6 +55,30 @@ class CursorNavigationTrigger extends StatefulWidget {
     );
   }
 
+  /// A scroll trigger that nudges the view along its scroll axis while a drag
+  /// hovers it.
+  ///
+  /// The actual scrolling is left to [onTrigger] because the body scrolls by
+  /// pixels while the schedule scrolls by item index. This only shares the
+  /// delay from [configuration] and the default strip ([triggerHeight] tall,
+  /// [width] wide) used when no [builder] is given.
+  factory CursorNavigationTrigger.scroll({
+    Key? key,
+    required ScrollTriggerConfiguration configuration,
+    required void Function() onTrigger,
+    required double viewPortHeight,
+    required double triggerHeight,
+    required double width,
+    VerticalTriggerWidgetBuilder? builder,
+  }) {
+    return CursorNavigationTrigger(
+      key: key,
+      triggerDelay: configuration.triggerDelay,
+      onTrigger: onTrigger,
+      child: builder?.call(viewPortHeight) ?? SizedBox(height: triggerHeight, width: width),
+    );
+  }
+
   @override
   State<CursorNavigationTrigger> createState() => _CursorNavigationTriggerState();
 }

--- a/test/widgets/scroll_trigger_test.dart
+++ b/test/widgets/scroll_trigger_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/day_tile.dart' show DayEventTile;
+
+import '../utilities.dart';
+
+// The body's top/bottom scroll triggers are built through
+// CursorNavigationTrigger.scroll (the shared helper for the body and schedule
+// scroll triggers). Holding a drag at the top or bottom edge must still scroll
+// the body vertically, the same as before the helper existed.
+void main() {
+  final start = DateTime(2025, 3, 24); // Monday
+
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  final components = TileComponents(
+    tileBuilder: (event, tileRange) => Container(key: ValueKey('inner-${event.id}'), color: Colors.red),
+  );
+
+  final precise = CalendarInteraction(
+    inputMode: InputMode.precise,
+    createEventGesture: CreateEventGesture.tap,
+    modifyEventGesture: CreateEventGesture.tap,
+  );
+
+  MultiDayViewController viewController() => calendarController.viewController as MultiDayViewController;
+
+  // Align the top of the viewport with [hour] so each test starts with room to
+  // scroll in the direction it drags.
+  Future<void> pumpWeek(WidgetTester tester, int hour) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: MultiDayViewConfiguration.week(
+          displayRange: DateTimeRange(start: start, end: start.add(const Duration(days: 7))),
+          initialDateTime: start,
+          initialTimeOfDay: TimeOfDay(hour: hour, minute: 0),
+        ),
+        body: CalendarBody(multiDayTileComponents: components, interaction: precise),
+      ),
+    );
+  }
+
+  // Drag [tile] from its center to [target] in steps so the edge trigger
+  // registers a drag-enter (a single jump past it does not) and starts its
+  // timer, hold long enough for the scroll to run, then release.
+  Future<void> dragTo(WidgetTester tester, Finder tile, Offset target) async {
+    final tileCenter = tester.getCenter(tile);
+    final gesture = await tester.startGesture(tileCenter);
+    await tester.pump();
+    await gesture.moveTo(Offset(tileCenter.dx, (tileCenter.dy + target.dy) / 2));
+    await tester.pump();
+    await gesture.moveTo(target);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 800));
+    await tester.pump(const Duration(milliseconds: 250));
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('holding a drag at the bottom edge scrolls the body down', (tester) async {
+    // Start at the top of the day so the whole day is below and there is room
+    // to scroll down. The event sits just below the top edge, so it is visible.
+    final eventStart = start.add(const Duration(hours: 1));
+    final id = eventsController.addEvent(
+      CalendarEvent(dateTimeRange: DateTimeRange(start: eventStart, end: eventStart.add(const Duration(hours: 1)))),
+    );
+
+    await pumpWeek(tester, 0);
+    final offsetBefore = viewController().scrollController.offset;
+
+    final tile = find.byKey(DayEventTile.tileKey(id));
+    expect(tile, findsOneWidget);
+    final bodyRect = tester.getRect(find.byType(CalendarBody));
+    await dragTo(tester, tile, Offset(tester.getCenter(tile).dx, bodyRect.bottom - 2));
+
+    expect(
+      viewController().scrollController.offset,
+      greaterThan(offsetBefore),
+      reason: 'holding a drag at the bottom edge should scroll the body down',
+    );
+  });
+
+  testWidgets('holding a drag at the top edge scrolls the body up', (tester) async {
+    // Start at midday so the morning is above and there is room to scroll up.
+    final eventStart = start.add(const Duration(hours: 12));
+    final id = eventsController.addEvent(
+      CalendarEvent(dateTimeRange: DateTimeRange(start: eventStart, end: eventStart.add(const Duration(hours: 1)))),
+    );
+
+    await pumpWeek(tester, 12);
+    final offsetBefore = viewController().scrollController.offset;
+    expect(offsetBefore, greaterThan(0), reason: 'midday start should leave room to scroll up');
+
+    final tile = find.byKey(DayEventTile.tileKey(id));
+    expect(tile, findsOneWidget);
+    final bodyRect = tester.getRect(find.byType(CalendarBody));
+    await dragTo(tester, tile, Offset(tester.getCenter(tile).dx, bodyRect.top + 2));
+
+    expect(
+      viewController().scrollController.offset,
+      lessThan(offsetBefore),
+      reason: 'holding a drag at the top edge should scroll the body up',
+    );
+  });
+}


### PR DESCRIPTION
Follow-up to #302, which unified the page-edge triggers and deliberately left the scroll triggers alone. This does the same for them.

## What

The body (`vertical_drag_target.dart`) and the schedule (`schedule_drag_target.dart`) each built their top and bottom scroll triggers by hand, and within each file the two differed only by direction.

- Add a `CursorNavigationTrigger.scroll` factory, a sibling to `.page`, that holds the shared delay and the default edge strip.
- The scroll action stays with the caller, because the body scrolls by pixels (`ScrollController.animateTo`) while the schedule scrolls by item index (`itemScrollController.scrollTo`). Forcing those together would add a layer without removing duplication.
- In each file the top and bottom triggers now come from one direction-parameterized helper, so the scroll logic is written once instead of twice.
- The schedule's edge-item lookup reads clearer as `min`/`max` over the item indices.

No behaviour or public API change.

## Tests

- New `test/widgets/scroll_trigger_test.dart` drags a body event to the top and bottom edges and checks the body scrolls the right way, covering the `.scroll` factory and the body's direction-collapse.
- Full suite green (1237), `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
