### PR TITLE
fix: put the overflow button on the right day in right-to-left layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.23.0
+
+### Fixes
+
+- The "+N more" overflow button is now attributed to the day its events are on in right-to-left layouts. The layout frame orders its columns by text direction, but read them back as if they always ran left to right, so every button landed on the mirrored date. In a right-to-left month view with events on Wednesday the 29th, the buttons appeared on the 30th and 31st. `MultiDayLayoutFrame` gained an optional `textDirection`, which defaults to left to right, so a custom frame generator is unaffected. [#334](https://github.com/werner-scholtz/kalender/pull/334)
+
 ## 0.22.0
 
 ### Features

--- a/lib/src/layout_delegates/multi_day_event_layout.dart
+++ b/lib/src/layout_delegates/multi_day_event_layout.dart
@@ -208,6 +208,9 @@ MultiDayLayoutFrame defaultMultiDayFrameGenerator({
     events: sortedEvents,
     totalNumberOfRows: sortedEvents.isEmpty ? 0 : maxRow + 1,
     columnRowMap: columnRowMap,
+    // The columns above were ordered by this, so the frame has to read them
+    // back the same way.
+    textDirection: textDirection,
   );
 
   // Store in cache if provided
@@ -292,17 +295,29 @@ class MultiDayLayoutFrame {
   /// A map that contains the number of rows for each date.
   final Map<int, int> columnRowMap;
 
+  /// The direction the columns run in.
+  ///
+  /// Columns are laid out left to right, so in [TextDirection.rtl] column 0 is
+  /// the last date of [dateTimeRange] rather than the first.
+  final TextDirection textDirection;
+
   const MultiDayLayoutFrame({
     required this.dateTimeRange,
     required this.layoutInfo,
     required this.events,
     required this.totalNumberOfRows,
     required this.columnRowMap,
+    this.textDirection = TextDirection.ltr,
   });
 
   /// Returns the date for the given column index.
-  InternalDateTime dateFromColumn(int column) =>
-      InternalDateTime.fromDateTime(dateTimeRange.start.add(Duration(days: column)));
+  ///
+  /// Reads from the end of the range in [TextDirection.rtl], mirroring the
+  /// column order the frame was laid out with.
+  InternalDateTime dateFromColumn(int column) {
+    final days = textDirection == TextDirection.ltr ? column : dateTimeRange.dates().length - 1 - column;
+    return InternalDateTime.fromDateTime(dateTimeRange.start.add(Duration(days: days)));
+  }
 
   /// Returns the visible events and their layout information based on the provided max number of rows.
   ///

--- a/test/widgets/month_rtl_overflow_test.dart
+++ b/test/widgets/month_rtl_overflow_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+// The frame generator reverses its column order for right-to-left, so column 0
+// holds the last date rather than the first. MultiDayLayoutFrame did not know
+// the direction and always read a column back as `start + column days`, so in
+// RTL every "+N more" button was attributed to the mirrored date. With events
+// on Wed 29 Jan the buttons landed on the 30th and 31st.
+void main() {
+  group('MultiDayLayoutFrame.dateFromColumn', () {
+    // Mon 27 Jan - Sun 2 Feb 2025, a single week row of the month grid.
+    final week = InternalDateTimeRange(
+      start: InternalDateTime.fromDateTime(DateTime.utc(2025, 1, 27)),
+      end: InternalDateTime.fromDateTime(DateTime.utc(2025, 2, 3)),
+    );
+
+    MultiDayLayoutFrame frameFor(TextDirection textDirection) {
+      return defaultMultiDayFrameGenerator(
+        events: const [],
+        visibleDateTimeRange: week,
+        textDirection: textDirection,
+        location: null,
+      );
+    }
+
+    test('left to right reads columns from the start of the range', () {
+      final frame = frameFor(TextDirection.ltr);
+
+      expect(frame.dateFromColumn(0), InternalDateTime.fromDateTime(DateTime.utc(2025, 1, 27)));
+      expect(frame.dateFromColumn(2), InternalDateTime.fromDateTime(DateTime.utc(2025, 1, 29)));
+      expect(frame.dateFromColumn(6), InternalDateTime.fromDateTime(DateTime.utc(2025, 2, 2)));
+    });
+
+    test('right to left reads columns from the end of the range', () {
+      final frame = frameFor(TextDirection.rtl);
+
+      // Column 0 is the rightmost day of the range, not the leftmost.
+      expect(frame.dateFromColumn(0), InternalDateTime.fromDateTime(DateTime.utc(2025, 2, 2)));
+      expect(frame.dateFromColumn(4), InternalDateTime.fromDateTime(DateTime.utc(2025, 1, 29)));
+      expect(frame.dateFromColumn(6), InternalDateTime.fromDateTime(DateTime.utc(2025, 1, 27)));
+    });
+
+    test('every column maps to a distinct date in both directions', () {
+      for (final direction in TextDirection.values) {
+        final frame = frameFor(direction);
+        final dates = {for (var c = 0; c < 7; c++) frame.dateFromColumn(c)};
+        expect(dates.length, 7, reason: '$direction should cover the week exactly once');
+        expect(dates, week.dates().toSet(), reason: '$direction should cover the same days');
+      }
+    });
+  });
+
+  group('Month view overflow button dates', () {
+    /// Opens a month view with [eventCount] events on [day] and returns the
+    /// dates the "+N more" buttons were keyed to.
+    Future<Set<DateTime>> buttonDates(
+      WidgetTester tester, {
+      required DateTime day,
+      required TextDirection textDirection,
+      int eventCount = 8,
+    }) async {
+      final dpi = tester.view.devicePixelRatio;
+      tester.view.physicalSize = Size(800 * dpi, 600 * dpi);
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final eventsController = DefaultEventsController();
+      for (var i = 0; i < eventCount; i++) {
+        eventsController.addEvent(
+          CalendarEvent(dateTimeRange: DateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+        );
+      }
+
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        Directionality(
+          textDirection: textDirection,
+          child: CalendarView(
+            eventsController: eventsController,
+            calendarController: CalendarController(),
+            viewConfiguration: MonthViewConfiguration.singleMonth(
+              displayRange: year2025DisplayRange,
+              initialDateTime: DateTime(2025, 1, 15),
+            ),
+            body: const CalendarBody(),
+          ),
+        ),
+      );
+
+      // The button for a date is keyed by that date, so probe the week the
+      // events fall in and collect whichever ones rendered.
+      final found = <DateTime>{};
+      for (var d = 27; d <= 31; d++) {
+        final date = DateTime.utc(2025, 1, d);
+        if (find.byKey(MultiDayPortalOverlayButton.getKey(date)).evaluate().isNotEmpty) found.add(date);
+      }
+      return found;
+    }
+
+    // 29 Jan 2025 is a Wednesday, in the last row of a 5 row January.
+    final day = DateTime.utc(2025, 1, 29);
+
+    testWidgets('left to right attributes the button to the event day', (tester) async {
+      final dates = await buttonDates(tester, day: day, textDirection: TextDirection.ltr);
+
+      expect(dates, contains(day), reason: 'the day the events are on should overflow');
+      expect(dates, isNot(contains(DateTime.utc(2025, 1, 31))), reason: 'a day with no events must not overflow');
+    });
+
+    testWidgets('right to left attributes the button to the same day', (tester) async {
+      final dates = await buttonDates(tester, day: day, textDirection: TextDirection.rtl);
+
+      expect(dates, contains(day), reason: 'direction must not change which date overflows');
+      expect(dates, isNot(contains(DateTime.utc(2025, 1, 31))), reason: 'the mirrored date must not overflow');
+    });
+
+    testWidgets('both directions overflow exactly the same dates', (tester) async {
+      final ltr = await buttonDates(tester, day: day, textDirection: TextDirection.ltr);
+      final rtl = await buttonDates(tester, day: day, textDirection: TextDirection.rtl);
+
+      expect(rtl, ltr, reason: 'text direction is a layout concern, it must not move dates');
+    });
+  });
+}


### PR DESCRIPTION
Found while testing #324. Predates 0.21.0.

In a right-to-left month view the "+N more" buttons land on the wrong days. With 8 events on Wednesday **29 Jan**, LTR puts buttons on the **29th and 30th**, RTL on the **30th and 31st** — every button shifted to its mirrored date, and the overlay it opens lists that wrong day's events.

## Cause

`defaultMultiDayFrameGenerator` orders its columns by text direction:

```dart
final visibleDates = textDirection == TextDirection.ltr ? dates : dates.reversed.toList();
```

So in RTL, column 0 is the **last** date of the range. But `MultiDayLayoutFrame` never carried the direction and always read a column back as if it ran left to right:

```dart
InternalDateTime dateFromColumn(int column) =>
    InternalDateTime.fromDateTime(dateTimeRange.start.add(Duration(days: column)));
```

The arithmetic matches the symptom exactly. For the week row Mon 27 Jan – Sun 2 Feb, RTL places the 29th at column 4 and the 30th at column 3, and the old lookup returns `27 + 4 = 31` and `27 + 3 = 30`.

The visible date range is identical in both directions, so this was never a paging problem — purely the column-to-date mapping.

## Fix

Give the frame the direction it was laid out with, and mirror the lookup. The columns themselves were always right; only reading them back was wrong.

**Not breaking.** `MultiDayLayoutFrame` is public API (exported from `kalender.dart`, and the readme documents `defaultMultiDayFrameGenerator` for custom layouts), so `textDirection` is optional and defaults to `TextDirection.ltr`. A custom generator constructing its own frame is unaffected.

The column count comes from `dateTimeRange.dates().length` rather than `columnRowMap.length`, so a hand-built frame with a partial map still maps correctly.

## Tests

`test/widgets/month_rtl_overflow_test.dart`, all verified to fail before the fix:

- `dateFromColumn` reads from the start in LTR and the end in RTL;
- every column maps to a distinct date, covering the week exactly once, in both directions;
- a month view in each direction attributes the button to the event's day and not the mirrored one;
- both directions overflow **exactly the same set of dates** — text direction is a layout concern and must not move dates.

Full suite 1353 passing (up from 1347), analyzer clean, and all six timezones pass — including the existing `free_scroll_rtl_test.dart`, which exercises the same frame generator.

Changelog under 0.23.0; `pubspec.yaml` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)