### PR TITLE
chore: release v0.22.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: This Flutter package offers a Calendar Widget featuring Day, MultiDay, Month and Schedule views. Moreover, it empowers you to tailor the visual aspects of the calendar widget.
-version: 0.21.0
+version: 0.22.0
 repository: https://github.com/werner-scholtz/kalender.git
 topics: 
   - calendar


### PR DESCRIPTION
Version bump for 0.22.0. Merge #326 (readme) first, then this, then the tag goes on the merge commit.

## What's in 0.22.0

**Features**
- `MultiDayOverlayStyle` gained `cardTheme`, `closeButtonStyle`, `barrierColor`, `width`, `headerHeight` ([#325](https://github.com/werner-scholtz/kalender/pull/325))
- The overlay header date is a plain label instead of a button that did nothing ([#325](https://github.com/werner-scholtz/kalender/pull/325))

**Fixes**
- Month view no longer lets a global `overlayStyles`/`overlayBuilders` shadow the per-view one ([#323](https://github.com/werner-scholtz/kalender/pull/323))
- The overlay card no longer runs past the bottom of the view and gets clipped; it scrolls when taller than the view ([#324](https://github.com/werner-scholtz/kalender/pull/324))

## Why a minor, not a patch

Additive API on `MultiDayOverlayStyle`, no signature changes, nothing removed.

Two behaviour changes worth knowing, neither breaking at the API level:
- the tonal circle behind the overlay's day number is gone, since the date is a label now;
- apps that set *both* a global and a month-specific `overlayStyles` will now get the month-specific one, which is what the docs always said.

## Checks

- `flutter analyze` — no issues
- `flutter test` — 1332 passing
- `flutter pub publish --dry-run` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)