### PR TITLE
feat: copyWith, merge, lerp and equality for the component style classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.21.0
+
+### Features
+
+- All component style classes (`DayHeaderStyle`, `TimelineStyle`, `HourLinesStyle`, and the rest) now support `copyWith`, `merge`, `lerp`, and value equality. This is groundwork for the upcoming theme extension. [#314](https://github.com/werner-scholtz/kalender/pull/314)
+
 ## 0.20.0
 
 ### Features

--- a/lib/src/widgets/components/day_header.dart
+++ b/lib/src/widgets/components/day_header.dart
@@ -43,6 +43,62 @@ class DayHeaderStyle {
     this.numberStringBuilder,
     this.stringBuilder,
   });
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  DayHeaderStyle copyWith({
+    TextStyle? textStyle,
+    TextStyle? numberTextStyle,
+    MainAxisAlignment? mainAxisAlignment,
+    String Function(DateTime date)? numberStringBuilder,
+    String Function(DateTime date)? stringBuilder,
+  }) {
+    return DayHeaderStyle(
+      textStyle: textStyle ?? this.textStyle,
+      numberTextStyle: numberTextStyle ?? this.numberTextStyle,
+      mainAxisAlignment: mainAxisAlignment ?? this.mainAxisAlignment,
+      numberStringBuilder: numberStringBuilder ?? this.numberStringBuilder,
+      stringBuilder: stringBuilder ?? this.stringBuilder,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  DayHeaderStyle merge(DayHeaderStyle? other) {
+    if (other == null) return this;
+    return DayHeaderStyle(
+      textStyle: other.textStyle ?? textStyle,
+      numberTextStyle: other.numberTextStyle ?? numberTextStyle,
+      mainAxisAlignment: other.mainAxisAlignment ?? mainAxisAlignment,
+      numberStringBuilder: other.numberStringBuilder ?? numberStringBuilder,
+      stringBuilder: other.stringBuilder ?? stringBuilder,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b]. Fields that cannot be interpolated switch at the midpoint.
+  static DayHeaderStyle? lerp(DayHeaderStyle? a, DayHeaderStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return DayHeaderStyle(
+      textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
+      numberTextStyle: TextStyle.lerp(a?.numberTextStyle, b?.numberTextStyle, t),
+      mainAxisAlignment: t < 0.5 ? a?.mainAxisAlignment : b?.mainAxisAlignment,
+      numberStringBuilder: t < 0.5 ? a?.numberStringBuilder : b?.numberStringBuilder,
+      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is DayHeaderStyle &&
+        other.textStyle == textStyle &&
+        other.numberTextStyle == numberTextStyle &&
+        other.mainAxisAlignment == mainAxisAlignment &&
+        other.numberStringBuilder == numberStringBuilder &&
+        other.stringBuilder == stringBuilder;
+  }
+
+  @override
+  int get hashCode => Object.hash(textStyle, numberTextStyle, mainAxisAlignment, numberStringBuilder, stringBuilder);
 }
 
 /// A widget that displays the name of the day and the day number of the week.

--- a/lib/src/widgets/components/day_separator.dart
+++ b/lib/src/widgets/components/day_separator.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/material.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
@@ -28,6 +30,57 @@ class DaySeparatorStyle {
     this.topIndent,
     this.bottomIndent,
   });
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  DaySeparatorStyle copyWith({
+    Color? color,
+    double? width,
+    double? topIndent,
+    double? bottomIndent,
+  }) {
+    return DaySeparatorStyle(
+      color: color ?? this.color,
+      width: width ?? this.width,
+      topIndent: topIndent ?? this.topIndent,
+      bottomIndent: bottomIndent ?? this.bottomIndent,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  DaySeparatorStyle merge(DaySeparatorStyle? other) {
+    if (other == null) return this;
+    return DaySeparatorStyle(
+      color: other.color ?? color,
+      width: other.width ?? width,
+      topIndent: other.topIndent ?? topIndent,
+      bottomIndent: other.bottomIndent ?? bottomIndent,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b].
+  static DaySeparatorStyle? lerp(DaySeparatorStyle? a, DaySeparatorStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return DaySeparatorStyle(
+      color: Color.lerp(a?.color, b?.color, t),
+      width: lerpDouble(a?.width, b?.width, t),
+      topIndent: lerpDouble(a?.topIndent, b?.topIndent, t),
+      bottomIndent: lerpDouble(a?.bottomIndent, b?.bottomIndent, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is DaySeparatorStyle &&
+        other.color == color &&
+        other.width == width &&
+        other.topIndent == topIndent &&
+        other.bottomIndent == bottomIndent;
+  }
+
+  @override
+  int get hashCode => Object.hash(color, width, topIndent, bottomIndent);
 }
 
 /// A widget that displays a separator between days.

--- a/lib/src/widgets/components/hour_lines.dart
+++ b/lib/src/widgets/components/hour_lines.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -35,6 +37,57 @@ class HourLinesStyle {
     this.indent,
     this.endIndent,
   });
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  HourLinesStyle copyWith({
+    Color? color,
+    double? thickness,
+    double? indent,
+    double? endIndent,
+  }) {
+    return HourLinesStyle(
+      color: color ?? this.color,
+      thickness: thickness ?? this.thickness,
+      indent: indent ?? this.indent,
+      endIndent: endIndent ?? this.endIndent,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  HourLinesStyle merge(HourLinesStyle? other) {
+    if (other == null) return this;
+    return HourLinesStyle(
+      color: other.color ?? color,
+      thickness: other.thickness ?? thickness,
+      indent: other.indent ?? indent,
+      endIndent: other.endIndent ?? endIndent,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b].
+  static HourLinesStyle? lerp(HourLinesStyle? a, HourLinesStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return HourLinesStyle(
+      color: Color.lerp(a?.color, b?.color, t),
+      thickness: lerpDouble(a?.thickness, b?.thickness, t),
+      indent: lerpDouble(a?.indent, b?.indent, t),
+      endIndent: lerpDouble(a?.endIndent, b?.endIndent, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is HourLinesStyle &&
+        other.color == color &&
+        other.thickness == thickness &&
+        other.indent == indent &&
+        other.endIndent == endIndent;
+  }
+
+  @override
+  int get hashCode => Object.hash(color, thickness, indent, endIndent);
 }
 
 /// A widget that displays lines for each hour based on the [timeOfDayRange] and [heightPerMinute].

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -29,6 +29,52 @@ class MonthDayHeaderStyle {
 
   /// The [TextStyle] used by the [MonthDayHeader] widget to display the day number of the week.
   final TextStyle? numberTextStyle;
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  MonthDayHeaderStyle copyWith({
+    TextStyle? textStyle,
+    String Function(DateTime date)? stringBuilder,
+    TextStyle? numberTextStyle,
+  }) {
+    return MonthDayHeaderStyle(
+      textStyle: textStyle ?? this.textStyle,
+      stringBuilder: stringBuilder ?? this.stringBuilder,
+      numberTextStyle: numberTextStyle ?? this.numberTextStyle,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  MonthDayHeaderStyle merge(MonthDayHeaderStyle? other) {
+    if (other == null) return this;
+    return MonthDayHeaderStyle(
+      textStyle: other.textStyle ?? textStyle,
+      stringBuilder: other.stringBuilder ?? stringBuilder,
+      numberTextStyle: other.numberTextStyle ?? numberTextStyle,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b]. Fields that cannot be interpolated switch at the midpoint.
+  static MonthDayHeaderStyle? lerp(MonthDayHeaderStyle? a, MonthDayHeaderStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return MonthDayHeaderStyle(
+      textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
+      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
+      numberTextStyle: TextStyle.lerp(a?.numberTextStyle, b?.numberTextStyle, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MonthDayHeaderStyle &&
+        other.textStyle == textStyle &&
+        other.stringBuilder == stringBuilder &&
+        other.numberTextStyle == numberTextStyle;
+  }
+
+  @override
+  int get hashCode => Object.hash(textStyle, stringBuilder, numberTextStyle);
 }
 
 /// A widget that displays the day number.

--- a/lib/src/widgets/components/month_grid.dart
+++ b/lib/src/widgets/components/month_grid.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/material.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
@@ -21,6 +23,42 @@ class MonthGridStyle {
 
   /// The thickness of the month grid lines.
   final double? thickness;
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  MonthGridStyle copyWith({Color? color, double? thickness}) {
+    return MonthGridStyle(
+      color: color ?? this.color,
+      thickness: thickness ?? this.thickness,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  MonthGridStyle merge(MonthGridStyle? other) {
+    if (other == null) return this;
+    return MonthGridStyle(
+      color: other.color ?? color,
+      thickness: other.thickness ?? thickness,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b].
+  static MonthGridStyle? lerp(MonthGridStyle? a, MonthGridStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return MonthGridStyle(
+      color: Color.lerp(a?.color, b?.color, t),
+      thickness: lerpDouble(a?.thickness, b?.thickness, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MonthGridStyle && other.color == color && other.thickness == thickness;
+  }
+
+  @override
+  int get hashCode => Object.hash(color, thickness);
 }
 
 /// A widget that displays the month grid.

--- a/lib/src/widgets/components/multi_day_overlay.dart
+++ b/lib/src/widgets/components/multi_day_overlay.dart
@@ -70,6 +70,80 @@ class MultiDayOverlayStyle {
     this.eventsPadding,
     this.eventPadding,
   });
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  MultiDayOverlayStyle copyWith({
+    String Function(DateTime date)? dayNameBuilder,
+    TextStyle? dayNameTextStyle,
+    TextStyle? dateTextStyle,
+    Icon? closeIcon,
+    EdgeInsets? headerPadding,
+    EdgeInsets? eventsPadding,
+    EdgeInsets? eventPadding,
+  }) {
+    return MultiDayOverlayStyle(
+      dayNameBuilder: dayNameBuilder ?? this.dayNameBuilder,
+      dayNameTextStyle: dayNameTextStyle ?? this.dayNameTextStyle,
+      dateTextStyle: dateTextStyle ?? this.dateTextStyle,
+      closeIcon: closeIcon ?? this.closeIcon,
+      headerPadding: headerPadding ?? this.headerPadding,
+      eventsPadding: eventsPadding ?? this.eventsPadding,
+      eventPadding: eventPadding ?? this.eventPadding,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  MultiDayOverlayStyle merge(MultiDayOverlayStyle? other) {
+    if (other == null) return this;
+    return MultiDayOverlayStyle(
+      dayNameBuilder: other.dayNameBuilder ?? dayNameBuilder,
+      dayNameTextStyle: other.dayNameTextStyle ?? dayNameTextStyle,
+      dateTextStyle: other.dateTextStyle ?? dateTextStyle,
+      closeIcon: other.closeIcon ?? closeIcon,
+      headerPadding: other.headerPadding ?? headerPadding,
+      eventsPadding: other.eventsPadding ?? eventsPadding,
+      eventPadding: other.eventPadding ?? eventPadding,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b]. Fields that cannot be interpolated switch at the midpoint.
+  static MultiDayOverlayStyle? lerp(MultiDayOverlayStyle? a, MultiDayOverlayStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return MultiDayOverlayStyle(
+      dayNameBuilder: t < 0.5 ? a?.dayNameBuilder : b?.dayNameBuilder,
+      dayNameTextStyle: TextStyle.lerp(a?.dayNameTextStyle, b?.dayNameTextStyle, t),
+      dateTextStyle: TextStyle.lerp(a?.dateTextStyle, b?.dateTextStyle, t),
+      closeIcon: t < 0.5 ? a?.closeIcon : b?.closeIcon,
+      headerPadding: EdgeInsets.lerp(a?.headerPadding, b?.headerPadding, t),
+      eventsPadding: EdgeInsets.lerp(a?.eventsPadding, b?.eventsPadding, t),
+      eventPadding: EdgeInsets.lerp(a?.eventPadding, b?.eventPadding, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MultiDayOverlayStyle &&
+        other.dayNameBuilder == dayNameBuilder &&
+        other.dayNameTextStyle == dayNameTextStyle &&
+        other.dateTextStyle == dateTextStyle &&
+        other.closeIcon == closeIcon &&
+        other.headerPadding == headerPadding &&
+        other.eventsPadding == eventsPadding &&
+        other.eventPadding == eventPadding;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        dayNameBuilder,
+        dayNameTextStyle,
+        dateTextStyle,
+        closeIcon,
+        headerPadding,
+        eventsPadding,
+        eventPadding,
+      );
 }
 
 class MultiDayOverlay extends StatelessWidget {

--- a/lib/src/widgets/components/multi_day_overlay_portal_button.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal_button.dart
@@ -25,6 +25,61 @@ class MultiDayPortalOverlayButtonStyle {
   final String Function(int numberOfHiddenRows)? stringBuilder;
 
   const MultiDayPortalOverlayButtonStyle({this.textStyle, this.textPadding, this.stringBuilder, this.textOverflow});
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  MultiDayPortalOverlayButtonStyle copyWith({
+    TextStyle? textStyle,
+    EdgeInsetsGeometry? textPadding,
+    TextOverflow? textOverflow,
+    String Function(int numberOfHiddenRows)? stringBuilder,
+  }) {
+    return MultiDayPortalOverlayButtonStyle(
+      textStyle: textStyle ?? this.textStyle,
+      textPadding: textPadding ?? this.textPadding,
+      textOverflow: textOverflow ?? this.textOverflow,
+      stringBuilder: stringBuilder ?? this.stringBuilder,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  MultiDayPortalOverlayButtonStyle merge(MultiDayPortalOverlayButtonStyle? other) {
+    if (other == null) return this;
+    return MultiDayPortalOverlayButtonStyle(
+      textStyle: other.textStyle ?? textStyle,
+      textPadding: other.textPadding ?? textPadding,
+      textOverflow: other.textOverflow ?? textOverflow,
+      stringBuilder: other.stringBuilder ?? stringBuilder,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b]. Fields that cannot be interpolated switch at the midpoint.
+  static MultiDayPortalOverlayButtonStyle? lerp(
+    MultiDayPortalOverlayButtonStyle? a,
+    MultiDayPortalOverlayButtonStyle? b,
+    double t,
+  ) {
+    if (identical(a, b)) return a;
+    return MultiDayPortalOverlayButtonStyle(
+      textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
+      textPadding: EdgeInsetsGeometry.lerp(a?.textPadding, b?.textPadding, t),
+      textOverflow: t < 0.5 ? a?.textOverflow : b?.textOverflow,
+      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MultiDayPortalOverlayButtonStyle &&
+        other.textStyle == textStyle &&
+        other.textPadding == textPadding &&
+        other.textOverflow == textOverflow &&
+        other.stringBuilder == stringBuilder;
+  }
+
+  @override
+  int get hashCode => Object.hash(textStyle, textPadding, textOverflow, stringBuilder);
 }
 
 class MultiDayPortalOverlayButton extends StatelessWidget {

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -30,6 +30,52 @@ class ScheduleDateStyle {
 
   /// The [TextStyle] used by the [ScheduleDate] widget to display the day number of the week.
   final TextStyle? numberTextStyle;
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  ScheduleDateStyle copyWith({
+    TextStyle? textStyle,
+    String Function(DateTime date)? stringBuilder,
+    TextStyle? numberTextStyle,
+  }) {
+    return ScheduleDateStyle(
+      textStyle: textStyle ?? this.textStyle,
+      stringBuilder: stringBuilder ?? this.stringBuilder,
+      numberTextStyle: numberTextStyle ?? this.numberTextStyle,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  ScheduleDateStyle merge(ScheduleDateStyle? other) {
+    if (other == null) return this;
+    return ScheduleDateStyle(
+      textStyle: other.textStyle ?? textStyle,
+      stringBuilder: other.stringBuilder ?? stringBuilder,
+      numberTextStyle: other.numberTextStyle ?? numberTextStyle,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b]. Fields that cannot be interpolated switch at the midpoint.
+  static ScheduleDateStyle? lerp(ScheduleDateStyle? a, ScheduleDateStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return ScheduleDateStyle(
+      textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
+      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
+      numberTextStyle: TextStyle.lerp(a?.numberTextStyle, b?.numberTextStyle, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ScheduleDateStyle &&
+        other.textStyle == textStyle &&
+        other.stringBuilder == stringBuilder &&
+        other.numberTextStyle == numberTextStyle;
+  }
+
+  @override
+  int get hashCode => Object.hash(textStyle, stringBuilder, numberTextStyle);
 }
 
 /// A widget that displays the name of the day and the day number of the week.

--- a/lib/src/widgets/components/schedule_tile_highlight.dart
+++ b/lib/src/widgets/components/schedule_tile_highlight.dart
@@ -20,6 +20,33 @@ class ScheduleTileHighlightStyle {
 
   /// The [BoxDecoration] used to style the highlight.
   final BoxDecoration? decoration;
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  ScheduleTileHighlightStyle copyWith({BoxDecoration? decoration}) {
+    return ScheduleTileHighlightStyle(decoration: decoration ?? this.decoration);
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  ScheduleTileHighlightStyle merge(ScheduleTileHighlightStyle? other) {
+    if (other == null) return this;
+    return ScheduleTileHighlightStyle(decoration: other.decoration ?? decoration);
+  }
+
+  /// Linearly interpolates between [a] and [b].
+  static ScheduleTileHighlightStyle? lerp(ScheduleTileHighlightStyle? a, ScheduleTileHighlightStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return ScheduleTileHighlightStyle(decoration: BoxDecoration.lerp(a?.decoration, b?.decoration, t));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ScheduleTileHighlightStyle && other.decoration == decoration;
+  }
+
+  @override
+  int get hashCode => decoration.hashCode;
 }
 
 /// A widget that highlights the list item if the date is within the given dateTimeRange.

--- a/lib/src/widgets/components/time_indicator.dart
+++ b/lib/src/widgets/components/time_indicator.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
@@ -37,6 +38,57 @@ class TimeIndicatorStyle {
     this.circleColor,
     this.circleSize,
   });
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  TimeIndicatorStyle copyWith({
+    Color? lineColor,
+    double? thickness,
+    Color? circleColor,
+    Size? circleSize,
+  }) {
+    return TimeIndicatorStyle(
+      lineColor: lineColor ?? this.lineColor,
+      thickness: thickness ?? this.thickness,
+      circleColor: circleColor ?? this.circleColor,
+      circleSize: circleSize ?? this.circleSize,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  TimeIndicatorStyle merge(TimeIndicatorStyle? other) {
+    if (other == null) return this;
+    return TimeIndicatorStyle(
+      lineColor: other.lineColor ?? lineColor,
+      thickness: other.thickness ?? thickness,
+      circleColor: other.circleColor ?? circleColor,
+      circleSize: other.circleSize ?? circleSize,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b].
+  static TimeIndicatorStyle? lerp(TimeIndicatorStyle? a, TimeIndicatorStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return TimeIndicatorStyle(
+      lineColor: Color.lerp(a?.lineColor, b?.lineColor, t),
+      thickness: lerpDouble(a?.thickness, b?.thickness, t),
+      circleColor: Color.lerp(a?.circleColor, b?.circleColor, t),
+      circleSize: Size.lerp(a?.circleSize, b?.circleSize, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is TimeIndicatorStyle &&
+        other.lineColor == lineColor &&
+        other.thickness == thickness &&
+        other.circleColor == circleColor &&
+        other.circleSize == circleSize;
+  }
+
+  @override
+  int get hashCode => Object.hash(lineColor, thickness, circleColor, circleSize);
 }
 
 /// A widget that displays the current time as a line and a circle.

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -115,6 +117,92 @@ class TimelineStyle {
     this.startDecoration,
     this.endDecoration,
   });
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  TimelineStyle copyWith({
+    TextStyle? textStyle,
+    TextDirection? textDirection,
+    TextAlign? textAlign,
+    TextOverflow? textOverflow,
+    String Function(TimeOfDay timeOfDay)? stringBuilder,
+    EdgeInsets? textPadding,
+    double? width,
+    Decoration? startDecoration,
+    Decoration? endDecoration,
+  }) {
+    return TimelineStyle(
+      textStyle: textStyle ?? this.textStyle,
+      textDirection: textDirection ?? this.textDirection,
+      textAlign: textAlign ?? this.textAlign,
+      textOverflow: textOverflow ?? this.textOverflow,
+      stringBuilder: stringBuilder ?? this.stringBuilder,
+      textPadding: textPadding ?? this.textPadding,
+      width: width ?? this.width,
+      startDecoration: startDecoration ?? this.startDecoration,
+      endDecoration: endDecoration ?? this.endDecoration,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  TimelineStyle merge(TimelineStyle? other) {
+    if (other == null) return this;
+    return TimelineStyle(
+      textStyle: other.textStyle ?? textStyle,
+      textDirection: other.textDirection ?? textDirection,
+      textAlign: other.textAlign ?? textAlign,
+      textOverflow: other.textOverflow ?? textOverflow,
+      stringBuilder: other.stringBuilder ?? stringBuilder,
+      textPadding: other.textPadding ?? textPadding,
+      width: other.width ?? width,
+      startDecoration: other.startDecoration ?? startDecoration,
+      endDecoration: other.endDecoration ?? endDecoration,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b]. Fields that cannot be interpolated switch at the midpoint.
+  static TimelineStyle? lerp(TimelineStyle? a, TimelineStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return TimelineStyle(
+      textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
+      textDirection: t < 0.5 ? a?.textDirection : b?.textDirection,
+      textAlign: t < 0.5 ? a?.textAlign : b?.textAlign,
+      textOverflow: t < 0.5 ? a?.textOverflow : b?.textOverflow,
+      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
+      textPadding: EdgeInsets.lerp(a?.textPadding, b?.textPadding, t),
+      width: lerpDouble(a?.width, b?.width, t),
+      startDecoration: Decoration.lerp(a?.startDecoration, b?.startDecoration, t),
+      endDecoration: Decoration.lerp(a?.endDecoration, b?.endDecoration, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is TimelineStyle &&
+        other.textStyle == textStyle &&
+        other.textDirection == textDirection &&
+        other.textAlign == textAlign &&
+        other.textOverflow == textOverflow &&
+        other.stringBuilder == stringBuilder &&
+        other.textPadding == textPadding &&
+        other.width == width &&
+        other.startDecoration == startDecoration &&
+        other.endDecoration == endDecoration;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        textStyle,
+        textDirection,
+        textAlign,
+        textOverflow,
+        stringBuilder,
+        textPadding,
+        width,
+        startDecoration,
+        endDecoration,
+      );
 }
 
 /// A mixin that provides utility methods for the [TimeLine] and [HourLines] widget.

--- a/lib/src/widgets/components/week_day_header.dart
+++ b/lib/src/widgets/components/week_day_header.dart
@@ -27,6 +27,52 @@ class WeekDayHeaderStyle {
 
   /// The padding around the [WeekDayHeader] widget.
   final EdgeInsets? padding;
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  WeekDayHeaderStyle copyWith({
+    TextStyle? textStyle,
+    String Function(DateTime date)? stringBuilder,
+    EdgeInsets? padding,
+  }) {
+    return WeekDayHeaderStyle(
+      textStyle: textStyle ?? this.textStyle,
+      stringBuilder: stringBuilder ?? this.stringBuilder,
+      padding: padding ?? this.padding,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  WeekDayHeaderStyle merge(WeekDayHeaderStyle? other) {
+    if (other == null) return this;
+    return WeekDayHeaderStyle(
+      textStyle: other.textStyle ?? textStyle,
+      stringBuilder: other.stringBuilder ?? stringBuilder,
+      padding: other.padding ?? padding,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b]. Fields that cannot be interpolated switch at the midpoint.
+  static WeekDayHeaderStyle? lerp(WeekDayHeaderStyle? a, WeekDayHeaderStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return WeekDayHeaderStyle(
+      textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
+      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
+      padding: EdgeInsets.lerp(a?.padding, b?.padding, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is WeekDayHeaderStyle &&
+        other.textStyle == textStyle &&
+        other.stringBuilder == stringBuilder &&
+        other.padding == padding;
+  }
+
+  @override
+  int get hashCode => Object.hash(textStyle, stringBuilder, padding);
 }
 
 /// A widget that displays the name of the day of the week.

--- a/lib/src/widgets/components/week_number.dart
+++ b/lib/src/widgets/components/week_number.dart
@@ -36,6 +36,62 @@ class WeekNumberStyle {
 
   /// The alignment of the week number within its available cell.
   final AlignmentGeometry? alignment;
+
+  /// Creates a copy of this style with the given fields replaced with the new values.
+  WeekNumberStyle copyWith({
+    TextStyle? textStyle,
+    VisualDensity? visualDensity,
+    String? tooltip,
+    EdgeInsets? padding,
+    AlignmentGeometry? alignment,
+  }) {
+    return WeekNumberStyle(
+      textStyle: textStyle ?? this.textStyle,
+      visualDensity: visualDensity ?? this.visualDensity,
+      tooltip: tooltip ?? this.tooltip,
+      padding: padding ?? this.padding,
+      alignment: alignment ?? this.alignment,
+    );
+  }
+
+  /// Returns a copy of this style where the non-null fields of [other] replace the matching fields.
+  WeekNumberStyle merge(WeekNumberStyle? other) {
+    if (other == null) return this;
+    return WeekNumberStyle(
+      textStyle: other.textStyle ?? textStyle,
+      visualDensity: other.visualDensity ?? visualDensity,
+      tooltip: other.tooltip ?? tooltip,
+      padding: other.padding ?? padding,
+      alignment: other.alignment ?? alignment,
+    );
+  }
+
+  /// Linearly interpolates between [a] and [b]. Fields that cannot be interpolated switch at the midpoint.
+  static WeekNumberStyle? lerp(WeekNumberStyle? a, WeekNumberStyle? b, double t) {
+    if (identical(a, b)) return a;
+    return WeekNumberStyle(
+      textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
+      visualDensity: t < 0.5 ? a?.visualDensity : b?.visualDensity,
+      tooltip: t < 0.5 ? a?.tooltip : b?.tooltip,
+      padding: EdgeInsets.lerp(a?.padding, b?.padding, t),
+      alignment: AlignmentGeometry.lerp(a?.alignment, b?.alignment, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is WeekNumberStyle &&
+        other.textStyle == textStyle &&
+        other.visualDensity == visualDensity &&
+        other.tooltip == tooltip &&
+        other.padding == padding &&
+        other.alignment == alignment;
+  }
+
+  @override
+  int get hashCode => Object.hash(textStyle, visualDensity, tooltip, padding, alignment);
 }
 
 /// A widget that displays the week number.

--- a/test/models/component_styles_test.dart
+++ b/test/models/component_styles_test.dart
@@ -1,0 +1,413 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+/// Covers the copyWith/merge/lerp/equality contract shared by all component style classes.
+///
+/// Each class follows the same rules:
+/// - copyWith replaces only the given fields.
+/// - merge overlays the non-null fields of the other style onto this one.
+/// - lerp interpolates lerpable fields and switches the rest at the midpoint.
+/// - Styles with the same field values are equal.
+void main() {
+  group('DayHeaderStyle', () {
+    const a = DayHeaderStyle(textStyle: TextStyle(fontSize: 10), mainAxisAlignment: MainAxisAlignment.start);
+    const b = DayHeaderStyle(textStyle: TextStyle(fontSize: 20), mainAxisAlignment: MainAxisAlignment.end);
+
+    test('copyWith', () {
+      final copy = a.copyWith(numberTextStyle: const TextStyle(fontSize: 8));
+      expect(copy.numberTextStyle, const TextStyle(fontSize: 8));
+      expect(copy.textStyle, a.textStyle);
+      expect(copy.mainAxisAlignment, a.mainAxisAlignment);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const DayHeaderStyle(textStyle: TextStyle(fontSize: 30)));
+      expect(merged.textStyle, const TextStyle(fontSize: 30));
+      expect(merged.mainAxisAlignment, a.mainAxisAlignment);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      final mid = DayHeaderStyle.lerp(a, b, 0.5)!;
+      expect(mid.textStyle?.fontSize, 15);
+      expect(DayHeaderStyle.lerp(a, b, 0.25)!.mainAxisAlignment, MainAxisAlignment.start);
+      expect(DayHeaderStyle.lerp(a, b, 0.75)!.mainAxisAlignment, MainAxisAlignment.end);
+      expect(DayHeaderStyle.lerp(null, null, 0.5), null);
+      expect(DayHeaderStyle.lerp(a, a, 0.5), a);
+    });
+
+    test('equality', () {
+      expect(a, const DayHeaderStyle(textStyle: TextStyle(fontSize: 10), mainAxisAlignment: MainAxisAlignment.start));
+      expect(a == b, false);
+    });
+  });
+
+  group('TimelineStyle', () {
+    const a = TimelineStyle(width: 10, textPadding: EdgeInsets.all(4), textDirection: TextDirection.ltr);
+    const b = TimelineStyle(width: 20, textPadding: EdgeInsets.all(8), textDirection: TextDirection.rtl);
+
+    test('copyWith', () {
+      final copy = a.copyWith(width: 15);
+      expect(copy.width, 15);
+      expect(copy.textPadding, a.textPadding);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const TimelineStyle(width: 30));
+      expect(merged.width, 30);
+      expect(merged.textPadding, a.textPadding);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      final mid = TimelineStyle.lerp(a, b, 0.5)!;
+      expect(mid.width, 15);
+      expect(mid.textPadding, const EdgeInsets.all(6));
+      expect(TimelineStyle.lerp(a, b, 0.25)!.textDirection, TextDirection.ltr);
+      expect(TimelineStyle.lerp(a, b, 0.75)!.textDirection, TextDirection.rtl);
+      expect(TimelineStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(a, const TimelineStyle(width: 10, textPadding: EdgeInsets.all(4), textDirection: TextDirection.ltr));
+      expect(a == b, false);
+    });
+  });
+
+  group('HourLinesStyle', () {
+    const a = HourLinesStyle(color: Color(0xFF000000), thickness: 1, indent: 0);
+    const b = HourLinesStyle(color: Color(0xFFFFFFFF), thickness: 3, indent: 10);
+
+    test('copyWith', () {
+      final copy = a.copyWith(thickness: 2);
+      expect(copy.thickness, 2);
+      expect(copy.color, a.color);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const HourLinesStyle(endIndent: 5));
+      expect(merged.endIndent, 5);
+      expect(merged.color, a.color);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      final mid = HourLinesStyle.lerp(a, b, 0.5)!;
+      expect(mid.thickness, 2);
+      expect(mid.indent, 5);
+      expect(mid.color, Color.lerp(a.color, b.color, 0.5));
+      expect(HourLinesStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(a, const HourLinesStyle(color: Color(0xFF000000), thickness: 1, indent: 0));
+      expect(a == b, false);
+    });
+  });
+
+  group('DaySeparatorStyle', () {
+    const a = DaySeparatorStyle(color: Color(0xFF000000), width: 1, topIndent: 0);
+    const b = DaySeparatorStyle(color: Color(0xFFFFFFFF), width: 3, topIndent: 10);
+
+    test('copyWith', () {
+      final copy = a.copyWith(width: 2);
+      expect(copy.width, 2);
+      expect(copy.color, a.color);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const DaySeparatorStyle(bottomIndent: 5));
+      expect(merged.bottomIndent, 5);
+      expect(merged.color, a.color);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      final mid = DaySeparatorStyle.lerp(a, b, 0.5)!;
+      expect(mid.width, 2);
+      expect(mid.topIndent, 5);
+      expect(DaySeparatorStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(a, const DaySeparatorStyle(color: Color(0xFF000000), width: 1, topIndent: 0));
+      expect(a == b, false);
+    });
+  });
+
+  group('TimeIndicatorStyle', () {
+    const a = TimeIndicatorStyle(lineColor: Color(0xFF000000), thickness: 1, circleSize: Size(10, 10));
+    const b = TimeIndicatorStyle(lineColor: Color(0xFFFFFFFF), thickness: 3, circleSize: Size(20, 20));
+
+    test('copyWith', () {
+      final copy = a.copyWith(circleColor: const Color(0xFF00FF00));
+      expect(copy.circleColor, const Color(0xFF00FF00));
+      expect(copy.lineColor, a.lineColor);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const TimeIndicatorStyle(thickness: 4));
+      expect(merged.thickness, 4);
+      expect(merged.circleSize, a.circleSize);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      final mid = TimeIndicatorStyle.lerp(a, b, 0.5)!;
+      expect(mid.thickness, 2);
+      expect(mid.circleSize, const Size(15, 15));
+      expect(TimeIndicatorStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(a, const TimeIndicatorStyle(lineColor: Color(0xFF000000), thickness: 1, circleSize: Size(10, 10)));
+      expect(a == b, false);
+    });
+  });
+
+  group('WeekNumberStyle', () {
+    const a = WeekNumberStyle(tooltip: 'a', padding: EdgeInsets.all(4), alignment: Alignment.topLeft);
+    const b = WeekNumberStyle(tooltip: 'b', padding: EdgeInsets.all(8), alignment: Alignment.bottomRight);
+
+    test('copyWith', () {
+      final copy = a.copyWith(tooltip: 'c');
+      expect(copy.tooltip, 'c');
+      expect(copy.padding, a.padding);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const WeekNumberStyle(visualDensity: VisualDensity.comfortable));
+      expect(merged.visualDensity, VisualDensity.comfortable);
+      expect(merged.tooltip, a.tooltip);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      final mid = WeekNumberStyle.lerp(a, b, 0.5)!;
+      expect(mid.padding, const EdgeInsets.all(6));
+      expect(mid.alignment, Alignment.center);
+      expect(WeekNumberStyle.lerp(a, b, 0.25)!.tooltip, 'a');
+      expect(WeekNumberStyle.lerp(a, b, 0.75)!.tooltip, 'b');
+      expect(WeekNumberStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(a, const WeekNumberStyle(tooltip: 'a', padding: EdgeInsets.all(4), alignment: Alignment.topLeft));
+      expect(a == b, false);
+    });
+  });
+
+  group('MonthGridStyle', () {
+    const a = MonthGridStyle(color: Color(0xFF000000), thickness: 1);
+    const b = MonthGridStyle(color: Color(0xFFFFFFFF), thickness: 3);
+
+    test('copyWith', () {
+      final copy = a.copyWith(thickness: 2);
+      expect(copy.thickness, 2);
+      expect(copy.color, a.color);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const MonthGridStyle(thickness: 4));
+      expect(merged.thickness, 4);
+      expect(merged.color, a.color);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      expect(MonthGridStyle.lerp(a, b, 0.5)!.thickness, 2);
+      expect(MonthGridStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(a, const MonthGridStyle(color: Color(0xFF000000), thickness: 1));
+      expect(a == b, false);
+    });
+  });
+
+  group('MonthDayHeaderStyle', () {
+    const a = MonthDayHeaderStyle(textStyle: TextStyle(fontSize: 10));
+    const b = MonthDayHeaderStyle(textStyle: TextStyle(fontSize: 20));
+
+    test('copyWith', () {
+      final copy = a.copyWith(numberTextStyle: const TextStyle(fontSize: 8));
+      expect(copy.numberTextStyle, const TextStyle(fontSize: 8));
+      expect(copy.textStyle, a.textStyle);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const MonthDayHeaderStyle(numberTextStyle: TextStyle(fontSize: 9)));
+      expect(merged.numberTextStyle, const TextStyle(fontSize: 9));
+      expect(merged.textStyle, a.textStyle);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      expect(MonthDayHeaderStyle.lerp(a, b, 0.5)!.textStyle?.fontSize, 15);
+      expect(MonthDayHeaderStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(a, const MonthDayHeaderStyle(textStyle: TextStyle(fontSize: 10)));
+      expect(a == b, false);
+    });
+  });
+
+  group('WeekDayHeaderStyle', () {
+    const a = WeekDayHeaderStyle(textStyle: TextStyle(fontSize: 10), padding: EdgeInsets.all(4));
+    const b = WeekDayHeaderStyle(textStyle: TextStyle(fontSize: 20), padding: EdgeInsets.all(8));
+
+    test('copyWith', () {
+      final copy = a.copyWith(padding: const EdgeInsets.all(2));
+      expect(copy.padding, const EdgeInsets.all(2));
+      expect(copy.textStyle, a.textStyle);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const WeekDayHeaderStyle(padding: EdgeInsets.all(6)));
+      expect(merged.padding, const EdgeInsets.all(6));
+      expect(merged.textStyle, a.textStyle);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      final mid = WeekDayHeaderStyle.lerp(a, b, 0.5)!;
+      expect(mid.textStyle?.fontSize, 15);
+      expect(mid.padding, const EdgeInsets.all(6));
+      expect(WeekDayHeaderStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(a, const WeekDayHeaderStyle(textStyle: TextStyle(fontSize: 10), padding: EdgeInsets.all(4)));
+      expect(a == b, false);
+    });
+  });
+
+  group('ScheduleDateStyle', () {
+    const a = ScheduleDateStyle(textStyle: TextStyle(fontSize: 10));
+    const b = ScheduleDateStyle(textStyle: TextStyle(fontSize: 20));
+
+    test('copyWith', () {
+      final copy = a.copyWith(numberTextStyle: const TextStyle(fontSize: 8));
+      expect(copy.numberTextStyle, const TextStyle(fontSize: 8));
+      expect(copy.textStyle, a.textStyle);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const ScheduleDateStyle(numberTextStyle: TextStyle(fontSize: 9)));
+      expect(merged.numberTextStyle, const TextStyle(fontSize: 9));
+      expect(merged.textStyle, a.textStyle);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      expect(ScheduleDateStyle.lerp(a, b, 0.5)!.textStyle?.fontSize, 15);
+      expect(ScheduleDateStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(a, const ScheduleDateStyle(textStyle: TextStyle(fontSize: 10)));
+      expect(a == b, false);
+    });
+  });
+
+  group('ScheduleTileHighlightStyle', () {
+    const a = ScheduleTileHighlightStyle(decoration: BoxDecoration(color: Color(0xFF000000)));
+    const b = ScheduleTileHighlightStyle(decoration: BoxDecoration(color: Color(0xFFFFFFFF)));
+
+    test('copyWith', () {
+      final copy = a.copyWith(decoration: const BoxDecoration(color: Color(0xFF00FF00)));
+      expect(copy.decoration, const BoxDecoration(color: Color(0xFF00FF00)));
+    });
+
+    test('merge', () {
+      final merged = a.merge(b);
+      expect(merged.decoration, b.decoration);
+      expect(a.merge(null), a);
+      expect(a.merge(const ScheduleTileHighlightStyle()).decoration, a.decoration);
+    });
+
+    test('lerp', () {
+      final mid = ScheduleTileHighlightStyle.lerp(a, b, 0.5)!;
+      expect(mid.decoration?.color, Color.lerp(const Color(0xFF000000), const Color(0xFFFFFFFF), 0.5));
+      expect(ScheduleTileHighlightStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(a, const ScheduleTileHighlightStyle(decoration: BoxDecoration(color: Color(0xFF000000))));
+      expect(a == b, false);
+    });
+  });
+
+  group('MultiDayOverlayStyle', () {
+    const a = MultiDayOverlayStyle(dayNameTextStyle: TextStyle(fontSize: 10), headerPadding: EdgeInsets.all(4));
+    const b = MultiDayOverlayStyle(dayNameTextStyle: TextStyle(fontSize: 20), headerPadding: EdgeInsets.all(8));
+
+    test('copyWith', () {
+      final copy = a.copyWith(closeIcon: const Icon(Icons.close));
+      expect(copy.closeIcon?.icon, Icons.close);
+      expect(copy.dayNameTextStyle, a.dayNameTextStyle);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const MultiDayOverlayStyle(eventPadding: EdgeInsets.all(2)));
+      expect(merged.eventPadding, const EdgeInsets.all(2));
+      expect(merged.dayNameTextStyle, a.dayNameTextStyle);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      final mid = MultiDayOverlayStyle.lerp(a, b, 0.5)!;
+      expect(mid.dayNameTextStyle?.fontSize, 15);
+      expect(mid.headerPadding, const EdgeInsets.all(6));
+      expect(MultiDayOverlayStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(
+          a, const MultiDayOverlayStyle(dayNameTextStyle: TextStyle(fontSize: 10), headerPadding: EdgeInsets.all(4)));
+      expect(a == b, false);
+    });
+  });
+
+  group('MultiDayPortalOverlayButtonStyle', () {
+    const a = MultiDayPortalOverlayButtonStyle(textStyle: TextStyle(fontSize: 10), textPadding: EdgeInsets.all(4));
+    const b = MultiDayPortalOverlayButtonStyle(textStyle: TextStyle(fontSize: 20), textPadding: EdgeInsets.all(8));
+
+    test('copyWith', () {
+      final copy = a.copyWith(textOverflow: TextOverflow.fade);
+      expect(copy.textOverflow, TextOverflow.fade);
+      expect(copy.textStyle, a.textStyle);
+    });
+
+    test('merge', () {
+      final merged = a.merge(const MultiDayPortalOverlayButtonStyle(textOverflow: TextOverflow.clip));
+      expect(merged.textOverflow, TextOverflow.clip);
+      expect(merged.textStyle, a.textStyle);
+      expect(a.merge(null), a);
+    });
+
+    test('lerp', () {
+      final mid = MultiDayPortalOverlayButtonStyle.lerp(a, b, 0.5)!;
+      expect(mid.textStyle?.fontSize, 15);
+      expect(mid.textPadding, const EdgeInsets.all(6));
+      expect(MultiDayPortalOverlayButtonStyle.lerp(null, null, 0.5), null);
+    });
+
+    test('equality', () {
+      expect(
+        a,
+        const MultiDayPortalOverlayButtonStyle(textStyle: TextStyle(fontSize: 10), textPadding: EdgeInsets.all(4)),
+      );
+      expect(a == b, false);
+    });
+  });
+
+  test('stringBuilder fields keep function identity through copyWith and merge', () {
+    String builder(DateTime date) => 'x';
+    final style = const DayHeaderStyle().copyWith(stringBuilder: builder);
+    expect(style.stringBuilder, builder);
+    expect(const DayHeaderStyle().merge(style).stringBuilder, builder);
+  });
+}

--- a/test/models/component_styles_test.dart
+++ b/test/models/component_styles_test.dart
@@ -366,7 +366,9 @@ void main() {
 
     test('equality', () {
       expect(
-          a, const MultiDayOverlayStyle(dayNameTextStyle: TextStyle(fontSize: 10), headerPadding: EdgeInsets.all(4)));
+        a,
+        const MultiDayOverlayStyle(dayNameTextStyle: TextStyle(fontSize: 10), headerPadding: EdgeInsets.all(4)),
+      );
       expect(a == b, false);
     });
   });


### PR DESCRIPTION
First step of the theming work: make every component style class a proper value class so it can take part in a theme.

Each of the 13 leaf style classes (`DayHeaderStyle`, `TimelineStyle`, `HourLinesStyle`, `DaySeparatorStyle`, `TimeIndicatorStyle`, `WeekNumberStyle`, `MonthGridStyle`, `MonthDayHeaderStyle`, `WeekDayHeaderStyle`, `ScheduleDateStyle`, `ScheduleTileHighlightStyle`, `MultiDayOverlayStyle`, `MultiDayPortalOverlayButtonStyle`) gains:

- `copyWith` — replace individual fields, matching the existing `PageTriggerConfiguration.copyWith` style.
- `merge` — overlay the non-null fields of another style onto this one. This is what the upcoming theme resolution uses (widget style over theme extension over Material 3 defaults).
- static `lerp` — interpolate lerpable fields (colors, text styles, paddings, sizes), switch the rest at the midpoint, following Material's `*ThemeData.lerp` convention. This is what makes animated theme changes work once the styles live in a `ThemeExtension`.
- value `==` and `hashCode`.

Purely additive, no behavior changes. 53 new tests cover the copyWith/merge/lerp/equality contract for every class.

Next up (separate PR): `KalenderThemeData` as a `ThemeExtension` with centralized Material 3 defaults, resolved via `KalenderTheme.of(context)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)