### PR TITLE
test(examples): sprinkle targeted tests to catch fringe issues

### DIFF
--- a/examples/advanced_example/test/widget_test.dart
+++ b/examples/advanced_example/test/widget_test.dart
@@ -1,4 +1,5 @@
 import 'package:advanced_example/main.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
 
@@ -9,5 +10,16 @@ void main() {
 
     expect(find.byType(CalendarView), findsOneWidget);
     expect(find.byType(PeopleWidget), findsOneWidget);
+  });
+
+  testWidgets('unmounts without error', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    // Replacing the tree disposes the calendar and the zoom detector; this catches
+    // dispose() paths that touch a deactivated context.
+    await tester.pumpWidget(const SizedBox());
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
   });
 }

--- a/examples/example/test/widget_test.dart
+++ b/examples/example/test/widget_test.dart
@@ -11,4 +11,15 @@ void main() {
     expect(find.byType(CalendarView), findsOneWidget);
     expect(find.byIcon(Icons.today), findsOneWidget);
   });
+
+  testWidgets('unmounts without error', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    // Replacing the tree disposes the calendar; this catches dispose() paths that
+    // touch a deactivated context.
+    await tester.pumpWidget(const SizedBox());
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
 }

--- a/examples/ics/test/widget_test.dart
+++ b/examples/ics/test/widget_test.dart
@@ -44,6 +44,23 @@ void main() {
     expect(ics, contains('SUMMARY:Weekly'));
   });
 
+  test('expansion is bounded to the window', () {
+    final sources = parseIcs(_sample);
+    // A window in February: the single January event is outside it, and only the
+    // February occurrences of the weekly event should be produced.
+    final window = DateTimeRange(start: DateTime(2025, 2, 1), end: DateTime(2025, 2, 28));
+    final events = expandEvents(sources, window);
+
+    expect(events.any((e) => e.uid == 's@example.com'), isFalse, reason: 'single January event is outside the window');
+
+    // February 2025 Mondays: 3, 10, 17, 24.
+    final weekly = events.where((e) => e.uid == 'w@example.com');
+    expect(weekly.length, 4);
+    for (final event in weekly) {
+      expect(event.dateTimeRange.start.isBefore(window.start), isFalse, reason: 'no instance before the window start');
+    }
+  });
+
   testWidgets('renders the calendar', (tester) async {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();

--- a/examples/recurrence/test/widget_test.dart
+++ b/examples/recurrence/test/widget_test.dart
@@ -1,13 +1,33 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:recurrence/main.dart';
+import 'package:recurrence/recurrence.dart';
 
 void main() {
-  testWidgets('App renders without errors', (WidgetTester tester) async {
+  testWidgets('App renders without errors', (tester) async {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
-
-    // Verify the calendar toolbar is present.
-    expect(find.text('Kalender Recurrence Example'), findsNothing); // title is in MaterialApp, not visible
     expect(find.byType(MyHomePage), findsOneWidget);
+  });
+
+  group('RecurrenceType.generateDateTimeRanges', () {
+    final first = DateTimeRange(start: DateTime(2025, 1, 6, 9), end: DateTime(2025, 1, 6, 10));
+
+    test('daily steps one day at a time', () {
+      final ranges = RecurrenceType.daily.generateDateTimeRanges(first, 3);
+      expect(ranges.length, 3);
+      expect(ranges[0].start, DateTime(2025, 1, 6, 9));
+      expect(ranges[1].start, DateTime(2025, 1, 7, 9));
+      expect(ranges[2].start, DateTime(2025, 1, 8, 9));
+    });
+
+    test('weekly steps seven days at a time', () {
+      final ranges = RecurrenceType.weekly.generateDateTimeRanges(first, 2);
+      expect(ranges[1].start, DateTime(2025, 1, 13, 9));
+    });
+
+    test('none yields a single range regardless of count', () {
+      expect(RecurrenceType.none.generateDateTimeRanges(first, 5).length, 1);
+    });
   });
 }

--- a/examples/riverpod/test/widget_test.dart
+++ b/examples/riverpod/test/widget_test.dart
@@ -12,4 +12,15 @@ void main() {
     expect(find.byType(CalendarView), findsOneWidget);
     expect(find.byType(DropdownMenu<ViewConfiguration>), findsOneWidget);
   });
+
+  test('selecting a view updates the provider', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final configs = container.read(viewConfigurationsProvider);
+    expect(container.read(selectedViewProvider), configs.first, reason: 'defaults to the first configuration');
+
+    container.read(selectedViewProvider.notifier).select(configs.last);
+    expect(container.read(selectedViewProvider), configs.last, reason: 'selecting updates the state');
+  });
 }


### PR DESCRIPTION
Your follow-up idea — a few more tests across the examples to catch fringe issues if they ever occur. Kept them robust (logic + clean-teardown), not brittle UI interaction.

## Added
- **recurrence** — unit tests for `RecurrenceType.generateDateTimeRanges` (daily steps a day, weekly steps a week, none yields one range). The recurrence math was previously untested.
- **ics** — asserts recurrence expansion is bounded to the requested window (a January single event stays out of a February window; only the four February Mondays are produced).
- **riverpod** — the selected-view `Notifier` updates state when a view is selected (via `ProviderContainer`, no menu tapping).
- **example** and **advanced_example** — "unmounts without error" tests. Replacing the tree disposes the calendar (and the zoom detector) and asserts no exception — the same bug class as the web_demo overlay dispose crash caught in #342.

## Verification
- All five examples: `flutter analyze` clean, `flutter test` green.
- These run automatically via the `analyze_examples.yml` matrix (#343) on any change to `lib/**` or `examples/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)