### PR TITLE
chore(recurrence): drop dead members, expand the README

### DIFF
--- a/examples/recurrence/README.md
+++ b/examples/recurrence/README.md
@@ -1,3 +1,25 @@
 # Recurrence
 
-This example shows how to implement recurring events with the Kalender package.
+Recurring events built on top of `kalender`. The package has no recurrence of its
+own, so this example shows one way to add it in the app.
+
+## How it works
+
+- A `Recurrence` describes the rule (type, first occurrence, count). This example
+  keeps it deliberately small: `none`, `daily`, and `weekly`.
+- Each rule is expanded into concrete `RecurringCalendarEvent`s, which are added to
+  the events controller. Every generated event shares a `groupId`, so editing or
+  deleting one can fan out to the whole group.
+- `RecurrenceController` (`lib/recurrence.dart`) holds the groups and keeps the
+  events controller in sync when a recurrence is created, edited, or removed.
+
+Because occurrences are generated up front, this suits a small, bounded number of
+repeats. For open-ended rules from the iCalendar standard (`RRULE`, "every 2nd
+Tuesday", "repeat forever") see the `ics` example, which expands the rule lazily
+over the visible range instead.
+
+Run it from this directory:
+
+```sh
+flutter run
+```

--- a/examples/recurrence/lib/recurring_event.dart
+++ b/examples/recurrence/lib/recurring_event.dart
@@ -11,13 +11,6 @@ class RecurringCalendarEvent extends CalendarEvent {
     super.interaction,
   });
 
-  factory RecurringCalendarEvent.fromCalendarEvent(CalendarEvent event, String groupId) {
-    return RecurringCalendarEvent(
-      dateTimeRange: event.internalRange(),
-      groupId: groupId,
-    );
-  }
-
   /// Copy the [CalendarEvent] with the new values.
   @override
   RecurringCalendarEvent copyWith({
@@ -62,7 +55,6 @@ class RecurrenceGroup {
   RecurrenceGroup copyWith({
     List<String>? eventIds,
     Recurrence? recurrence,
-    DateTimeRange? originalRange,
   }) {
     return RecurrenceGroup(
       id: id,


### PR DESCRIPTION
Part of the examples cleanup pass (recurrence example).

## Changes
- **Dead code:** removed the never-called `RecurringCalendarEvent.fromCalendarEvent` factory and the unused `originalRange` parameter on `RecurrenceGroup.copyWith`.
- **README:** rewrote the one-liner into a real description — the `groupId` concept, that recurrence is app-side (the package has none), and how this materialize-up-front approach contrasts with the lazy `RRULE` expansion coming in the `ics` example.

## Verification
- `flutter analyze` — clean.
- `flutter test` — the existing test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)