### PR TITLE
fix: keep free-scroll multi-day events visible after scrolling back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.20.0
+
+### Fixes
+
+- Fixed free-scroll multi-day events disappearing after scrolling back to a day before the event's start. The multi-day layout cache is keyed by date range and is shared across the free-scroll band's moving window, so a window cached before an event existed kept returning an event-less frame. Changing events now clears the whole cache instead of only the visible window. [#306](https://github.com/werner-scholtz/kalender/pull/306)
+
+### Tests
+
+- Added coverage that a free-scroll multi-day event stays visible when scrolling back to windows that were cached before the event was created. [#306](https://github.com/werner-scholtz/kalender/pull/306)
+
 ## 0.19.1
 
 ### Features

--- a/examples/web_demo/lib/models/demo_configuration.dart
+++ b/examples/web_demo/lib/models/demo_configuration.dart
@@ -38,7 +38,7 @@ class DemoConfiguration extends ChangeNotifier {
     MonthViewConfiguration.singleMonth(displayRange: _displayRange),
     ScheduleViewConfiguration.continuous(name: "Schedule", displayRange: _displayRange),
     ScheduleViewConfiguration.paginated(name: "Paginated Schedule", displayRange: _displayRange),
-    MultiDayViewConfiguration.freeScroll(numberOfDays: 3, name: "FreeScroll (WIP)", displayRange: _displayRange),
+    MultiDayViewConfiguration.freeScroll(numberOfDays: 3, name: "FreeScroll", displayRange: _displayRange),
   ];
 
   /// The body configuration of the calendar.

--- a/lib/src/widgets/events_widgets/multi_day_events_widget.dart
+++ b/lib/src/widgets/events_widgets/multi_day_events_widget.dart
@@ -240,7 +240,13 @@ class _MultiDayEventLayoutWidgetState extends State<MultiDayEventLayoutWidget> {
       _dateTimeRange = widget.internalDateTimeRange;
 
       if (shouldUpdateCache) {
-        widget.multiDayCache?.removeCache(_dateTimeRange);
+        // The events, configuration, and text direction apply to every range,
+        // not just the current one, so a change invalidates every cached frame.
+        // The paged headers rebuild each range in its own widget, but the
+        // free-scroll band is a single widget whose range moves as it scrolls.
+        // Dropping only the current range would leave stale frames for the
+        // windows it scrolls back to, so clear the whole cache.
+        widget.multiDayCache?.clearAll();
       }
 
       setState(() {

--- a/test/widgets/free_scroll_cache_invalidation_test.dart
+++ b/test/widgets/free_scroll_cache_invalidation_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/multi_day_tile.dart' show MultiDayEventTile;
+
+import '../utilities.dart';
+
+// The free-scroll header renders multi-day events as one continuous band whose
+// range moves as it scrolls, sharing a single layout-frame cache across every
+// window it visits. The cache is keyed only by date range, so when the events
+// change it must be cleared for every window, not just the one on screen.
+//
+// Regression: a window rendered (and cached) before an event existed used to
+// keep returning its event-less frame. Scrolling back to that window after
+// creating the event made the event vanish, even though it clearly covered the
+// visible days.
+void main() {
+  final displayRange = DateTimeRange(start: DateTime(2018), end: DateTime(2036));
+  final initial = DateTime(2026, 7, 10);
+
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  final components = TileComponents(
+    tileBuilder: (event, tileRange) => Container(key: ValueKey('inner-${event.id}')),
+  );
+
+  Future<void> pumpFreeScroll(WidgetTester tester) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: MultiDayViewConfiguration.freeScroll(
+          numberOfDays: 3,
+          displayRange: displayRange,
+          initialDateTime: initial,
+          initialTimeOfDay: const TimeOfDay(hour: 0, minute: 0),
+        ),
+        header: CalendarHeader(multiDayTileComponents: components),
+        body: CalendarBody(multiDayTileComponents: components),
+      ),
+    );
+  }
+
+  MultiDayViewController viewController() => calendarController.viewController as MultiDayViewController;
+
+  testWidgets('multi-day event stays visible when scrolling back to windows cached before it existed', (tester) async {
+    await pumpFreeScroll(tester);
+
+    // Scroll back then forward so the earlier windows get rendered and cached
+    // while no event exists yet, mirroring creating the event after opening the
+    // view.
+    final pageController = viewController().pageController;
+    final base = (pageController.page ?? 0).round();
+    pageController.jumpToPage(base - 2);
+    await tester.pumpAndSettle();
+    pageController.jumpToPage(base);
+    await tester.pumpAndSettle();
+
+    // A three-day event starting on the initial leading day.
+    final id = eventsController.addEvent(
+      CalendarEvent(dateTimeRange: DateTimeRange(start: initial, end: initial.add(const Duration(days: 3)))),
+    );
+    await tester.pumpAndSettle();
+
+    final tile = MultiDayEventTile.tileKey(id);
+    expect(find.byKey(tile), findsOneWidget, reason: 'visible at the initial position');
+
+    // Scroll back through the previously-cached windows. The event still covers
+    // the visible days, so its tile must stay on screen.
+    pageController.jumpToPage(base - 1);
+    await tester.pumpAndSettle();
+    expect(find.byKey(tile), findsOneWidget, reason: 'still visible one day back');
+
+    pageController.jumpToPage(base - 2);
+    await tester.pumpAndSettle();
+    expect(find.byKey(tile), findsOneWidget, reason: 'still visible two days back');
+  });
+}


### PR DESCRIPTION
## What

In the free-scroll multi-day view, a multi-day event could disappear when scrolling back to a day before its start. See the reported case: an event starting on the leading day stays visible, but scrolling back one or two days (so it starts on the second or third visible day) dropped it.

## Why

The multi-day layout frame cache (`MultiDayLayoutFrameCache`) is keyed only by the date range. The paged headers build a separate widget per page, so each range's cache self-heals when events change. The free-scroll band is a single widget whose range moves as it scrolls, reusing the cache across every window it visits.

When events changed we only invalidated the cache for the window currently on screen. Windows that were rendered (and cached) before an event existed kept returning their event-less frames. Scrolling back to one of those windows hit the stale frame and the event vanished, even though it clearly covered the visible days.

The events, configuration, and text direction all apply to every range, so a change to any of them invalidates every cached frame. The fix clears the whole cache instead of just the current range.

## Also

- Dropped the "(WIP)" suffix from the web demo's FreeScroll view name, since the feature is mostly done.

## Tests

- Added `free_scroll_cache_invalidation_test.dart`: renders and caches earlier windows before an event exists, creates the event, then scrolls back through those windows and asserts the tile stays visible. Fails without the fix.
- Full suite (1238 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGQfp2GRmS726LQ4tMPFV