### PR TITLE
fix: keep the multi-day overlay card inside the view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - The month view now uses the overlay builders and styles set on `monthComponents`/`monthComponentStyles` instead of letting the global `CalendarComponents.overlayBuilders` and `overlayStyles` shadow them. This matches what `CalendarComponents` documents and what the multi-day header already did. Only apps that set both are affected. [#323](https://github.com/werner-scholtz/kalender/pull/323)
+- The multi-day overlay card no longer runs past the bottom of the view and gets clipped. It was positioned without being measured, so only its top and sides were clamped, which showed up when a day low in the month grid had more events than fit. The card now stays inside the view on all four sides, and its event list scrolls when the card would be taller than the view. [#324](https://github.com/werner-scholtz/kalender/pull/324)
 
 ## 0.21.0
 

--- a/lib/src/widgets/components/multi_day_overlay.dart
+++ b/lib/src/widgets/components/multi_day_overlay.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -146,6 +148,58 @@ class MultiDayOverlayStyle {
       );
 }
 
+/// Positions the overlay card, keeping all four of its edges inside the overlay.
+///
+/// The card has to be measured before it can be placed, since it is always
+/// taller than the day cell it is anchored to. A [SingleChildLayoutDelegate]
+/// receives the measured size in [getPositionForChild], so the card is placed
+/// and clamped in a single pass.
+class _MultiDayOverlayLayoutDelegate extends SingleChildLayoutDelegate {
+  const _MultiDayOverlayLayoutDelegate({
+    required this.anchorTop,
+    required this.anchorCenterX,
+    required this.width,
+  });
+
+  /// Where the top of the card should sit, before clamping.
+  final double anchorTop;
+
+  /// The horizontal center of the button the card belongs to.
+  final double anchorCenterX;
+
+  /// The width of the card.
+  final double width;
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+    // The height is deliberately loose. The card has to measure its own height
+    // for the bottom edge to be clamped, and a tight height brings back the
+    // overflow this delegate exists to prevent.
+    return BoxConstraints(minWidth: width, maxWidth: width, maxHeight: constraints.maxHeight);
+  }
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    // Pull the card up before pushing it down, so that a card which fills the
+    // overlay is aligned to the top rather than the bottom.
+    var top = anchorTop;
+    if (top + childSize.height > size.height) top = size.height - childSize.height;
+    if (top < 0) top = 0;
+
+    final left =
+        (anchorCenterX - childSize.width / 2).clamp(0.0, math.max(0.0, size.width - childSize.width)).toDouble();
+
+    return Offset(left, top);
+  }
+
+  @override
+  bool shouldRelayout(covariant _MultiDayOverlayLayoutDelegate oldDelegate) {
+    return oldDelegate.anchorTop != anchorTop ||
+        oldDelegate.anchorCenterX != anchorCenterX ||
+        oldDelegate.width != width;
+  }
+}
+
 class MultiDayOverlay extends StatelessWidget {
   /// The date for which the widget is created.
   final InternalDateTime date;
@@ -201,45 +255,28 @@ class MultiDayOverlay extends StatelessWidget {
     return Key('multi_day_overlay_close_button_${date.millisecondsSinceEpoch}');
   }
 
-  /// Calculates the top and left position of the overlay.
-  (double top, double left, double right) _calculatePosition(
+  /// Calculates where the overlay card would ideally sit, and how wide it is.
+  ///
+  /// The anchor lines the card's event list up with the day cell's event area,
+  /// putting the header above it. The card is taller than the cell it is
+  /// anchored to, because it lists every event for the day including the hidden
+  /// ones, so [_MultiDayOverlayLayoutDelegate] clamps the anchor to the
+  /// viewport once the card has been measured.
+  (double anchorTop, double anchorCenterX, double width) _calculateAnchor(
     BoxConstraints constraints,
     double headerHeight,
   ) {
     final portalRenderBox = getOverlayPortalRenderBox();
-
-    final multiDayEventsLayoutRenderBox = getMultiDayEventLayoutRenderBox();
-    final multiDayEventsLayoutSize = multiDayEventsLayoutRenderBox.size;
+    final multiDayEventsLayoutSize = getMultiDayEventLayoutRenderBox().size;
 
     // Get the position of the portal widget.
     final portalWidth = portalRenderBox.size.width;
     final portalPosition = portalRenderBox.localToGlobal(Offset.zero);
 
-    // Calculate the left and top position of the overlay.
-    // Ensure the overlay does not go off the top of the screen.
-    var top = portalPosition.dy - multiDayEventsLayoutSize.height - headerHeight;
-    if (top < 0) top = 0;
+    final anchorTop = portalPosition.dy - multiDayEventsLayoutSize.height - headerHeight;
+    final anchorCenterX = portalPosition.dx + portalWidth / 2;
 
-    // Calculate the left position of the overlay.
-    // Ensure the overlay does not go off the left side of the screen.
-    final maxWidth = _determineWidth(constraints);
-    var left = portalPosition.dx - (maxWidth / 2) + portalWidth / 2;
-    if (left < 0) left = 0;
-
-    // Ensure the overlay does not go off the right side of the screen.
-    var width = maxWidth;
-    final right = left + width;
-    if (right > constraints.maxWidth) {
-      if (left > constraints.maxWidth - maxWidth) {
-        // If there is space on the left side, adjust the left position.
-        left = constraints.maxWidth - maxWidth;
-      } else {
-        // Otherwise, adjust the width to fit within the constraints.
-        width = constraints.maxWidth - left;
-      }
-    }
-
-    return (top, left, width);
+    return (anchorTop, anchorCenterX, _determineWidth(constraints));
   }
 
   /// Determines the width of the overlay based on the constraints.
@@ -272,23 +309,25 @@ class MultiDayOverlay extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final headerHeight = _determineHeaderHeight(constraints);
-        final (top, left, width) = _calculatePosition(constraints, headerHeight);
+        final (anchorTop, anchorCenterX, width) = _calculateAnchor(constraints, headerHeight);
         return Stack(
           fit: StackFit.expand,
           children: [
             Positioned.fill(child: GestureDetector(behavior: HitTestBehavior.opaque, onTap: portalController.hide)),
-            Positioned(
-              top: top,
-              left: left,
-              width: width,
+            CustomSingleChildLayout(
+              delegate: _MultiDayOverlayLayoutDelegate(
+                anchorTop: anchorTop,
+                anchorCenterX: anchorCenterX,
+                width: width,
+              ),
               child: Card(
                 key: getOverlayCardKey(date),
                 child: Column(
+                  mainAxisSize: MainAxisSize.min,
                   spacing: 8,
                   children: [
                     SizedBox(
                       height: headerHeight,
-                      width: width,
                       child: Padding(
                         padding: style.headerPadding ?? const EdgeInsets.symmetric(vertical: 8),
                         child: Stack(
@@ -319,54 +358,63 @@ class MultiDayOverlay extends StatelessWidget {
                         ),
                       ),
                     ),
-                    Padding(
-                      padding: style.eventsPadding ?? const EdgeInsets.all(4.0),
-                      child: Stack(
-                        children: [
-                          ListBody(
+                    // Flexible and the scroll view belong together: without
+                    // Flexible the column child keeps an unbounded height and
+                    // never scrolls, and without the scroll view the bounded
+                    // height reaches ListBody, which requires an unbounded one.
+                    Flexible(
+                      child: SingleChildScrollView(
+                        primary: false,
+                        child: Padding(
+                          padding: style.eventsPadding ?? const EdgeInsets.all(4.0),
+                          child: Stack(
                             children: [
-                              for (final event in events)
-                                Padding(
-                                  padding: style.eventPadding ?? const EdgeInsets.symmetric(vertical: 2.0),
-                                  child: SizedBox(
-                                    height: tileHeight,
-                                    child: overlayTileBuilder(
-                                      event,
-                                      InternalDateTimeRange.fromDateTimeRange(date.dayRange),
-                                      portalController.hide,
+                              ListBody(
+                                children: [
+                                  for (final event in events)
+                                    Padding(
+                                      padding: style.eventPadding ?? const EdgeInsets.symmetric(vertical: 2.0),
+                                      child: SizedBox(
+                                        height: tileHeight,
+                                        child: overlayTileBuilder(
+                                          event,
+                                          InternalDateTimeRange.fromDateTimeRange(date.dayRange),
+                                          portalController.hide,
+                                        ),
+                                      ),
                                     ),
-                                  ),
-                                ),
+                                ],
+                              ),
+                              ValueListenableBuilder<CalendarEvent?>(
+                                valueListenable: context.calendarController.selectedEvent,
+                                builder: (context, selectedEvent, child) {
+                                  if (selectedEvent == null) return const SizedBox();
+                                  if (!events.any((e) => e.id == selectedEvent.id)) return const SizedBox();
+
+                                  final eventIndex = events.indexWhere((e) => e.id == selectedEvent.id);
+                                  if (eventIndex == -1) return const SizedBox();
+
+                                  final eventPadding = style.eventPadding ?? const EdgeInsets.symmetric(vertical: 2.0);
+                                  final verticalPadding = eventPadding.vertical;
+
+                                  return Positioned(
+                                    top: eventIndex * (tileHeight + verticalPadding),
+                                    left: 0,
+                                    right: 0,
+                                    height: tileHeight + verticalPadding,
+                                    child: PassThroughPointer(
+                                      child: Padding(
+                                        padding: eventPadding,
+                                        child: context.tileComponents.dropTargetTile?.call(selectedEvent) ??
+                                            const SizedBox(),
+                                      ),
+                                    ),
+                                  );
+                                },
+                              ),
                             ],
                           ),
-                          ValueListenableBuilder<CalendarEvent?>(
-                            valueListenable: context.calendarController.selectedEvent,
-                            builder: (context, selectedEvent, child) {
-                              if (selectedEvent == null) return const SizedBox();
-                              if (!events.any((e) => e.id == selectedEvent.id)) return const SizedBox();
-
-                              final eventIndex = events.indexWhere((e) => e.id == selectedEvent.id);
-                              if (eventIndex == -1) return const SizedBox();
-
-                              final eventPadding = style.eventPadding ?? const EdgeInsets.symmetric(vertical: 2.0);
-                              final verticalPadding = eventPadding.vertical;
-
-                              return Positioned(
-                                top: eventIndex * (tileHeight + verticalPadding),
-                                left: 0,
-                                right: 0,
-                                height: tileHeight + verticalPadding,
-                                child: PassThroughPointer(
-                                  child: Padding(
-                                    padding: eventPadding,
-                                    child:
-                                        context.tileComponents.dropTargetTile?.call(selectedEvent) ?? const SizedBox(),
-                                  ),
-                                ),
-                              );
-                            },
-                          ),
-                        ],
+                        ),
                       ),
                     ),
                   ],

--- a/test/widgets/overlay_test.dart
+++ b/test/widgets/overlay_test.dart
@@ -125,4 +125,123 @@ void main() {
       });
     }
   });
+
+  // The group above anchors the overlay off the week header, which sits at the
+  // top of the view, so the card is never near the bottom edge. The overlay
+  // card used to be positioned without being measured, and only its top and
+  // sides were clamped, so a card anchored low in the view ran off the bottom
+  // and was clipped by the enclosing Stack.
+  group('Month overlay bounds', () {
+    /// Opens the overlay for [day] in a month view of the given [size], with
+    /// [eventCount] events on that day, and returns the card's rect and the
+    /// view's rect.
+    Future<({Rect card, Rect view})> openOverlay(
+      WidgetTester tester, {
+      required DateTime day,
+      required int eventCount,
+      Size size = const Size(800, 600),
+    }) async {
+      final dpi = tester.view.devicePixelRatio;
+      tester.view.physicalSize = Size(size.width * dpi, size.height * dpi);
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final eventsController = DefaultEventsController();
+      for (var i = 0; i < eventCount; i++) {
+        eventsController.addEvent(
+          CalendarEvent(dateTimeRange: DateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+        );
+      }
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        CalendarView(
+          eventsController: eventsController,
+          calendarController: CalendarController(),
+          viewConfiguration: MonthViewConfiguration.singleMonth(
+            displayRange: year2025DisplayRange,
+            initialDateTime: DateTime(2025, 1, 15),
+          ),
+          body: const CalendarBody(),
+        ),
+      );
+
+      final button = find.byKey(MultiDayPortalOverlayButton.getKey(day));
+      expect(button, findsOne, reason: 'the day should overflow and show a "+N more" button');
+
+      await tester.tap(button);
+      await tester.pumpAndSettle();
+
+      final card = find.byKey(MultiDayOverlay.getOverlayCardKey(day));
+      expect(card, findsOne);
+
+      return (card: tester.getRect(card), view: tester.getRect(find.byType(CalendarView)));
+    }
+
+    // January 2025 lays out as 5 rows (Mon 30 Dec - Sun 2 Feb), so the 29th
+    // sits in the last row, closest to the bottom edge.
+    final lastRowDay = DateTime.utc(2025, 1, 29);
+    final firstRowDay = DateTime.utc(2025, 1, 2);
+
+    testWidgets('a day in the last week row stays inside the view', (tester) async {
+      final rects = await openOverlay(tester, day: lastRowDay, eventCount: 8);
+
+      expect(
+        rects.card.bottom,
+        lessThanOrEqualTo(rects.view.bottom),
+        reason: 'card bottom ${rects.card.bottom} overflows view bottom ${rects.view.bottom}',
+      );
+      expect(
+        rects.card.top,
+        greaterThanOrEqualTo(rects.view.top),
+        reason: 'card top ${rects.card.top} is above view top ${rects.view.top}',
+      );
+    });
+
+    testWidgets('a day in the first week row stays inside the view', (tester) async {
+      final rects = await openOverlay(tester, day: firstRowDay, eventCount: 8);
+
+      expect(rects.card.top, greaterThanOrEqualTo(rects.view.top), reason: 'card top ${rects.card.top}');
+      expect(rects.card.bottom, lessThanOrEqualTo(rects.view.bottom), reason: 'card bottom ${rects.card.bottom}');
+    });
+
+    testWidgets('a card taller than the view is capped and scrolls', (tester) async {
+      final rects = await openOverlay(tester, day: lastRowDay, eventCount: 40);
+
+      expect(
+        rects.card.height,
+        lessThanOrEqualTo(rects.view.height),
+        reason: 'card height ${rects.card.height} exceeds view height ${rects.view.height}',
+      );
+      expect(rects.card.top, greaterThanOrEqualTo(rects.view.top));
+      expect(rects.card.bottom, lessThanOrEqualTo(rects.view.bottom));
+
+      final scrollable = find.descendant(
+        of: find.byKey(MultiDayOverlay.getOverlayCardKey(lastRowDay)),
+        matching: find.byType(Scrollable),
+      );
+      expect(scrollable, findsOne, reason: 'the event list should be scrollable');
+
+      final position = tester.state<ScrollableState>(scrollable).position;
+      expect(position.maxScrollExtent, greaterThan(0), reason: 'the events should overflow the capped card');
+
+      await tester.drag(scrollable, const Offset(0, -80));
+      await tester.pumpAndSettle();
+      expect(position.pixels, greaterThan(0), reason: 'the event list should scroll');
+    });
+
+    testWidgets('a card shorter than the view is not scrollable', (tester) async {
+      await openOverlay(tester, day: lastRowDay, eventCount: 8);
+
+      final position = tester
+          .state<ScrollableState>(
+            find.descendant(
+              of: find.byKey(MultiDayOverlay.getOverlayCardKey(lastRowDay)),
+              matching: find.byType(Scrollable),
+            ),
+          )
+          .position;
+
+      expect(position.maxScrollExtent, 0, reason: 'a card that fits should have nothing to scroll');
+    });
+  });
 }


### PR DESCRIPTION
Stacked on #323 — review that first, and this diff will shrink once it lands.

## The bug

Open a month view, pick a day in the last week row with more events than fit, tap "+N more". The card runs past the bottom of the view and is clipped.

`_calculatePosition` clamped the top edge and both sides, but never the bottom — it *couldn't*, because it never measured the card it was positioning:

```dart
var top = portalPosition.dy - multiDayEventsLayoutSize.height - headerHeight;
if (top < 0) top = 0;
```

The card's height is the header plus one row per event, and it lists **every** event for the day including the hidden ones that made the button appear. So it is always taller than the cell it is anchored to and always hangs below the button. It only becomes visible when the button is low enough that the overflow leaves the viewport, where the enclosing `Stack` clips it with the default `Clip.hardEdge`.

Measured: card bottom at **744** in a **600**-tall view. 144 pixels gone.

## The fix

`CustomSingleChildLayout`. Its delegate receives the child's measured size in `getPositionForChild`, so all four edges are clamped in one pass, with no measure-then-reposition frame. The anchor maths stays in `build` (reading the two `RenderBox` callbacks as before) and passes plain numbers to the delegate.

A card can also be taller than the whole view, which clamping alone can't fix, so the delegate caps the height and the event list scrolls.

`Flexible` and the `SingleChildScrollView` are a package deal — worth knowing before anyone "simplifies" one away:
- without `Flexible`, a non-flex `Column` child gets an unbounded main axis regardless of `mainAxisSize`, so the scroll view sizes to full content and never scrolls;
- without the scroll view, the bounded height reaches `RenderListBody`, which asserts its main axis is unbounded.

The dead width-shrink branch is gone: `_determineWidth` returns either 300 (when it fits) or `maxWidth`, so the card always fits horizontally and clamping alone is enough.

## Not breaking

`MultiDayOverlayBuilder` keeps both `RenderBoxCallback`s — the anchor still needs them. Additive only.

## Tests

Four new cases in `test/widgets/overlay_test.dart`, covering last row, first row, a card taller than the view (capped + scrolls), and a card that fits (nothing to scroll). Three of the four fail on the old code with exactly the numbers above (744 vs 600; 1224 vs 600 for the tall card).

The existing tests only used `MultiDayViewConfiguration.week()`, which anchors near the top of the view, so the card was never near the bottom edge.

Also verified by rendering the overlay to an image: the 8-event card now sits flush inside the bottom edge, and the 40-event card is capped to the viewport with the rest scrollable.

Full suite green (1312), analyzer clean.

## Found while testing, not fixed here

In a right-to-left month view the "+N more" buttons land one day late — with events on 29 Jan, LTR shows buttons on the 29th/30th and RTL on the 30th/31st. This reproduces on released `main` (0.21.0) and is unrelated to this change, so I've left it alone. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)