### PR TITLE
demo: stop the navigation buttons jumping when paging

### DIFF
--- a/examples/web_demo/lib/widgets/calendar/navigation_header.dart
+++ b/examples/web_demo/lib/widgets/calendar/navigation_header.dart
@@ -41,7 +41,12 @@ class NavigationHeader extends StatelessWidget {
           child: Row(
             spacing: isTouch ? 2.0 : 4.0,
             children: [
+              // The date label sits alone on the left, before the Spacer, so
+              // navigating (which only changes its text) grows it into empty
+              // space instead of pushing the buttons around. The navigation
+              // controls live in the right-hand cluster.
               HeaderDateButton(controller: controller, compact: maxW < 500),
+              const Spacer(),
               if (showNav) ...[
                 IconButton(
                   icon: const Icon(Icons.chevron_left),
@@ -55,7 +60,6 @@ class NavigationHeader extends StatelessWidget {
                 ),
               ],
               if (!isTouch) TodayButton(controller: controller, compact: isCompact),
-              const Spacer(),
               if (showLocation) LocationMenu(useChips: useChips),
               ViewMenu(
                 viewConfigurations: viewConfigurations,


### PR DESCRIPTION
## What

In the web demo's toolbar, the previous / next / today buttons shifted sideways every time you paged, because the date label next to them changed width (short month names like "May 2026" versus long ones like "September 2026").

## Why

`HeaderDateButton` was the first item in the toolbar row and sized to its own text. Paging only changes that label, but because it sat before the navigation buttons, its width change pushed them along.

## Fix

Move the navigation controls (prev, next, today) into the right-hand cluster with the other tools, and leave the date label alone on the left before the `Spacer`. Paging now grows the label into empty space, so the buttons stay put. This also matches the common layout of a page title on the left and controls grouped on the right.

Note: changing the timezone or view can still nudge the navigation group slightly, since those labels share the right cluster, but paging (the reported problem) no longer moves them.

Demo-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGQfp2GRmS726LQ4tMPFV