### PR TITLE
ci: don't run the performance bench for demo rebuilds

### DIFF
--- a/.github/workflows/performance_profiling.yml
+++ b/.github/workflows/performance_profiling.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches: [main]
     # Skip benchmark rebuilds for changes that cannot move the numbers (the static
-    # dashboard page, its deploy workflow, and docs) so history stays meaningful.
+    # dashboard page, its deploy workflow, the web demo, and docs) so history
+    # stays meaningful. The `examples/testing` harness that the frame profiling
+    # drives is deliberately not ignored.
     paths-ignore:
       - 'benchmark/dashboard/**'
       - '.github/workflows/deploy_dashboard.yml'
+      - 'examples/web_demo/**'
       - '**/*.md'
   # PRs only run when labelled `profile` (see the job-level `if` below), so this
   # does not run for every PR.
@@ -29,7 +32,12 @@ concurrency:
 
 jobs:
   benchmark:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'profile')
+    # Empty "web demo" rebuild commits change no files, so the path filter above
+    # does not catch them. Skip those pushes here too.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && !contains(github.event.head_commit.message, 'web demo')) ||
+      contains(github.event.pull_request.labels.*.name, 'profile')
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
## What

The performance benchmark ran on every push to `main`, including web-demo changes and the empty "web demo" rebuild commit, neither of which can move the library's benchmark numbers.

## Fix

- Add `examples/web_demo/**` to the workflow's `paths-ignore`, so merging a demo-only change no longer runs the bench. The `examples/testing` harness that the frame profiling drives is deliberately left out of the ignore list, so changes to it still run.
- Skip pushes whose head commit message contains "web demo". The rebuild is an empty commit that changes no files, so the path filter alone does not catch it.

Non-demo pushes to `main`, labelled `profile` PRs, and manual `workflow_dispatch` runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGQfp2GRmS726LQ4tMPFV