### PR TITLE
docs: drop the Preview section, it repeated the Live Demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ A highly customizable Flutter calendar widget with Day, MultiDay, Month, and Sch
 ## Table of Contents
 
 - [Features](#features)
-- [Preview](#preview)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Custom Events](#custom-events)
@@ -54,12 +53,6 @@ A highly customizable Flutter calendar widget with Day, MultiDay, Month, and Sch
 * **Locale:** Localize day/month names via the [intl](https://pub.dev/packages/intl) package. [find out more](#locale)
 * **Location:** Timezone-aware display via the [timezone](https://pub.dev/packages/timezone) package. [find out more](#location)
 * **Now callback:** Override what "now" means for the time indicator and today highlighting. Useful when the calendar's `Location` differs from the user's wall-clock time. [find out more](#now-callback)
-
-## Preview
-
-See all views, desktop and mobile, light and dark, in the **[Live Demo](https://werner-scholtz.github.io/kalender/)**.
-
----
 
 ## Installation
 


### PR DESCRIPTION
The readme linked the Live Demo twice, three lines apart:

```markdown
**[Live Demo](...)** · **[Benchmarks](...)** · **[Migration Guide](MIGRATION.md)**
```

```markdown
## Preview

See all views, desktop and mobile, light and dark, in the **[Live Demo](...)**.
```

## Why it ended up like that

The section used to hold inline screenshots. `af5bed81` took them out and left the pointer behind, so a whole section now exists to repeat a link already in the header.

Removes the section and its table of contents entry. No other reference to `#preview` exists, so nothing dangles.

## Why not restore the screenshots instead

`readme_assets/` still has `month_view.png`, `week_view.png` and `schedule_view.png`, all unreferenced since `af5bed81`. Putting them back would give the section a purpose, but they predate the today-highlight change in #328, so they would ship stale on day one. Worth doing properly with regenerated images if you want a visual preview on pub.dev — as its own change, not smuggled into a dedupe.

Left the three images alone: `.pubignore` already excludes `readme_assets/`, so they cost nothing in the published archive and are only repo clutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)