### PR TITLE
docs: theming section in the readme, web demo uses KalenderThemeData

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A highly customizable Flutter calendar widget with Day, MultiDay, Month, and Sch
 - [Tile Components](#tile-components)
 - [Callbacks](#callbacks)
 - [Configuration & Interaction](#configuration--interaction)
+- [Theming](#theming)
 - [Appearance / Custom Components](#appearance--custom-components)
 - [Event Layout](#event-layout)
 - [Locale](#locale)
@@ -798,9 +799,37 @@ Wrap your `CalendarView` with this widget to enable Ctrl+scroll zooming.
 
 ---
 
+## Theming
+
+Out of the box the calendar follows your app's Material 3 theme: line colors, text styles, and the rest are derived from the ambient `ColorScheme` and `TextTheme`.
+
+To change how every calendar in the app looks, register a `KalenderThemeData` on your theme. Any field you leave out keeps its Material 3 default.
+
+```dart
+MaterialApp(
+  theme: ThemeData(
+    colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+    extensions: [
+      KalenderThemeData(
+        hourLinesStyle: HourLinesStyle(thickness: 2),
+        timeIndicatorStyle: TimeIndicatorStyle(lineColor: Colors.pink),
+      ),
+    ],
+  ),
+)
+```
+
+Styles resolve in three layers, most specific first:
+
+1. A style passed to a single calendar through `CalendarComponents` (see [Appearance](#appearance--custom-components)).
+2. The `KalenderThemeData` registered on the theme.
+3. The Material 3 defaults.
+
+Theme changes animate: because `KalenderThemeData` is a `ThemeExtension` with `lerp`, switching themes transitions the calendar's colors along with the rest of the app.
+
 ## Appearance / Custom Components
 
-Pass a `CalendarComponents` object to `CalendarView` to override default widget builders or just pass style objects to tweak colors, text styles, and padding without defining your own widgets.
+Pass a `CalendarComponents` object to `CalendarView` to override default widget builders or just pass style objects to tweak colors, text styles, and padding without defining your own widgets. Styles passed here apply to that one `CalendarView` and win over the [theme](#theming).
 
 Style classes: [`MultiDayComponentStyles`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/models/components/multi_day_styles.dart), [`MonthComponentStyles`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/models/components/month_styles.dart), [`ScheduleComponentStyles`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/models/components/schedule_components.dart).
 

--- a/examples/web_demo/lib/theme.dart
+++ b/examples/web_demo/lib/theme.dart
@@ -1,11 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:kalender/kalender.dart';
 import 'package:web_demo/utils.dart';
 
 ThemeData buildAppTheme(Brightness brightness) {
   final colorScheme = ColorScheme.fromSeed(seedColor: const Color(0xFF6366F1), brightness: brightness);
+  final lineColor = colorScheme.outlineVariant.withAlpha(60);
+  final mutedText = TextStyle(color: colorScheme.onSurfaceVariant);
   return ThemeData(
     useMaterial3: true,
     colorScheme: colorScheme,
+    extensions: [
+      KalenderThemeData(
+        dayHeaderStyle: DayHeaderStyle(textStyle: mutedText, numberTextStyle: mutedText),
+        hourLinesStyle: HourLinesStyle(color: lineColor),
+        daySeparatorStyle: DaySeparatorStyle(color: lineColor),
+        monthGridStyle: MonthGridStyle(color: lineColor),
+      ),
+    ],
     iconTheme: IconThemeData(size: isTouch ? 22.0 : 18.0, color: colorScheme.onSurfaceVariant),
     appBarTheme: AppBarTheme(
       elevation: 0,

--- a/examples/web_demo/lib/widgets/calendar/calendar.dart
+++ b/examples/web_demo/lib/widgets/calendar/calendar.dart
@@ -162,33 +162,15 @@ class _CalendarContentState extends State<CalendarContent> {
     );
   }
 
+  // The colors and text styles live in the app theme as a KalenderThemeData
+  // extension (see theme.dart). Only widget builders are wired up here.
   CalendarComponents _components(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final lineColor = cs.outlineVariant.withAlpha(60);
-    final mutedText = TextStyle(color: cs.onSurfaceVariant);
     return CalendarComponents(
-      multiDayComponentStyles: MultiDayComponentStyles(
-        headerStyles: MultiDayHeaderComponentStyles(
-          dayHeaderStyle: DayHeaderStyle(
-            textStyle: mutedText,
-            numberTextStyle: mutedText,
-          ),
-        ),
-        bodyStyles: MultiDayBodyComponentStyles(
-          hourLinesStyle: HourLinesStyle(color: lineColor),
-          daySeparatorStyle: DaySeparatorStyle(color: lineColor),
-        ),
-      ),
       monthComponents: MonthComponents(
         bodyComponents: MonthBodyComponents(
           weekNumberBuilder: _buildWeekNumberText,
           monthDayCellBuilder:
               context.configuration.shadeAdjacentMonth ? MonthDayCell.shadeAdjacentMonths() : MonthDayCell.builder,
-        ),
-      ),
-      monthComponentStyles: MonthComponentStyles(
-        bodyStyles: MonthBodyComponentStyles(
-          monthGridStyle: MonthGridStyle(color: lineColor),
         ),
       ),
     );


### PR DESCRIPTION
Stacked on #316 (→ #315 → #314). Final step of the theming series: documentation and the showcase.

- **Readme**: new Theming section (linked from the table of contents) explaining that the calendar follows the app's Material 3 theme out of the box, how to register a `KalenderThemeData`, the three resolution layers, and that theme changes animate. The Appearance section now notes that per-view styles win over the theme.
- **Web demo**: the calendar colors move out of the hand-built `CalendarComponents` in `calendar.dart` into a `KalenderThemeData` extension in `theme.dart`, next to the rest of the app's component themes. The components object keeps only the widget builders (week number text, adjacent-month shading). Nice side effect: the demo's light/dark switch now animates the calendar's line colors along with everything else.

No changelog entry, matching how readme and demo changes are handled.

The whole stack, bottom to top:
1. #314 — style classes become value classes (`copyWith`/`merge`/`lerp`/equality)
2. #315 — `KalenderThemeData` + `KalenderTheme.of` with centralized Material 3 defaults
3. #316 — widgets resolve through the theme, defaults centralized, `eventPadding` fix
4. this PR — docs and demo

Merging in order keeps each diff reviewable. The demo build was verified with the same wasm release command CI uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)