### PR TITLE
feat: highlight today in the overlay, and make every today highlight tonal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Features
 
 - `MultiDayOverlayStyle` gained `cardTheme`, `closeButtonStyle`, `barrierColor`, `width`, and `headerHeight`, so the overlay card, its close button, and the area behind it can be styled to match the rest of the app. The card and button take Flutter's own `CardThemeData` and `ButtonStyle`. All of them default to null, so the stock appearance is unchanged. [#325](https://github.com/werner-scholtz/kalender/pull/325)
-- The date in the overlay header is a plain label instead of a button that did nothing when tapped. It is styled by the existing `MultiDayOverlayStyle.dateTextStyle`, which now defaults to `headlineSmall`. This removes the tonal circle that used to sit behind the day number. [#325](https://github.com/werner-scholtz/kalender/pull/325)
+- The date in the overlay header no longer looks like a button that does nothing when tapped, and it is highlighted when it is today, like the day number in every other view. [#325](https://github.com/werner-scholtz/kalender/pull/325) [#328](https://github.com/werner-scholtz/kalender/pull/328)
+- The today highlight is now tonal in every view, instead of grey. It is drawn with a disabled button so that it is not tappable, and a disabled button paints itself in the disabled colors, which made the highlight read as "unavailable" rather than "today". The day header, month day header, schedule date, and multi-day overlay all share one implementation now, so they cannot drift apart. [#328](https://github.com/werner-scholtz/kalender/pull/328)
 
 ### Fixes
 

--- a/lib/src/theme/kalender_theme.dart
+++ b/lib/src/theme/kalender_theme.dart
@@ -156,7 +156,7 @@ class KalenderThemeData extends ThemeExtension<KalenderThemeData> {
       ),
       multiDayOverlayStyle: MultiDayOverlayStyle(
         closeIcon: const Icon(Icons.close),
-        dateTextStyle: textTheme.headlineSmall,
+        dateTextStyle: textTheme.bodyMedium,
         headerPadding: const EdgeInsets.symmetric(vertical: 8),
         eventsPadding: const EdgeInsets.all(4),
         eventPadding: const EdgeInsets.symmetric(vertical: 2),

--- a/lib/src/widgets/components/day_header.dart
+++ b/lib/src/widgets/components/day_header.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
+import 'package:kalender/src/widgets/internal_components/day_number.dart';
 
 /// The day header builder.
 ///
@@ -138,10 +139,11 @@ class DayHeader extends StatelessWidget {
     );
 
     final localDate = InternalDateTime.fromExternal(date, location: context.location);
-    final isToday = context.isToday(localDate);
-    final button = isToday
-        ? IconButton.filled(key: todayKey, onPressed: null, icon: numberText, visualDensity: VisualDensity.compact)
-        : IconButton(onPressed: null, icon: numberText, visualDensity: VisualDensity.compact);
+    final button = DayNumber(
+      number: numberText,
+      isToday: context.isToday(localDate),
+      todayKey: todayKey,
+    );
 
     final dayName = Text(
       style.stringBuilder?.call(localDate) ?? localDate.dayNameShortLocalized(context.locale),

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
+import 'package:kalender/src/widgets/internal_components/day_number.dart';
 
 /// The month day header builder.
 ///
@@ -121,31 +122,15 @@ class MonthDayHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final style = (KalenderTheme.of(context).monthDayHeaderStyle ?? const MonthDayHeaderStyle()).merge(this.style);
     final localDate = InternalDateTime.fromExternal(date, location: context.location);
-    final isToday = context.isToday(localDate);
-    final numberText = Text(date.day.toString(), style: style.numberTextStyle);
-    final buttonSize = style.buttonSize;
-    final constraints = buttonSize == null ? null : BoxConstraints.tight(buttonSize);
-    final buttonPadding = buttonSize == null ? null : EdgeInsets.zero;
-    final button = isToday
-        ? IconButton.filled(
-            key: todayKey,
-            onPressed: null,
-            icon: numberText,
-            visualDensity: VisualDensity.compact,
-            padding: buttonPadding,
-            constraints: constraints,
-          )
-        : IconButton(
-            onPressed: null,
-            icon: numberText,
-            visualDensity: VisualDensity.compact,
-            padding: buttonPadding,
-            constraints: constraints,
-          );
 
     return Padding(
       padding: style.margin ?? EdgeInsets.zero,
-      child: button,
+      child: DayNumber(
+        number: Text(date.day.toString(), style: style.numberTextStyle),
+        isToday: context.isToday(localDate),
+        todayKey: todayKey,
+        size: style.buttonSize,
+      ),
     );
   }
 }

--- a/lib/src/widgets/components/multi_day_overlay.dart
+++ b/lib/src/widgets/components/multi_day_overlay.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/event_tiles/tiles/multi_day_overlay_tile.dart';
+import 'package:kalender/src/widgets/internal_components/day_number.dart';
 import 'package:kalender/src/widgets/internal_components/pass_through_pointer.dart';
 
 /// A function that returns a [MultiDayEventOverlayTile] for the multi-day overlay.
@@ -327,6 +328,9 @@ class MultiDayOverlay extends StatelessWidget {
     return Key('multi_day_overlay_barrier_${date.millisecondsSinceEpoch}');
   }
 
+  /// Key applied to the [IconButton] when the date is today.
+  static const todayKey = ValueKey('MultiDayOverlay.today');
+
   /// Calculates where the overlay card would ideally sit, and how wide it is.
   ///
   /// The anchor lines the card's event list up with the day cell's event area,
@@ -417,7 +421,11 @@ class MultiDayOverlay extends StatelessWidget {
                               ),
                               Align(
                                 alignment: Alignment.bottomCenter,
-                                child: Text(date.day.toString(), style: style.dateTextStyle),
+                                child: DayNumber(
+                                  number: Text(date.day.toString(), style: style.dateTextStyle),
+                                  isToday: context.isToday(date),
+                                  todayKey: todayKey,
+                                ),
                               ),
                               Align(
                                 alignment: textDirection == TextDirection.ltr ? Alignment.topRight : Alignment.topLeft,

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
+import 'package:kalender/src/widgets/internal_components/day_number.dart';
 
 // TODO: update
 
@@ -104,25 +105,11 @@ class ScheduleDate extends StatelessWidget {
       style: style.textStyle,
     );
 
-    final isToday = context.isToday(date);
-    final button = isToday
-        ? IconButton.filled(
-            key: todayKey,
-            onPressed: null,
-            icon: Text(
-              date.day.toString(),
-              style: style.numberTextStyle,
-            ),
-            visualDensity: VisualDensity.compact,
-          )
-        : IconButton(
-            onPressed: null,
-            icon: Text(
-              date.day.toString(),
-              style: style.numberTextStyle,
-            ),
-            visualDensity: VisualDensity.compact,
-          );
+    final button = DayNumber(
+      number: Text(date.day.toString(), style: style.numberTextStyle),
+      isToday: context.isToday(date),
+      todayKey: todayKey,
+    );
 
     return FittedBox(
       fit: BoxFit.scaleDown,

--- a/lib/src/widgets/internal_components/day_number.dart
+++ b/lib/src/widgets/internal_components/day_number.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+/// The day number shown by the date components, highlighted when it is today.
+///
+/// Shared by every widget that shows a day number, so the today highlight looks
+/// the same everywhere: the day header, the month day header, the schedule
+/// date, and the multi-day overlay.
+///
+/// It is never interactive. It is a label that happens to be drawn like a
+/// button, so [onPressed] is always null and the highlight has to set the
+/// disabled colors to stay tonal.
+class DayNumber extends StatelessWidget {
+  const DayNumber({
+    super.key,
+    required this.number,
+    required this.isToday,
+    required this.todayKey,
+    this.size,
+  });
+
+  /// The day number itself, already styled by the calling component.
+  final Widget number;
+
+  /// Whether [number] is today, and so should be highlighted.
+  final bool isToday;
+
+  /// The key applied when [isToday]. Each component passes its own, so tests
+  /// and consumers can find that component's highlight.
+  final Key todayKey;
+
+  /// The size of the button. When null it keeps its natural size.
+  final Size? size;
+
+  @override
+  Widget build(BuildContext context) {
+    final constraints = size == null ? null : BoxConstraints.tight(size!);
+    final padding = size == null ? null : EdgeInsets.zero;
+
+    if (!isToday) {
+      return IconButton(
+        onPressed: null,
+        icon: number,
+        visualDensity: VisualDensity.compact,
+        padding: padding,
+        constraints: constraints,
+      );
+    }
+
+    final colorScheme = Theme.of(context).colorScheme;
+    return IconButton.filledTonal(
+      key: todayKey,
+      onPressed: null,
+      icon: number,
+      visualDensity: VisualDensity.compact,
+      padding: padding,
+      constraints: constraints,
+      // Without this the button paints with the disabled colors, which greys
+      // the highlight out and reads as "unavailable" rather than "today".
+      style: IconButton.styleFrom(
+        disabledBackgroundColor: colorScheme.secondaryContainer,
+        disabledForegroundColor: colorScheme.onSecondaryContainer,
+      ),
+    );
+  }
+}

--- a/test/widgets/day_number_test.dart
+++ b/test/widgets/day_number_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/src/widgets/internal_components/day_number.dart';
+
+// The today highlight used to be a disabled IconButton.filled, which Material
+// paints with the disabled colors. That greyed it out, so it read as
+// "unavailable" rather than "today". DayNumber keeps the tonal look while
+// staying non-interactive, for every component that shows a day number.
+void main() {
+  const todayKey = ValueKey('test.today');
+
+  Future<ColorScheme> pump(WidgetTester tester, {required bool isToday, Size? size}) async {
+    late ColorScheme colorScheme;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue)),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              colorScheme = Theme.of(context).colorScheme;
+              return DayNumber(
+                number: const Text('15'),
+                isToday: isToday,
+                todayKey: todayKey,
+                size: size,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    return colorScheme;
+  }
+
+  IconButton button(WidgetTester tester) => tester.widget<IconButton>(find.byType(IconButton));
+
+  testWidgets('is never interactive', (tester) async {
+    await pump(tester, isToday: false);
+    expect(button(tester).onPressed, isNull);
+
+    await pump(tester, isToday: true);
+    expect(button(tester).onPressed, isNull, reason: 'the highlight is a label too');
+  });
+
+  testWidgets('applies the today key only when it is today', (tester) async {
+    await pump(tester, isToday: true);
+    expect(find.byKey(todayKey), findsOne);
+
+    await pump(tester, isToday: false);
+    expect(find.byKey(todayKey), findsNothing);
+    expect(find.text('15'), findsOne, reason: 'the number still renders, just unhighlighted');
+  });
+
+  testWidgets('today keeps the tonal colors rather than the disabled greys', (tester) async {
+    final colorScheme = await pump(tester, isToday: true);
+    final style = button(tester).style;
+
+    expect(
+      style?.backgroundColor?.resolve({WidgetState.disabled}),
+      colorScheme.secondaryContainer,
+      reason: 'a disabled button would otherwise paint onSurface at 12% opacity',
+    );
+    expect(style?.foregroundColor?.resolve({WidgetState.disabled}), colorScheme.onSecondaryContainer);
+  });
+
+  testWidgets('a day that is not today is not given a background', (tester) async {
+    await pump(tester, isToday: false);
+    expect(button(tester).style, isNull, reason: 'it should be a plain icon button');
+  });
+
+  testWidgets('size tightens the button, null keeps its natural size', (tester) async {
+    // The size constrains the highlight itself. IconButton keeps its own tap
+    // target around that, so assert what is passed down rather than the
+    // rendered footprint.
+    await pump(tester, isToday: true, size: const Size(28, 28));
+    expect(button(tester).constraints, BoxConstraints.tight(const Size(28, 28)));
+    expect(button(tester).padding, EdgeInsets.zero, reason: 'the padding would fight a tight size');
+
+    await pump(tester, isToday: true);
+    expect(button(tester).constraints, isNull, reason: 'no size means the button decides');
+    expect(button(tester).padding, isNull);
+  });
+}

--- a/test/widgets/overlay_style_test.dart
+++ b/test/widgets/overlay_style_test.dart
@@ -19,6 +19,7 @@ void main() {
     KalenderThemeData? extension,
     MultiDayOverlayStyle? style,
     CardThemeData? appCardTheme,
+    NowCallback? nowCallback,
   }) async {
     final dpi = tester.view.devicePixelRatio;
     tester.view.physicalSize = Size(800 * dpi, 600 * dpi);
@@ -41,6 +42,7 @@ void main() {
             viewConfiguration: MonthViewConfiguration.singleMonth(
               displayRange: year2025DisplayRange,
               initialDateTime: DateTime(2025, 1, 15),
+              nowCallback: nowCallback,
             ),
             components: CalendarComponents(
               monthComponentStyles: MonthComponentStyles(
@@ -188,19 +190,24 @@ void main() {
     });
   });
 
+  // The date used to be an IconButton.filledTonal with `onPressed: () {}` — an
+  // enabled button that did nothing. It is disabled now, and the filled variant
+  // is reserved for today, matching DayHeader, MonthDayHeader and ScheduleDate.
   group('the date in the header', () {
-    testWidgets('is a plain label, not a button that does nothing', (tester) async {
+    /// The IconButton the day number sits in.
+    IconButton dateButton(WidgetTester tester) {
+      return tester.widget<IconButton>(
+        find.ancestor(
+          of: find.descendant(of: find.byKey(MultiDayOverlay.getOverlayCardKey(day)), matching: find.text('15')),
+          matching: find.byType(IconButton),
+        ),
+      );
+    }
+
+    testWidgets('is not interactive', (tester) async {
       await openOverlay(tester);
 
-      final header = find.byKey(MultiDayOverlay.getOverlayCardKey(day));
-      final dateText = find.descendant(of: header, matching: find.text('15'));
-      expect(dateText, findsOne, reason: 'the day number should render');
-
-      expect(
-        find.ancestor(of: dateText, matching: find.byType(IconButton)),
-        findsNothing,
-        reason: 'the date used to be a filled tonal IconButton with an empty onPressed',
-      );
+      expect(dateButton(tester).onPressed, isNull, reason: 'it is a label, it should offer nothing to press');
     });
 
     testWidgets('uses dateTextStyle', (tester) async {
@@ -210,6 +217,36 @@ void main() {
         find.descendant(of: find.byKey(MultiDayOverlay.getOverlayCardKey(day)), matching: find.text('15')),
       );
       expect(text.style?.fontSize, 33);
+    });
+
+    testWidgets('is highlighted when the date is today', (tester) async {
+      await openOverlay(tester, nowCallback: () => DateTime(2025, 1, 15, 10));
+
+      expect(find.byKey(MultiDayOverlay.todayKey), findsOne);
+      expect(
+        find.descendant(of: find.byKey(MultiDayOverlay.todayKey), matching: find.text('15')),
+        findsOne,
+        reason: 'the highlight should be on the overlay\'s own date',
+      );
+      expect(dateButton(tester).onPressed, isNull, reason: 'the highlight is still not interactive');
+    });
+
+    testWidgets('is not highlighted when the date is not today', (tester) async {
+      await openOverlay(tester, nowCallback: () => DateTime(2025, 1, 16, 10));
+
+      expect(find.byKey(MultiDayOverlay.todayKey), findsNothing);
+      expect(
+        find.descendant(of: find.byKey(MultiDayOverlay.getOverlayCardKey(day)), matching: find.text('15')),
+        findsOne,
+        reason: 'the date should still render, just without the highlight',
+      );
+    });
+
+    testWidgets('follows the now callback rather than the real clock', (tester) async {
+      // A neighbouring day being "today" must not highlight this overlay.
+      await openOverlay(tester, nowCallback: () => DateTime(2025, 1, 14, 23, 59));
+
+      expect(find.byKey(MultiDayOverlay.todayKey), findsNothing);
     });
   });
 }


### PR DESCRIPTION
Must land before the 0.22.0 tag — it corrects a call I got wrong in #325, while that change is still unreleased.

## What I got wrong in #325

The overlay's date was `IconButton.filledTonal(onPressed: () {})` — an **enabled** button that did nothing. I read that as "it shouldn't be a button" and made it a plain `Text`.

Wrong diagnosis. The defect was `() {}`, not the button. And the library already had the answer in three places:

```dart
// day_header.dart:142, month_day_header.dart:129, schedule_date.dart:108
final button = isToday
    ? IconButton.filled(key: todayKey, onPressed: null, icon: numberText, ...)
    : IconButton(onPressed: null, icon: numberText, ...);
```

`onPressed: null` is disabled, so it isn't tappable — a label that happens to be drawn like the rest of the calendar's day numbers. My plain `Text` threw out the circle when all that needed changing was `() {}` → `null`, and left no way to get it back.

So the overlay now does what the other three do, and gets a today highlight for free. `dateTextStyle`'s default also moves `headlineSmall` → `bodyMedium`, matching all three siblings' `numberTextStyle` — `headlineSmall` only made sense for a bare label.

## The tonal fix

Those three drew the highlight with a **disabled** `IconButton.filled`, and Material paints disabled buttons with `disabledBackgroundColor` — `onSurface` at 12%. So the today highlight was **grey**, which reads as "unavailable" rather than "today". Setting the disabled colors keeps it tonal:

```dart
style: IconButton.styleFrom(
  disabledBackgroundColor: colorScheme.secondaryContainer,
  disabledForegroundColor: colorScheme.onSecondaryContainer,
),
```

This is a **visual change in every view**, deliberately: month grid, week header, schedule, and the overlay. Verified by rendering each one before and after.

## Why extract DayNumber

The four call sites were byte-identical, and three of them already were before this work. The `styleFrom` override above is subtle and exists only because the button is disabled — inline, it gets pasted four times, and the next person changing the today look has to find all four. That is exactly how they drifted into triplicate.

It is internal (`lib/src/widgets/internal_components/`, not exported), and it is a de-duplication rather than a reusable abstraction: those four are every place in the library that renders a day number, and that list is not going to grow.

## Tests

- `test/widgets/day_number_test.dart` (new): never interactive, `todayKey` only when today, tonal colours resolve for the disabled state rather than the greys, no background when not today, and `size` passing through.
- `test/widgets/overlay_style_test.dart`: the date is not interactive, is highlighted when today, is not when it isn't, and follows the `now` callback rather than the real clock.
- The existing `today_highlight_test.dart` covers the other three components and passes unchanged, which is the check that the refactor preserved their behaviour.

Full suite green (1340), analyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)