### PR TITLE
docs: show how to theme the "+N more" overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,27 @@ Styles resolve in three layers, most specific first:
 
 Theme changes animate: because `KalenderThemeData` is a `ThemeExtension` with `lerp`, switching themes transitions the calendar's colors along with the rest of the app.
 
+### The "+N more" overlay
+
+The overlay that opens from a "+N more" button is themed the same way. Its card and close button take Flutter's own `CardThemeData` and `ButtonStyle`, so anything you can do to a `Card` or an `IconButton` you can do here.
+
+```dart
+KalenderThemeData(
+  multiDayOverlayStyle: MultiDayOverlayStyle(
+    cardTheme: CardThemeData(
+      color: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+    ),
+    closeButtonStyle: IconButton.styleFrom(backgroundColor: Colors.amber),
+    // Dims the calendar behind the card. Transparent by default.
+    barrierColor: Colors.black54,
+    width: 320,
+  ),
+)
+```
+
+`closeButtonStyle` merges over the defaults of a filled tonal icon button, so it only has to set what it wants to change.
+
 ## Appearance / Custom Components
 
 Pass a `CalendarComponents` object to `CalendarView` to override default widget builders or just pass style objects to tweak colors, text styles, and padding without defining your own widgets. Styles passed here apply to that one `CalendarView` and win over the [theme](#theming).


### PR DESCRIPTION
Readme pass ahead of the 0.22.0 release.

#325 made the overlay card, its close button, and the barrier behind it styleable, but the readme only covered the overlay's button *text* (under Locale). The Theming section had nothing about it.

Adds a short subsection under Theming with a worked example. The bit worth documenting is that `cardTheme` and `closeButtonStyle` take Flutter's own `CardThemeData` and `ButtonStyle` rather than flat per-property fields like the other styles use — that's not guessable from the surrounding docs.

No table of contents entry needed: it's a `###` and the contents only lists `##`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)