### PR TITLE
demo: keep short event titles legible at the default zoom

### DIFF
--- a/examples/web_demo/lib/utils.dart
+++ b/examples/web_demo/lib/utils.dart
@@ -89,8 +89,9 @@ List<CalendarEvent> generateEvents(BuildContext context) {
     final isWeekend = weekday == DateTime.saturday || weekday == DateTime.sunday;
 
     if (!isWeekend) {
-      // The daily standup anchors every weekday morning.
-      events.add(timed(day, 9, 0, const Duration(minutes: 15), 'Daily standup', _standupColor));
+      // The daily standup anchors every weekday morning. Kept at 30 minutes so
+      // its title stays legible at the default zoom.
+      events.add(timed(day, 9, 0, const Duration(minutes: 30), 'Daily standup', _standupColor));
 
       // A weekly rhythm that repeats on the same day each week.
       if (weekday == DateTime.monday) {

--- a/examples/web_demo/lib/widgets/calendar/event_tiles.dart
+++ b/examples/web_demo/lib/widgets/calendar/event_tiles.dart
@@ -45,7 +45,7 @@ class EventTile extends BaseEventTile {
         border: Border(left: BorderSide(color: color, width: 3)),
       ),
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
         child: Text(
           title(context),
           style: TextStyle(color: color, fontSize: 12, fontWeight: FontWeight.w500),


### PR DESCRIPTION
## What

In the demo, the daily standup's title was invisible at the default zoom.

## Why

The default zoom is `0.7` pixels per minute, so a 15-minute event is only about 10px tall. The timed-event tile's 4px top and bottom padding used up ~8px of that, leaving no room for the 12px title.

## Fix

- Bump the standup from 15 to 30 minutes (still a normal length), so it renders ~21px tall.
- Trim the timed-event tile's vertical padding from 4 to 2, so a 30-minute tile fits its one-line title and short events read better in general.

The shortest event in the demo is now 30 minutes, which is legible at the default zoom.

Demo-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGQfp2GRmS726LQ4tMPFV