### PR TITLE
feat: add EventsController.replaceEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.23.0
 
+### Features
+
+- `EventsController` gained `replaceEvents`, which swaps the whole event set in one call. `DefaultEventsController` does it atomically: a single notification and no intermediate empty state, which suits reloading events from a source such as an imported `.ics` file. The base class provides a default that clears then adds, so custom controllers keep working unchanged. [#344](https://github.com/werner-scholtz/kalender/pull/344)
+
 ### Fixes
 
 - The "+N more" overflow button is now attributed to the day its events are on in right-to-left layouts. The layout frame orders its columns by text direction, but read them back as if they always ran left to right, so every button landed on the mirrored date. In a right-to-left month view with events on Wednesday the 29th, the buttons appeared on the 30th and 31st. `MultiDayLayoutFrame` gained an optional `textDirection`, which defaults to left to right, so a custom frame generator is unaffected. [#334](https://github.com/werner-scholtz/kalender/pull/334)

--- a/examples/ics/lib/main.dart
+++ b/examples/ics/lib/main.dart
@@ -88,9 +88,7 @@ class _HomePageState extends State<HomePage> {
 
   void _regenerate(DateTimeRange window) {
     _covered = window;
-    // The controller has no atomic replace, so clear then add.
-    eventsController.clearEvents();
-    eventsController.addEvents(expandEvents(_sources, window));
+    eventsController.replaceEvents(expandEvents(_sources, window));
   }
 
   Future<void> _showExport() async {

--- a/lib/src/models/controllers/events_controller.dart
+++ b/lib/src/models/controllers/events_controller.dart
@@ -40,6 +40,22 @@ abstract class EventsController with ChangeNotifier {
   /// Removes all [CalendarEvent]s from [_events].
   void clearEvents();
 
+  /// Replaces all [CalendarEvent]s with [events] in a single update.
+  ///
+  /// Prefer this over [clearEvents] followed by [addEvents] when swapping the
+  /// whole set, for example after loading a new source. It avoids the
+  /// intermediate empty state and, where the implementation allows, notifies
+  /// listeners once instead of twice.
+  ///
+  /// Returns the id's assigned to the events in order.
+  ///
+  /// The default implementation clears then adds. Subclasses may override to do
+  /// it atomically.
+  List<String> replaceEvents(List<CalendarEvent> events) {
+    clearEvents();
+    return addEvents(events);
+  }
+
   /// Updates an [CalendarEvent].
   ///
   /// The [event] is the event that needs to be changed.

--- a/lib/src/models/controllers/events_controller/default_events_controller.dart
+++ b/lib/src/models/controllers/events_controller/default_events_controller.dart
@@ -62,6 +62,14 @@ class DefaultEventsController extends EventsController {
   }
 
   @override
+  List<String> replaceEvents(List<CalendarEvent> events) {
+    eventStore.clear();
+    final ids = events.map(eventStore.addNewEvent).toList();
+    notifyListeners();
+    return ids;
+  }
+
+  @override
   void updateEvent({
     required CalendarEvent event,
     required CalendarEvent updatedEvent,

--- a/test/models/default_events_controller_test.dart
+++ b/test/models/default_events_controller_test.dart
@@ -188,6 +188,54 @@ void main() {
     });
   });
 
+  // ─── replaceEvents ───────────────────────────────────────────────────────
+
+  group('replaceEvents', () {
+    test('Swaps the whole set: old events gone, new events present', () {
+      final old = List.generate(3, (i) {
+        final start = DateTime.utc(2024, 6, i + 1, 9);
+        return CalendarEvent(dateTimeRange: DateTimeRange(start: start, end: start.add(const Duration(hours: 1))));
+      });
+      controller.addEvents(old);
+
+      final replacement = List.generate(2, (i) {
+        final start = DateTime.utc(2024, 7, i + 1, 9);
+        return CalendarEvent(dateTimeRange: DateTimeRange(start: start, end: start.add(const Duration(hours: 1))));
+      });
+      final ids = controller.replaceEvents(replacement);
+
+      expect(ids.length, replacement.length, reason: 'One id per replacement event.');
+      expect(controller.events.length, replacement.length, reason: 'Only the replacement events remain.');
+      for (final event in old) {
+        expect(controller.events, isNot(contains(event)), reason: 'Old events should be gone.');
+      }
+      for (var i = 0; i < ids.length; i++) {
+        expect(controller.byId(ids[i]), replacement[i], reason: 'Replacement event $i is retrievable by its id.');
+      }
+    });
+
+    test('Notifies listeners exactly once', () {
+      controller.addEvents([
+        CalendarEvent(dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 6, 1, 9), end: DateTime.utc(2024, 6, 1, 10))),
+      ]);
+
+      var count = 0;
+      controller.addListener(() => count++);
+      controller.replaceEvents([
+        CalendarEvent(dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 7, 1, 9), end: DateTime.utc(2024, 7, 1, 10))),
+      ]);
+      expect(count, 1, reason: 'A single atomic update, not a clear followed by an add.');
+    });
+
+    test('Replacing with an empty list clears all events', () {
+      controller.addEvents([
+        CalendarEvent(dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 6, 1, 9), end: DateTime.utc(2024, 6, 1, 10))),
+      ]);
+      controller.replaceEvents([]);
+      expect(controller.events, isEmpty);
+    });
+  });
+
   // ─── ChangeNotifier ──────────────────────────────────────────────────────
 
   group('ChangeNotifier', () {


### PR DESCRIPTION
From the dogfooding backlog (C2), confirmed while building the ics example.

## Problem
Swapping the whole event set meant `clearEvents()` then `addEvents()` — two notifications and a transient empty state. The ics example's recurrence re-expansion (on every navigation past the materialized window) hit exactly this.

## Change
Add `EventsController.replaceEvents(List<CalendarEvent>)`:
- `DefaultEventsController` overrides it to be **atomic** — clears the store and adds in one pass, with a **single** notification and no intermediate empty state.
- The base `EventsController` provides a **default** (clear then add), so any custom controller keeps working unchanged — non-breaking.

The ics example now uses it in place of `clearEvents` + `addEvents`.

## Verification
- New tests: swaps the set (old gone, new present, one id each), notifies exactly once, and empty list clears all.
- Full package suite green (1356 tests). ics example analyzes + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)