### PR TITLE
ci: only run perf benchmarks when the numbers can move

### DIFF
--- a/.github/workflows/performance_profiling.yml
+++ b/.github/workflows/performance_profiling.yml
@@ -3,15 +3,16 @@ name: Performance Benchmarks
 on:
   push:
     branches: [main]
-    # Skip benchmark rebuilds for changes that cannot move the numbers (the static
-    # dashboard page, its deploy workflow, the web demo, and docs) so history
-    # stays meaningful. The `examples/testing` harness that the frame profiling
-    # drives is deliberately not ignored.
-    paths-ignore:
-      - 'benchmark/dashboard/**'
-      - '.github/workflows/deploy_dashboard.yml'
-      - 'examples/web_demo/**'
-      - '**/*.md'
+    # Only run when something that can move the numbers changes: the package, the
+    # micro-benchmark, or the `examples/testing` frame-profiling harness. An
+    # allowlist means new example folders and docs never trigger a run without
+    # anyone maintaining an ignore list.
+    paths:
+      - 'lib/**'
+      - 'benchmark/**'
+      - 'examples/testing/**'
+      - 'pubspec.yaml'
+      - '.github/workflows/performance_profiling.yml'
   # PRs only run when labelled `profile` (see the job-level `if` below), so this
   # does not run for every PR.
   pull_request:


### PR DESCRIPTION
## What

The performance workflow used a `paths-ignore` denylist that skipped docs, the dashboard, and `web_demo`, but **not** the other example folders. So every commit touching an example (and every future example folder) fired the full micro-benchmark + Xvfb frame-profiling run, even though those changes cannot move the measured numbers.

## Change

Flip the `push` trigger to a `paths:` allowlist that runs only when something perf-relevant changes:

- `lib/**` — the package under test
- `benchmark/**` — the micro-benchmark
- `examples/testing/**` — the frame-profiling harness
- `pubspec.yaml` — dependency changes
- the workflow file itself

New example folders and docs no longer trigger a run, with no ignore list to maintain. The job-level `if` (PR `profile`-label gate, web-demo message skip) is unchanged.

## Why now

The upcoming examples cleanup will merge several example-only PRs to `main`; without this, each one would kick off the expensive perf run for no reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)