### PR TITLE
chore: release v0.21.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: This Flutter package offers a Calendar Widget featuring Day, MultiDay, Month and Schedule views. Moreover, it empowers you to tailor the visual aspects of the calendar widget.
-version: 0.20.0
+version: 0.21.0
 repository: https://github.com/werner-scholtz/kalender.git
 topics: 
   - calendar


### PR DESCRIPTION
Bump the version to 0.21.0 for release. After this merges, tagging the merge commit `v0.21.0` triggers the pub.dev publish.

This release ships the theming work:
- `KalenderThemeData` / `KalenderTheme.of` with Material 3 defaults (#314, #315, #316)
- Readme theming docs and the themed web demo (#317, #319)
- The `MultiDayOverlayStyle.eventPadding` fix (#316)
- The month-view today-highlight margin tweak with the new `MonthDayHeaderStyle.margin` / `buttonSize` fields (#320)

Pre-release checks on this branch:
- `flutter analyze`: no issues
- `flutter test`: all 1305 tests pass
- `flutter pub publish --dry-run`: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)