### PR TITLE
docs: changelog and readme for the 0.20.0 changes so far

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 ## 0.20.0
 
+### Features
+
+- Multi-day and all-day events now render in the free-scroll view as a single tile spanning the day columns, instead of being split at each page boundary. They support the same interactions as the paged headers: create by dragging across the header, reschedule, resize, auto-scroll when a drag reaches the viewport edge, right-to-left layout, and the "+N more" overflow. [#78](https://github.com/werner-scholtz/kalender/issues/78) [#297](https://github.com/werner-scholtz/kalender/pull/297) [#298](https://github.com/werner-scholtz/kalender/pull/298) [#299](https://github.com/werner-scholtz/kalender/pull/299) [#300](https://github.com/werner-scholtz/kalender/pull/300) [#301](https://github.com/werner-scholtz/kalender/pull/301)
+
 ### Fixes
 
+- `PageTriggerConfiguration.triggerWidth` is now applied. It was accepted but ignored, and `copyWith` dropped it, so the edge strip that starts a page change while dragging was always `pageWidth / 50`. That is still the default, but it can now be set. [#302](https://github.com/werner-scholtz/kalender/pull/302)
 - Fixed free-scroll multi-day events disappearing after scrolling back to a day before the event's start. The multi-day layout cache is keyed by date range and is shared across the free-scroll band's moving window, so a window cached before an event existed kept returning an event-less frame. Changing events now clears the whole cache instead of only the visible window. [#306](https://github.com/werner-scholtz/kalender/pull/306)
 - Fixed an event jumping to a neighbouring day when resizing it by its top or bottom edge. The resize handle anchored the drag to the column's edge, so the smallest sideways movement flipped the day. It now follows the pointer, so a small drift no longer changes the day while a deliberate drag across columns still does. [#312](https://github.com/werner-scholtz/kalender/pull/312)
 
 ### Tests
 
+- Added free-scroll multi-day coverage: spanning tiles render as one tile and stay single while scrolling, create-by-drag, reschedule and edge auto-scroll work in the band, right-to-left renders and scrolls the right way, and the "+N more" overflow opens. [#297](https://github.com/werner-scholtz/kalender/pull/297) [#298](https://github.com/werner-scholtz/kalender/pull/298) [#300](https://github.com/werner-scholtz/kalender/pull/300) [#301](https://github.com/werner-scholtz/kalender/pull/301)
+- Added coverage that dragging an event to the viewport edge advances the page in the paged header and body, and scrolls the body vertically. [#302](https://github.com/werner-scholtz/kalender/pull/302) [#304](https://github.com/werner-scholtz/kalender/pull/304)
 - Added coverage that a free-scroll multi-day event stays visible when scrolling back to windows that were cached before the event was created. [#306](https://github.com/werner-scholtz/kalender/pull/306)
 - Added coverage that resizing an event's bottom edge with a small horizontal drift keeps it on its own day. [#312](https://github.com/werner-scholtz/kalender/pull/312)
 

--- a/README.md
+++ b/README.md
@@ -274,12 +274,13 @@ MultiDayViewConfiguration.week(
 ### MultiDay View
 Displays one or more days with time on the vertical axis.
 
-| Constructor                                         | Description           |
-| --------------------------------------------------- | --------------------- |
-| `MultiDayViewConfiguration.singleDay()`             | Single day            |
-| `MultiDayViewConfiguration.week()`                  | Full 7-day week       |
-| `MultiDayViewConfiguration.workWeek()`              | Monday to Friday      |
-| `MultiDayViewConfiguration.custom(numberOfDays: n)` | Custom number of days |
+| Constructor                                             | Description                                    |
+| -------------------------------------------------------- | ---------------------------------------------- |
+| `MultiDayViewConfiguration.singleDay()`                  | Single day                                     |
+| `MultiDayViewConfiguration.week()`                       | Full 7-day week                                |
+| `MultiDayViewConfiguration.workWeek()`                   | Monday to Friday                               |
+| `MultiDayViewConfiguration.custom(numberOfDays: n)`      | Custom number of days                          |
+| `MultiDayViewConfiguration.freeScroll(numberOfDays: n)`  | Scrolls freely across days, without page snaps |
 
 ### Month View
 Shows an entire month at a glance, weeks as rows.


### PR DESCRIPTION
Records the user-facing changes merged since v0.19.1, ready for the next release. Rebased onto main, which already carried the changelog entries for the free-scroll cache fix (#306) and the vertical resize fix (#312). This PR fills in the rest of the `## 0.20.0` section around them.

## Changelog additions

**Features**
- Free-scroll multi-day and all-day event support: spanning events render as one continuous tile across the day columns instead of splitting at each page edge, with create-by-drag, reschedule, resize, edge auto-scroll, right-to-left, and the "+N more" overflow. (#78, #297–#301)

**Fixes**
- `PageTriggerConfiguration.triggerWidth` is now applied instead of ignored, so the drag-to-navigate edge width is configurable (still defaults to `pageWidth / 50`). (#302)

**Tests**
- Free-scroll multi-day coverage, and coverage that dragging to the viewport edge advances the page / scrolls the body. (#297–#301, #302, #304)

Already on main (kept as-is): the #306 and #312 fix and test entries.

## Readme

- Added `MultiDayViewConfiguration.freeScroll(numberOfDays: n)` to the MultiDay view constructor table. It was missing entirely, and 0.20.0 is the release that makes it feature-complete.

## Left out on purpose

Internal or demo-only work that pub.dev users do not need: the CI Node.js runtime bump (#303), skipping the bench on demo rebuilds (#310), the web demo tweaks (#307, #308, #309, #311), the trigger-helper refactors themselves, and the web-demo rebuild commits.

No pubspec bump. The version bump is a separate step at release time, matching how 0.19.1 was handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
