### PR TITLE
fix: stop a tall headerHeight overflowing the overlay card

### DIFF
--- a/lib/src/widgets/components/multi_day_overlay.dart
+++ b/lib/src/widgets/components/multi_day_overlay.dart
@@ -89,7 +89,8 @@ class MultiDayOverlayStyle {
 
   /// The height of the header above the event list.
   ///
-  /// Defaults to [MultiDayOverlay.defaultHeaderHeight].
+  /// Defaults to [MultiDayOverlay.defaultHeaderHeight]. The header is never
+  /// taller than the space available to it.
   final double? headerHeight;
 
   const MultiDayOverlayStyle({
@@ -328,6 +329,12 @@ class MultiDayOverlay extends StatelessWidget {
     return Key('multi_day_overlay_barrier_${date.millisecondsSinceEpoch}');
   }
 
+  /// Returns a [Key] for the card's header, based on the date.
+  static Key getHeaderKey(DateTime date) {
+    assert(date.isUtc, 'Date must be in UTC');
+    return Key('multi_day_overlay_header_${date.millisecondsSinceEpoch}');
+  }
+
   /// Key applied to the [IconButton] when the date is today.
   static const todayKey = ValueKey('MultiDayOverlay.today');
 
@@ -364,20 +371,36 @@ class MultiDayOverlay extends StatelessWidget {
   static const defaultWidth = 300.0;
 
   /// Determines the height of the header, never taller than the space available.
-  double _determineHeaderHeight(BoxConstraints constraints, MultiDayOverlayStyle style) {
-    return math.min(style.headerHeight ?? defaultHeaderHeight, constraints.maxHeight);
+  ///
+  /// The header does not get the whole overlay: [cardMargin] and the gap between
+  /// the header and the event list come out of it first. Clamping against the
+  /// full height instead lets the column overflow by up to that much.
+  double _determineHeaderHeight(BoxConstraints constraints, MultiDayOverlayStyle style, EdgeInsetsGeometry cardMargin) {
+    final available = constraints.maxHeight - cardMargin.vertical - _columnSpacing;
+    return math.min(style.headerHeight ?? defaultHeaderHeight, math.max(0.0, available));
   }
 
   static const defaultHeaderHeight = 80.0;
+
+  /// The gap between the header and the event list.
+  static const _columnSpacing = 8.0;
+
+  /// The margin a [Card] uses when neither the style nor the theme sets one.
+  ///
+  /// Mirrors the Material default, which [Card] applies inside its own size.
+  static const _defaultCardMargin = EdgeInsets.all(4.0);
 
   @override
   Widget build(BuildContext context) {
     final textDirection = Directionality.of(context);
     final style = (KalenderTheme.of(context).multiDayOverlayStyle ?? const MultiDayOverlayStyle()).merge(this.style);
 
+    final cardTheme = style.cardTheme ?? CardTheme.of(context);
+    final cardMargin = cardTheme.margin ?? _defaultCardMargin;
+
     return LayoutBuilder(
       builder: (context, constraints) {
-        final headerHeight = _determineHeaderHeight(constraints, style);
+        final headerHeight = _determineHeaderHeight(constraints, style, cardMargin);
         final (anchorTop, anchorCenterX, width) = _calculateAnchor(constraints, style, headerHeight);
         return Stack(
           fit: StackFit.expand,
@@ -399,14 +422,15 @@ class MultiDayOverlay extends StatelessWidget {
                 width: width,
               ),
               child: CardTheme(
-                data: style.cardTheme ?? CardTheme.of(context),
+                data: cardTheme,
                 child: Card(
                   key: getOverlayCardKey(date),
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
-                    spacing: 8,
+                    spacing: _columnSpacing,
                     children: [
                       SizedBox(
+                        key: getHeaderKey(date),
                         height: headerHeight,
                         child: Padding(
                           padding: style.headerPadding ?? const EdgeInsets.symmetric(vertical: 8),

--- a/test/widgets/overlay_style_test.dart
+++ b/test/widgets/overlay_style_test.dart
@@ -146,6 +146,16 @@ void main() {
 
       expect(barrierColor(tester), const Color(0x80123456));
     });
+
+    testWidgets('tapping the barrier dismisses the overlay', (tester) async {
+      await openOverlay(tester, style: const MultiDayOverlayStyle(barrierColor: Color(0x80123456)));
+
+      // The barrier fills the overlay, so tap a corner well clear of the card.
+      await tester.tapAt(const Offset(4, 4));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(MultiDayOverlay.getOverlayCardKey(day)), findsNothing);
+    });
   });
 
   group('MultiDayOverlayStyle.closeButtonStyle', () {
@@ -168,26 +178,50 @@ void main() {
   });
 
   group('MultiDayOverlayStyle.width and headerHeight', () {
+    /// The rendered size of the card.
+    Size cardSize(WidgetTester tester) => tester.getSize(find.byKey(MultiDayOverlay.getOverlayCardKey(day)));
+
+    /// The rendered height of the header above the event list.
+    double headerHeight(WidgetTester tester) => tester.getSize(find.byKey(MultiDayOverlay.getHeaderKey(day))).height;
+
     testWidgets('default to the documented values', (tester) async {
       await openOverlay(tester);
 
-      final card = tester.getRect(find.byKey(MultiDayOverlay.getOverlayCardKey(day)));
-      expect(card.width, MultiDayOverlay.defaultWidth);
+      expect(cardSize(tester).width, MultiDayOverlay.defaultWidth);
+      expect(headerHeight(tester), MultiDayOverlay.defaultHeaderHeight);
     });
 
     testWidgets('are applied when set', (tester) async {
       await openOverlay(tester, style: const MultiDayOverlayStyle(width: 220, headerHeight: 50));
 
-      final card = tester.getRect(find.byKey(MultiDayOverlay.getOverlayCardKey(day)));
-      expect(card.width, 220);
+      expect(cardSize(tester).width, 220);
+      expect(headerHeight(tester), 50, reason: 'headerHeight should reach the header, not just the style object');
     });
 
     testWidgets('the card never gets wider than the space available', (tester) async {
       await openOverlay(tester, style: const MultiDayOverlayStyle(width: 5000));
 
-      final card = tester.getRect(find.byKey(MultiDayOverlay.getOverlayCardKey(day)));
-      expect(card.width, lessThanOrEqualTo(800));
+      // The overlay spans the whole 800-wide view, so the card fills it exactly.
+      expect(cardSize(tester).width, 800);
     });
+
+    // The header does not get the whole overlay height: the card's margin and
+    // the gap below the header come out of it first. Clamping against the full
+    // height let the column overflow by up to that much, so a headerHeight
+    // within ~16px of the view height painted the overflow stripes.
+    for (final requested in [584.0, 585.0, 590.0, 600.0, 5000.0]) {
+      testWidgets('a headerHeight of $requested on a 600 tall view does not overflow', (tester) async {
+        await openOverlay(tester, style: MultiDayOverlayStyle(headerHeight: requested));
+
+        expect(tester.takeException(), isNull, reason: 'the column should not overflow');
+        expect(
+          headerHeight(tester),
+          lessThanOrEqualTo(600),
+          reason: 'the header should be clamped to what is actually available',
+        );
+        expect(cardSize(tester).height, lessThanOrEqualTo(600));
+      });
+    }
   });
 
   // The date used to be an IconButton.filledTonal with `onPressed: () {}` — an
@@ -217,6 +251,16 @@ void main() {
         find.descendant(of: find.byKey(MultiDayOverlay.getOverlayCardKey(day)), matching: find.text('15')),
       );
       expect(text.style?.fontSize, 33);
+    });
+
+    testWidgets('defaults dateTextStyle to bodyMedium, like the other day numbers', (tester) async {
+      await openOverlay(tester);
+
+      final text = tester.widget<Text>(
+        find.descendant(of: find.byKey(MultiDayOverlay.getOverlayCardKey(day)), matching: find.text('15')),
+      );
+      final expected = Theme.of(tester.element(find.byType(CalendarView))).textTheme.bodyMedium;
+      expect(text.style, expected, reason: 'the M3 default should reach the date');
     });
 
     testWidgets('is highlighted when the date is today', (tester) async {


### PR DESCRIPTION
Found by the pre-release review. **Blocks the v0.22.0 tag** — `headerHeight` is a new field in #325 that has not shipped yet, so this keeps a broken field from ever reaching pub.dev.

## The bug

`_determineHeaderHeight` clamped against the whole overlay height:

```dart
return math.min(style.headerHeight ?? defaultHeaderHeight, constraints.maxHeight);
```

But the header does not get the whole overlay height. Two things come out of it first: the `Card`'s 8px vertical margin, and the `Column`'s 8px `spacing` between the header and the event list. So the real budget is `maxHeight - 16`, and a `headerHeight` in `(maxHeight - 16, maxHeight]` overflows the column — yellow stripes plus a console error.

Reproduced on an 800x600 view, month view, overlay open:

| `headerHeight` | before |
|---|---|
| 584 | fine |
| 585 | `RenderFlex overflowed by 1.00 pixels` |
| 590 | overflowed by 6.0 |
| 600 | overflowed by 16 |

Only the height path was affected. `Card` includes its margin in its own size, so a 300-wide card paints a 292-wide surface and the width clamp was already correct.

## The fix

Clamp against what is actually left. The margin is **resolved from the card theme** rather than assumed to be the default, so an app that sets `cardTheme.margin` (now possible as of #325) is accounted for too. The magic `spacing: 8` became a named constant, since the clamp now depends on it.

## The test was lying

`headerHeight` had no test that read it back. The group is named `'MultiDayOverlayStyle.width and headerHeight'` and passes `headerHeight: 50` — then only asserts the width. Making `_determineHeaderHeight` ignore the style entirely kept all 1340 tests green.

Now:
- the header is measured through a new `MultiDayOverlay.getHeaderKey`, both when set and at its default;
- the overflow is pinned at the boundary (584/585/590/600/5000), verified to fail against the old clamp — 585 and 590 both reproduce;
- `expect(card.width, 800)` replaces a one-sided `lessThanOrEqualTo(800)` that would have passed on a collapsed card.

Two more gaps found the same way, both previously unpinned: the `dateTextStyle: bodyMedium` default, and tapping the barrier to dismiss.

## Checks

- `flutter analyze` clean
- 1347 tests pass, up from 1340
- **all six timezones pass** on the full suite
- `flutter pub publish --dry-run` — 0 warnings
- all five example apps analyze clean

No changelog entry: `headerHeight` has not been released, so 0.22.0 ships it correct rather than fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)