### PR TITLE
feat: KalenderThemeData theme extension with Material 3 defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - All component style classes (`DayHeaderStyle`, `TimelineStyle`, `HourLinesStyle`, and the rest) now support `copyWith`, `merge`, `lerp`, and value equality. This is groundwork for the upcoming theme extension. [#314](https://github.com/werner-scholtz/kalender/pull/314)
+- Added `KalenderThemeData`, a `ThemeExtension` with one field per component style, and `KalenderTheme.of(context)`, which resolves it against centralized Material 3 defaults. Register it on `ThemeData.extensions` to style every calendar in the app, with animated theme changes supported. [#315](https://github.com/werner-scholtz/kalender/pull/315)
 
 ## 0.20.0
 

--- a/lib/kalender.dart
+++ b/lib/kalender.dart
@@ -15,6 +15,9 @@ export 'package:kalender/src/enumerations.dart';
 export 'package:kalender/src/layout_delegates/event_layout_delegate.dart';
 export 'package:kalender/src/layout_delegates/multi_day_event_layout.dart';
 
+/// Theme
+export 'package:kalender/src/theme/kalender_theme.dart';
+
 /// Models
 export 'package:kalender/src/models/controllers/calendar_controller.dart';
 export 'package:kalender/src/models/controllers/events_controller.dart';

--- a/lib/src/theme/kalender_theme.dart
+++ b/lib/src/theme/kalender_theme.dart
@@ -1,0 +1,300 @@
+import 'package:flutter/material.dart';
+import 'package:kalender/kalender.dart';
+
+/// The calendar's visual theme, following the same layering as Flutter's own component themes.
+///
+/// Styling is resolved in three layers, most specific first:
+/// 1. A style passed directly to a widget or through the component style containers.
+/// 2. A [KalenderThemeData] registered as a [ThemeExtension] on the app's [ThemeData].
+/// 3. Material 3 defaults derived from the ambient [Theme], see [KalenderThemeData.defaults].
+///
+/// To theme every calendar in the app:
+///
+/// ```dart
+/// MaterialApp(
+///   theme: ThemeData(
+///     extensions: [
+///       KalenderThemeData(
+///         timeIndicatorStyle: TimeIndicatorStyle(lineColor: Colors.pink),
+///       ),
+///     ],
+///   ),
+/// )
+/// ```
+class KalenderThemeData extends ThemeExtension<KalenderThemeData> {
+  /// The style of the [DayHeader].
+  final DayHeaderStyle? dayHeaderStyle;
+
+  /// The style of the [TimeLine].
+  final TimelineStyle? timelineStyle;
+
+  /// The style of the [HourLines].
+  final HourLinesStyle? hourLinesStyle;
+
+  /// The style of the [DaySeparator].
+  final DaySeparatorStyle? daySeparatorStyle;
+
+  /// The style of the [TimeIndicator].
+  final TimeIndicatorStyle? timeIndicatorStyle;
+
+  /// The style of the [WeekNumber].
+  final WeekNumberStyle? weekNumberStyle;
+
+  /// The style of the [MonthGrid].
+  final MonthGridStyle? monthGridStyle;
+
+  /// The style of the [MonthDayHeader].
+  final MonthDayHeaderStyle? monthDayHeaderStyle;
+
+  /// The style of the [WeekDayHeader].
+  final WeekDayHeaderStyle? weekDayHeaderStyle;
+
+  /// The style of the [ScheduleDate].
+  final ScheduleDateStyle? scheduleDateStyle;
+
+  /// The style of the [ScheduleTileHighlight].
+  final ScheduleTileHighlightStyle? scheduleTileHighlightStyle;
+
+  /// The style of the [MultiDayOverlay].
+  final MultiDayOverlayStyle? multiDayOverlayStyle;
+
+  /// The style of the [MultiDayPortalOverlayButton].
+  final MultiDayPortalOverlayButtonStyle? multiDayPortalOverlayButtonStyle;
+
+  /// Creates a new [KalenderThemeData].
+  const KalenderThemeData({
+    this.dayHeaderStyle,
+    this.timelineStyle,
+    this.hourLinesStyle,
+    this.daySeparatorStyle,
+    this.timeIndicatorStyle,
+    this.weekNumberStyle,
+    this.monthGridStyle,
+    this.monthDayHeaderStyle,
+    this.weekDayHeaderStyle,
+    this.scheduleDateStyle,
+    this.scheduleTileHighlightStyle,
+    this.multiDayOverlayStyle,
+    this.multiDayPortalOverlayButtonStyle,
+  });
+
+  /// The Material 3 defaults, derived from the [Theme] of the given [context].
+  ///
+  /// This is the single place where the calendar's default visuals are defined.
+  /// Fields that depend on runtime state stay null:
+  /// - string builders, which use the ambient locale inside the widgets.
+  /// - [TimeIndicatorStyle.circleColor], which falls back to the line color.
+  /// - text styles that intentionally inherit from [DefaultTextStyle].
+  static KalenderThemeData defaults(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    final tooltipDecoration = BoxDecoration(
+      color: colorScheme.surfaceContainerHighest,
+      borderRadius: BorderRadius.circular(8),
+    );
+
+    return KalenderThemeData(
+      dayHeaderStyle: DayHeaderStyle(
+        textStyle: textTheme.bodySmall,
+        numberTextStyle: textTheme.bodyMedium,
+        mainAxisAlignment: MainAxisAlignment.start,
+      ),
+      timelineStyle: TimelineStyle(
+        textStyle: textTheme.labelMedium,
+        textDirection: TextDirection.ltr,
+        textPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 36),
+        startDecoration: tooltipDecoration,
+        endDecoration: tooltipDecoration,
+      ),
+      hourLinesStyle: HourLinesStyle(
+        color: colorScheme.surfaceContainerHighest,
+        thickness: 1,
+        indent: 0,
+        endIndent: 0,
+      ),
+      daySeparatorStyle: DaySeparatorStyle(
+        color: colorScheme.surfaceContainerHighest,
+        width: 1,
+        topIndent: 0,
+        bottomIndent: 0,
+      ),
+      timeIndicatorStyle: TimeIndicatorStyle(
+        lineColor: colorScheme.error,
+        thickness: 1,
+        circleSize: const Size(10, 10),
+      ),
+      weekNumberStyle: WeekNumberStyle(
+        textStyle: textTheme.bodyMedium,
+        visualDensity: VisualDensity.compact,
+        tooltip: 'Week Number',
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        alignment: Alignment.center,
+      ),
+      monthGridStyle: MonthGridStyle(
+        color: colorScheme.surfaceContainerHighest,
+        thickness: 0,
+      ),
+      monthDayHeaderStyle: MonthDayHeaderStyle(
+        textStyle: textTheme.bodySmall,
+        numberTextStyle: textTheme.bodyMedium,
+      ),
+      weekDayHeaderStyle: WeekDayHeaderStyle(
+        textStyle: textTheme.bodySmall,
+        padding: const EdgeInsets.symmetric(vertical: 2),
+      ),
+      scheduleDateStyle: ScheduleDateStyle(
+        textStyle: textTheme.bodySmall,
+        numberTextStyle: textTheme.bodyMedium,
+      ),
+      scheduleTileHighlightStyle: ScheduleTileHighlightStyle(
+        decoration: BoxDecoration(color: colorScheme.primary.withAlpha(50)),
+      ),
+      multiDayOverlayStyle: const MultiDayOverlayStyle(
+        closeIcon: Icon(Icons.close),
+        headerPadding: EdgeInsets.symmetric(vertical: 8),
+        eventsPadding: EdgeInsets.all(4),
+        eventPadding: EdgeInsets.symmetric(vertical: 2),
+      ),
+      multiDayPortalOverlayButtonStyle: MultiDayPortalOverlayButtonStyle(
+        textStyle: textTheme.bodyMedium,
+        textPadding: const EdgeInsets.symmetric(horizontal: 4),
+        textOverflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
+  @override
+  KalenderThemeData copyWith({
+    DayHeaderStyle? dayHeaderStyle,
+    TimelineStyle? timelineStyle,
+    HourLinesStyle? hourLinesStyle,
+    DaySeparatorStyle? daySeparatorStyle,
+    TimeIndicatorStyle? timeIndicatorStyle,
+    WeekNumberStyle? weekNumberStyle,
+    MonthGridStyle? monthGridStyle,
+    MonthDayHeaderStyle? monthDayHeaderStyle,
+    WeekDayHeaderStyle? weekDayHeaderStyle,
+    ScheduleDateStyle? scheduleDateStyle,
+    ScheduleTileHighlightStyle? scheduleTileHighlightStyle,
+    MultiDayOverlayStyle? multiDayOverlayStyle,
+    MultiDayPortalOverlayButtonStyle? multiDayPortalOverlayButtonStyle,
+  }) {
+    return KalenderThemeData(
+      dayHeaderStyle: dayHeaderStyle ?? this.dayHeaderStyle,
+      timelineStyle: timelineStyle ?? this.timelineStyle,
+      hourLinesStyle: hourLinesStyle ?? this.hourLinesStyle,
+      daySeparatorStyle: daySeparatorStyle ?? this.daySeparatorStyle,
+      timeIndicatorStyle: timeIndicatorStyle ?? this.timeIndicatorStyle,
+      weekNumberStyle: weekNumberStyle ?? this.weekNumberStyle,
+      monthGridStyle: monthGridStyle ?? this.monthGridStyle,
+      monthDayHeaderStyle: monthDayHeaderStyle ?? this.monthDayHeaderStyle,
+      weekDayHeaderStyle: weekDayHeaderStyle ?? this.weekDayHeaderStyle,
+      scheduleDateStyle: scheduleDateStyle ?? this.scheduleDateStyle,
+      scheduleTileHighlightStyle: scheduleTileHighlightStyle ?? this.scheduleTileHighlightStyle,
+      multiDayOverlayStyle: multiDayOverlayStyle ?? this.multiDayOverlayStyle,
+      multiDayPortalOverlayButtonStyle: multiDayPortalOverlayButtonStyle ?? this.multiDayPortalOverlayButtonStyle,
+    );
+  }
+
+  /// Returns a copy of this theme where each style is overlaid with the matching style of [other].
+  ///
+  /// Field-level merge: a style present in both keeps its fields where [other]'s are null.
+  KalenderThemeData merge(KalenderThemeData? other) {
+    if (other == null) return this;
+    return KalenderThemeData(
+      dayHeaderStyle: dayHeaderStyle?.merge(other.dayHeaderStyle) ?? other.dayHeaderStyle,
+      timelineStyle: timelineStyle?.merge(other.timelineStyle) ?? other.timelineStyle,
+      hourLinesStyle: hourLinesStyle?.merge(other.hourLinesStyle) ?? other.hourLinesStyle,
+      daySeparatorStyle: daySeparatorStyle?.merge(other.daySeparatorStyle) ?? other.daySeparatorStyle,
+      timeIndicatorStyle: timeIndicatorStyle?.merge(other.timeIndicatorStyle) ?? other.timeIndicatorStyle,
+      weekNumberStyle: weekNumberStyle?.merge(other.weekNumberStyle) ?? other.weekNumberStyle,
+      monthGridStyle: monthGridStyle?.merge(other.monthGridStyle) ?? other.monthGridStyle,
+      monthDayHeaderStyle: monthDayHeaderStyle?.merge(other.monthDayHeaderStyle) ?? other.monthDayHeaderStyle,
+      weekDayHeaderStyle: weekDayHeaderStyle?.merge(other.weekDayHeaderStyle) ?? other.weekDayHeaderStyle,
+      scheduleDateStyle: scheduleDateStyle?.merge(other.scheduleDateStyle) ?? other.scheduleDateStyle,
+      scheduleTileHighlightStyle:
+          scheduleTileHighlightStyle?.merge(other.scheduleTileHighlightStyle) ?? other.scheduleTileHighlightStyle,
+      multiDayOverlayStyle: multiDayOverlayStyle?.merge(other.multiDayOverlayStyle) ?? other.multiDayOverlayStyle,
+      multiDayPortalOverlayButtonStyle:
+          multiDayPortalOverlayButtonStyle?.merge(other.multiDayPortalOverlayButtonStyle) ??
+              other.multiDayPortalOverlayButtonStyle,
+    );
+  }
+
+  @override
+  KalenderThemeData lerp(KalenderThemeData? other, double t) {
+    if (other == null) return this;
+    return KalenderThemeData(
+      dayHeaderStyle: DayHeaderStyle.lerp(dayHeaderStyle, other.dayHeaderStyle, t),
+      timelineStyle: TimelineStyle.lerp(timelineStyle, other.timelineStyle, t),
+      hourLinesStyle: HourLinesStyle.lerp(hourLinesStyle, other.hourLinesStyle, t),
+      daySeparatorStyle: DaySeparatorStyle.lerp(daySeparatorStyle, other.daySeparatorStyle, t),
+      timeIndicatorStyle: TimeIndicatorStyle.lerp(timeIndicatorStyle, other.timeIndicatorStyle, t),
+      weekNumberStyle: WeekNumberStyle.lerp(weekNumberStyle, other.weekNumberStyle, t),
+      monthGridStyle: MonthGridStyle.lerp(monthGridStyle, other.monthGridStyle, t),
+      monthDayHeaderStyle: MonthDayHeaderStyle.lerp(monthDayHeaderStyle, other.monthDayHeaderStyle, t),
+      weekDayHeaderStyle: WeekDayHeaderStyle.lerp(weekDayHeaderStyle, other.weekDayHeaderStyle, t),
+      scheduleDateStyle: ScheduleDateStyle.lerp(scheduleDateStyle, other.scheduleDateStyle, t),
+      scheduleTileHighlightStyle:
+          ScheduleTileHighlightStyle.lerp(scheduleTileHighlightStyle, other.scheduleTileHighlightStyle, t),
+      multiDayOverlayStyle: MultiDayOverlayStyle.lerp(multiDayOverlayStyle, other.multiDayOverlayStyle, t),
+      multiDayPortalOverlayButtonStyle: MultiDayPortalOverlayButtonStyle.lerp(
+        multiDayPortalOverlayButtonStyle,
+        other.multiDayPortalOverlayButtonStyle,
+        t,
+      ),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is KalenderThemeData &&
+        other.dayHeaderStyle == dayHeaderStyle &&
+        other.timelineStyle == timelineStyle &&
+        other.hourLinesStyle == hourLinesStyle &&
+        other.daySeparatorStyle == daySeparatorStyle &&
+        other.timeIndicatorStyle == timeIndicatorStyle &&
+        other.weekNumberStyle == weekNumberStyle &&
+        other.monthGridStyle == monthGridStyle &&
+        other.monthDayHeaderStyle == monthDayHeaderStyle &&
+        other.weekDayHeaderStyle == weekDayHeaderStyle &&
+        other.scheduleDateStyle == scheduleDateStyle &&
+        other.scheduleTileHighlightStyle == scheduleTileHighlightStyle &&
+        other.multiDayOverlayStyle == multiDayOverlayStyle &&
+        other.multiDayPortalOverlayButtonStyle == multiDayPortalOverlayButtonStyle;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        dayHeaderStyle,
+        timelineStyle,
+        hourLinesStyle,
+        daySeparatorStyle,
+        timeIndicatorStyle,
+        weekNumberStyle,
+        monthGridStyle,
+        monthDayHeaderStyle,
+        weekDayHeaderStyle,
+        scheduleDateStyle,
+        scheduleTileHighlightStyle,
+        multiDayOverlayStyle,
+        multiDayPortalOverlayButtonStyle,
+      );
+}
+
+/// Resolves the effective [KalenderThemeData] for a [BuildContext].
+abstract final class KalenderTheme {
+  /// The effective theme: the Material 3 defaults overlaid with the app's
+  /// [KalenderThemeData] extension, if one is registered on [ThemeData.extensions].
+  ///
+  /// A style passed directly to a widget still takes precedence over the
+  /// value returned here.
+  static KalenderThemeData of(BuildContext context) {
+    final extension = Theme.of(context).extension<KalenderThemeData>();
+    return KalenderThemeData.defaults(context).merge(extension);
+  }
+}

--- a/test/models/kalender_theme_test.dart
+++ b/test/models/kalender_theme_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+void main() {
+  /// Pumps a [MaterialApp] with the given [extension] and hands the inner context to [callback].
+  Future<void> pumpWithTheme(
+    WidgetTester tester, {
+    KalenderThemeData? extension,
+    required void Function(BuildContext context) callback,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [if (extension != null) extension]),
+        home: Builder(
+          builder: (context) {
+            callback(context);
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+  }
+
+  group('KalenderTheme.of', () {
+    testWidgets('returns the Material 3 defaults when no extension is registered', (tester) async {
+      await pumpWithTheme(
+        tester,
+        callback: (context) {
+          final theme = KalenderTheme.of(context);
+          final colorScheme = Theme.of(context).colorScheme;
+          final textTheme = Theme.of(context).textTheme;
+
+          expect(theme.hourLinesStyle?.color, colorScheme.surfaceContainerHighest);
+          expect(theme.hourLinesStyle?.thickness, 1);
+          expect(theme.daySeparatorStyle?.color, colorScheme.surfaceContainerHighest);
+          expect(theme.timeIndicatorStyle?.lineColor, colorScheme.error);
+          expect(theme.timeIndicatorStyle?.circleSize, const Size(10, 10));
+          expect(theme.timeIndicatorStyle?.circleColor, null);
+          expect(theme.dayHeaderStyle?.textStyle, textTheme.bodySmall);
+          expect(theme.dayHeaderStyle?.numberTextStyle, textTheme.bodyMedium);
+          expect(theme.monthDayHeaderStyle?.numberTextStyle, textTheme.bodyMedium);
+          expect(theme.scheduleDateStyle?.numberTextStyle, textTheme.bodyMedium);
+          expect(theme.timelineStyle?.textPadding, const EdgeInsets.symmetric(horizontal: 8, vertical: 36));
+          expect(theme.monthGridStyle?.thickness, 0);
+          expect(theme.weekNumberStyle?.tooltip, 'Week Number');
+          expect(theme.multiDayOverlayStyle?.eventPadding, const EdgeInsets.symmetric(vertical: 2));
+          expect(theme.multiDayPortalOverlayButtonStyle?.textOverflow, TextOverflow.ellipsis);
+        },
+      );
+    });
+
+    testWidgets('extension fields overlay the defaults, field by field', (tester) async {
+      const extension = KalenderThemeData(
+        timeIndicatorStyle: TimeIndicatorStyle(lineColor: Color(0xFF00FF00)),
+        hourLinesStyle: HourLinesStyle(thickness: 3),
+      );
+
+      await pumpWithTheme(
+        tester,
+        extension: extension,
+        callback: (context) {
+          final theme = KalenderTheme.of(context);
+          final colorScheme = Theme.of(context).colorScheme;
+
+          // Overridden fields come from the extension.
+          expect(theme.timeIndicatorStyle?.lineColor, const Color(0xFF00FF00));
+          expect(theme.hourLinesStyle?.thickness, 3);
+
+          // Fields the extension leaves null keep their defaults.
+          expect(theme.timeIndicatorStyle?.thickness, 1);
+          expect(theme.timeIndicatorStyle?.circleSize, const Size(10, 10));
+          expect(theme.hourLinesStyle?.color, colorScheme.surfaceContainerHighest);
+
+          // Styles the extension does not mention are untouched defaults.
+          expect(theme.daySeparatorStyle?.color, colorScheme.surfaceContainerHighest);
+        },
+      );
+    });
+
+    testWidgets('defaults follow the ambient color scheme', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.pink)),
+          home: Builder(
+            builder: (context) {
+              final theme = KalenderTheme.of(context);
+              expect(theme.timeIndicatorStyle?.lineColor, Theme.of(context).colorScheme.error);
+              expect(theme.hourLinesStyle?.color, Theme.of(context).colorScheme.surfaceContainerHighest);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+    });
+  });
+
+  group('KalenderThemeData', () {
+    test('copyWith replaces only the given styles', () {
+      const data = KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 1));
+      final copy = data.copyWith(monthGridStyle: const MonthGridStyle(thickness: 2));
+      expect(copy.monthGridStyle?.thickness, 2);
+      expect(copy.hourLinesStyle, data.hourLinesStyle);
+    });
+
+    test('merge overlays styles field by field', () {
+      const base = KalenderThemeData(
+        hourLinesStyle: HourLinesStyle(color: Color(0xFF000000), thickness: 1),
+        monthGridStyle: MonthGridStyle(thickness: 0),
+      );
+      const overlay = KalenderThemeData(
+        hourLinesStyle: HourLinesStyle(thickness: 5),
+        timeIndicatorStyle: TimeIndicatorStyle(lineColor: Color(0xFF0000FF)),
+      );
+
+      final merged = base.merge(overlay);
+      // Overlay wins where set, base fills the rest of the shared style.
+      expect(merged.hourLinesStyle?.thickness, 5);
+      expect(merged.hourLinesStyle?.color, const Color(0xFF000000));
+      // Styles only one side has come through as-is.
+      expect(merged.monthGridStyle?.thickness, 0);
+      expect(merged.timeIndicatorStyle?.lineColor, const Color(0xFF0000FF));
+      // Merging null is a no-op.
+      expect(base.merge(null), base);
+    });
+
+    test('lerp interpolates the sub-styles', () {
+      const a = KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 1));
+      const b = KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 3));
+      final mid = a.lerp(b, 0.5);
+      expect(mid.hourLinesStyle?.thickness, 2);
+      expect(a.lerp(null, 0.5), a);
+    });
+
+    test('equality', () {
+      const a = KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 1));
+      const b = KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 1));
+      const c = KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 2));
+      expect(a, b);
+      expect(a == c, false);
+    });
+
+    testWidgets('animated theme change interpolates through ThemeData.lerp', (tester) async {
+      const beginStyle = KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 1));
+      const endStyle = KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 3));
+
+      KalenderThemeData? sampled;
+      Widget app(KalenderThemeData data) {
+        return MaterialApp(
+          theme: ThemeData(extensions: [data]),
+          home: Builder(
+            builder: (context) {
+              sampled = Theme.of(context).extension<KalenderThemeData>();
+              return const SizedBox();
+            },
+          ),
+        );
+      }
+
+      await tester.pumpWidget(app(beginStyle));
+      expect(sampled?.hourLinesStyle?.thickness, 1);
+
+      await tester.pumpWidget(app(endStyle));
+      // MaterialApp animates theme changes, so halfway through the transition
+      // the extension is a lerped intermediate value.
+      await tester.pump(kThemeAnimationDuration ~/ 2);
+      final midThickness = sampled?.hourLinesStyle?.thickness;
+      expect(midThickness, greaterThan(1));
+      expect(midThickness, lessThan(3));
+
+      await tester.pumpAndSettle();
+      expect(sampled?.hourLinesStyle?.thickness, 3);
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #314. Second step of the theming work: the theme itself.

## What this adds

- **`KalenderThemeData`** — a `ThemeExtension<KalenderThemeData>` with one field per component style (13 today). Register it on the app theme to style every calendar in the app:

  ```dart
  MaterialApp(
    theme: ThemeData(
      extensions: [
        KalenderThemeData(
          timeIndicatorStyle: TimeIndicatorStyle(lineColor: Colors.pink),
        ),
      ],
    ),
  )
  ```

  Because it is a real theme extension with `lerp`, theme changes animate for free through `ThemeData.lerp` (covered by a test).

- **`KalenderThemeData.defaults(context)`** — the single place the calendar's default visuals are defined, all derived from the ambient Material 3 `colorScheme`/`textTheme`. This centralizes the fallbacks currently scattered through 13 widget `build` methods (and duplicated between files in a few places).

- **`KalenderTheme.of(context)`** — the resolver: Material 3 defaults, overlaid field by field with the app's registered extension. The layering matches Flutter's own component themes: widget-level style ▸ theme extension ▸ M3 defaults.

## Deliberate default decisions (no effect yet)

Nothing changes visually in this PR — the widgets still read their old inline fallbacks until the next PR migrates them to `KalenderTheme.of`. But the defaults builder already records two intentional changes:

- Time indicator: `colorScheme.error` instead of hardcoded `Colors.red`.
- `MonthDayHeaderStyle.numberTextStyle` / `ScheduleDateStyle.numberTextStyle`: `bodyMedium` instead of no themed fallback at all.

Fields that depend on runtime state stay null on purpose: string builders (locale-dependent), `TimeIndicatorStyle.circleColor` (falls back to the line color), and the overlay text styles that inherit from `DefaultTextStyle`.

8 new tests cover default resolution, field-by-field overlay, seed-scheme following, copyWith/merge/lerp/equality, and the animated theme transition.

Next up (separate PR): migrate the leaf widgets to read `KalenderTheme.of(context)`, removing the scattered inline fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)