### PR TITLE
docs: note that the week number tooltip can be translated too

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,7 +1060,9 @@ CalendarView(
 )
 ```
 
-For the overlay "N more" button text, override the style:
+Day and month names come from `intl`, but the two strings the calendar writes itself default to English. Override them to translate them.
+
+For the overlay "N more" button text:
 
 ```dart
 CalendarView(
@@ -1073,6 +1075,22 @@ CalendarView(
   ),
 )
 ```
+
+For the week number's tooltip, which appears in the month view's week number gutter and in the multi-day header:
+
+```dart
+MaterialApp(
+  theme: ThemeData(
+    extensions: [
+      KalenderThemeData(
+        weekNumberStyle: WeekNumberStyle(tooltip: 'Weeknummer'),
+      ),
+    ],
+  ),
+)
+```
+
+Both can be set either way: on a single `CalendarView` through `CalendarComponents`, or once for the whole app through [`KalenderThemeData`](#theming).
 
 ---
 


### PR DESCRIPTION
Follow-up to #322, which asked for the "N more" text to be internationalized. It already can be, through `MultiDayPortalOverlayButtonStyle.stringBuilder`, and the readme's Locale section covered that. It did not mention the *other* string the calendar writes itself.

There are exactly two, and both default to English with an override available:

| String | Override |
|---|---|
| `'$n more'` | `MultiDayPortalOverlayButtonStyle.stringBuilder` |
| `'Week Number'` | `WeekNumberStyle.tooltip` |

No behaviour change — this is purely the readme.

## Checked rather than assumed

- Both snippets compile (throwaway test against the real API, then deleted).
- The tooltip is shown in the month view's week number gutter **and** in the multi-day header (`multi_day_header.dart:172`). My first draft said it only appears when `showWeekNumbers` is on — that flag is month-only (`month_view_configuration.dart:14`), so the claim was wrong and is gone.
- The `#theming` anchor and the published 0.21.0 Locale section both resolve on pub.dev.

## Considered and rejected

Dropping the English defaults. Both strings are already overridable, so nulling `'Week Number'` would take the tooltip away from every app — including the English ones it was correct for, and dropping screen readers from "3, Week Number" to "3" — to solve something any affected app fixes in one line. `'$n more'` cannot be null at all, since it is the button's only label. The real gap was discoverability, which is a docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)