### PR TITLE
chore(testing): drop dead code, add a real README

### DIFF
--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -1,16 +1,33 @@
 # testing
 
-A new Flutter project.
+A performance harness for `kalender`, not a normal app. It drives the calendar
+through loading, navigation, scrolling, rescheduling, and resizing across the
+week, month, and schedule views at 10 and 50 events per day, and records the
+frame-build times.
 
-## Getting Started
+## Run it
 
-This project is a starting point for a Flutter application.
+From this directory, on a device with a display (Linux desktop shown here):
 
-A few resources to get you started if this is your first Flutter project:
+```sh
+flutter drive \
+  --driver=test_driver/perf_driver.dart \
+  --target=integration_test/performance_profiling_test.dart \
+  --profile \
+  -d linux
+```
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+## Knobs and output
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+- `KALENDER_PERF_RUNS` (default 5) sets how many times each scenario runs. Fewer
+  runs trade precision for speed:
+
+  ```sh
+  KALENDER_PERF_RUNS=3 flutter drive ...
+  ```
+
+- Results are written to `build/frame_results.json` (per scenario, view, and
+  workload: average, p90, and p99 build time, plus missed frames).
+
+The CI workflow `performance_profiling.yml` runs this same harness on pushes to
+`main` that can move the numbers and publishes the results to the dashboard.

--- a/examples/testing/integration_test/performance_profiling_test.dart
+++ b/examples/testing/integration_test/performance_profiling_test.dart
@@ -90,7 +90,7 @@ void main() {
             );
           });
 
-          // // 3. Profile scrolling.
+          // 3. Profile scrolling.
           testWidgets('${scenario.name} Scrolling', skip: view != Views.week, (
             tester,
           ) async {

--- a/examples/testing/integration_test/utils.dart
+++ b/examples/testing/integration_test/utils.dart
@@ -1,23 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 import 'package:kalender/kalender.dart';
 import 'package:testing/test_configuration.dart';
 
 import '../test_driver/perf_driver.dart';
-
-/// Extensions for [WidgetTester] to provide desktop-compatible scrolling utilities.
-extension Test on WidgetTester {
-  Future<void> profile({
-    required IntegrationTestWidgetsFlutterBinding binding,
-    required Future<void> Function() test,
-    required String reportKey,
-  }) {
-    return binding.traceAction(
-      () async => await test.call(),
-      reportKey: reportKey,
-    );
-  }
-}
 
 /// Performs a segmented drag operation to simulate realistic user interaction.
 ///

--- a/examples/testing/lib/main.dart
+++ b/examples/testing/lib/main.dart
@@ -30,7 +30,6 @@ class MyApp extends StatelessWidget {
 class Home extends StatefulWidget {
   final TestConfiguration? config;
   const Home({super.key, this.config});
-  static Key getTileKey(int id) => Key('tile-$id');
 
   @override
   State<Home> createState() => _HomeState();


### PR DESCRIPTION
Part of the examples cleanup pass (performance testing harness).

## Changes
- **Dead code:** removed the unused `Home.getTileKey` and the unused `Test.profile` `WidgetTester` extension (and the `integration_test` import that only it needed).
- Fixed a `// //` double-commented line.
- **README:** replaced the default template with real docs — how to run the harness, the `KALENDER_PERF_RUNS` knob, and where the `build/frame_results.json` output lands.

## Verification
- `flutter analyze` — clean. (This example has no plain `flutter test` target; it runs via `flutter drive`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)