### PR TITLE
ci: analyze and test the examples instead of deleting them

### DIFF
--- a/.github/workflows/analyze_examples.yml
+++ b/.github/workflows/analyze_examples.yml
@@ -1,0 +1,57 @@
+name: Analyze Examples
+
+# Only run when something that could affect the example apps changes: the package
+# they depend on, the examples themselves, the root pubspec, or this workflow.
+on:
+  pull_request:
+    branches: [main, main-wip]
+    paths:
+      - 'lib/**'
+      - 'examples/**'
+      - 'pubspec.yaml'
+      - '.github/workflows/analyze_examples.yml'
+  push:
+    branches: [main, main-wip]
+    paths:
+      - 'lib/**'
+      - 'examples/**'
+      - 'pubspec.yaml'
+      - '.github/workflows/analyze_examples.yml'
+
+jobs:
+  analyze-examples:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - example
+          - advanced_example
+          - recurrence
+          - riverpod
+          - ics
+          - web_demo
+          - testing
+    steps:
+      - uses: actions/checkout@v5
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.6
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+        shell: bash
+        working-directory: ./examples/${{ matrix.example }}
+
+      - name: Analyze
+        run: flutter analyze
+        shell: bash
+        working-directory: ./examples/${{ matrix.example }}
+
+      # The testing harness runs via `flutter drive`, not `flutter test`, so it
+      # has no unit test directory. Run tests only where one exists.
+      - name: Test
+        run: if [ -d test ]; then flutter test; else echo "no test directory, skipping"; fi
+        shell: bash
+        working-directory: ./examples/${{ matrix.example }}

--- a/.github/workflows/flutter_analyze_and_test.yml
+++ b/.github/workflows/flutter_analyze_and_test.yml
@@ -18,11 +18,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
 
-      - name: Remove examples folder.
-        run: rm -rf examples/
-        shell: bash
-        working-directory: ./
-
+      # The examples are excluded via analysis_options.yaml (analyzer.exclude) and
+      # verified by the analyze-examples job below.
       - name: Install dependencies
         run: flutter pub get
         shell: bash
@@ -37,6 +34,43 @@ jobs:
         run: flutter analyze
         shell: bash
         working-directory: ./
+
+  analyze-examples: # Analyze and test each example app
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - example
+          - advanced_example
+          - recurrence
+          - riverpod
+          - ics
+          - web_demo
+          - testing
+    steps:
+      - uses: actions/checkout@v5
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.6
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+        shell: bash
+        working-directory: ./examples/${{ matrix.example }}
+
+      - name: Analyze
+        run: flutter analyze
+        shell: bash
+        working-directory: ./examples/${{ matrix.example }}
+
+      # The testing harness runs via `flutter drive`, not `flutter test`, so it
+      # has no unit test directory. Run tests only where one exists.
+      - name: Test
+        run: if [ -d test ]; then flutter test; else echo "no test directory, skipping"; fi
+        shell: bash
+        working-directory: ./examples/${{ matrix.example }}
 
   test: # Separate job for tests with matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/flutter_analyze_and_test.yml
+++ b/.github/workflows/flutter_analyze_and_test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: subosito/flutter-action@v2
 
       # The examples are excluded via analysis_options.yaml (analyzer.exclude) and
-      # verified by the analyze-examples job below.
+      # verified by the separate analyze_examples.yml workflow.
       - name: Install dependencies
         run: flutter pub get
         shell: bash
@@ -34,43 +34,6 @@ jobs:
         run: flutter analyze
         shell: bash
         working-directory: ./
-
-  analyze-examples: # Analyze and test each example app
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        example:
-          - example
-          - advanced_example
-          - recurrence
-          - riverpod
-          - ics
-          - web_demo
-          - testing
-    steps:
-      - uses: actions/checkout@v5
-      - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: 3.44.6
-          channel: stable
-
-      - name: Install dependencies
-        run: flutter pub get
-        shell: bash
-        working-directory: ./examples/${{ matrix.example }}
-
-      - name: Analyze
-        run: flutter analyze
-        shell: bash
-        working-directory: ./examples/${{ matrix.example }}
-
-      # The testing harness runs via `flutter drive`, not `flutter test`, so it
-      # has no unit test directory. Run tests only where one exists.
-      - name: Test
-        run: if [ -d test ]; then flutter test; else echo "no test directory, skipping"; fi
-        shell: bash
-        working-directory: ./examples/${{ matrix.example }}
 
   test: # Separate job for tests with matrix
     runs-on: ubuntu-latest

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,10 @@ include: package:flutter_lints/flutter.yaml
 # https://dart.dev/guides/language/analysis-options
 
 analyzer:
+  # The examples are standalone apps with their own dependencies and lint config;
+  # they are analyzed by the dedicated analyze-examples CI job, not from here.
+  exclude:
+    - examples/**
   language:
     strict-inference: true
     strict-raw-types: true


### PR DESCRIPTION
The capstone of the examples cleanup pass. Lands after #335–#342.

## Problem
The analyze job ran `rm -rf examples/` before analyzing, and no workflow built or tested the example apps. That is exactly how three examples shipped a default counter test that `flutter test` never even discovered.

## Changes
- **Exclude `examples/**` from the root analyzer** via `analysis_options.yaml`, so the root analyze job no longer needs to delete the folder.
- **New `analyze-examples` matrix job**: for every example, run `flutter pub get` + `flutter analyze`, and `flutter test` where a `test/` directory exists (the `testing` harness runs via `flutter drive`, so it has none). Pinned to Flutter 3.44.6 to match the version the examples were verified against and the demo deploy.

Matrix: `example`, `advanced_example`, `recurrence`, `riverpod`, `ics`, `web_demo`, `testing`.

## Verification
- Root `flutter analyze` — clean, and now skips the examples via config.
- Each example was analyzed and tested locally on 3.44.6 while its cleanup PR was prepared; this job makes that a permanent gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)