### PR TITLE
chore: release v0.20.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: This Flutter package offers a Calendar Widget featuring Day, MultiDay, Month and Schedule views. Moreover, it empowers you to tailor the visual aspects of the calendar widget.
-version: 0.19.1
+version: 0.20.0
 repository: https://github.com/werner-scholtz/kalender.git
 topics: 
   - calendar


### PR DESCRIPTION
Bump the version to 0.20.0 for release. After this merges, tagging the merge commit `v0.20.0` triggers the pub.dev publish workflow.

Pre-release checks on this branch:
- `flutter analyze`: no issues
- `flutter test`: all 1239 tests pass
- `flutter pub publish --dry-run`: 0 warnings

The changelog and readme were already prepared in #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)