### PR TITLE
demo: modernize the web bootstrap in index.html

### DIFF
--- a/examples/web_demo/web/index.html
+++ b/examples/web_demo/web/index.html
@@ -31,29 +31,8 @@
 
   <title>web_demo</title>
   <link rel="manifest" href="manifest.json">
-
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    const serviceWorkerVersion = null;
-  </script>
-  <!-- This script adds the flutter initialization JS code -->
-  <script src="flutter.js" defer></script>
 </head>
 <body>
-  <script>
-    window.addEventListener('load', function(ev) {
-      // Download main.dart.js
-      _flutter.loader.loadEntrypoint({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        },
-        onEntrypointLoaded: function(engineInitializer) {
-          engineInitializer.initializeEngine().then(function(appRunner) {
-            appRunner.runApp();
-          });
-        }
-      });
-    });
-  </script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
## What

The web demo build printed two deprecation warnings:

```
Warning: In index.html:37: Flutter's service worker is deprecated and will be removed in a future Flutter release.
Warning: In index.html:46: "FlutterLoader.loadEntrypoint" is deprecated. Use "FlutterLoader.load" instead.
```

## Fix

Replace the hand-written loader (the `serviceWorkerVersion` script and the `_flutter.loader.loadEntrypoint(...)` block) with the generated `flutter_bootstrap.js`, which is the current Flutter web entry point. This drops both deprecated APIs.

Verified with `flutter build web`: it builds and the two warnings are gone.

Demo-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGQfp2GRmS726LQ4tMPFV