### PR TITLE
fix(ics-example): use the controller's visibleDateTimeRange accessor

### DIFF
--- a/examples/ics/lib/main.dart
+++ b/examples/ics/lib/main.dart
@@ -52,13 +52,13 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
-    calendarController.internalDateTimeRange.addListener(_onVisibleRangeChanged);
+    calendarController.visibleDateTimeRange.addListener(_onVisibleRangeChanged);
     _loadSample();
   }
 
   @override
   void dispose() {
-    calendarController.internalDateTimeRange.removeListener(_onVisibleRangeChanged);
+    calendarController.visibleDateTimeRange.removeListener(_onVisibleRangeChanged);
     eventsController.dispose();
     calendarController.dispose();
     super.dispose();
@@ -72,7 +72,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   void _onVisibleRangeChanged() {
-    final visible = calendarController.internalDateTimeRange.value?.forLocation();
+    final visible = calendarController.visibleDateTimeRange.value;
     if (visible == null || _sources.isEmpty) return;
     final covered = _covered;
     if (covered != null && !visible.start.isBefore(covered.start) && !visible.end.isAfter(covered.end)) {


### PR DESCRIPTION
## What

The ics example listened to the lower-level `internalDateTimeRange` and then called `.forLocation()` by hand to compute the visible window. The `CalendarController` already exposes `visibleDateTimeRange`, a location-adjusted `DateTimeRange` it keeps in sync, so the example now uses that directly.

## Why

The example is teaching material, and this is the accessor real apps should reach for. The old approach re-did work the controller already does. Since the example sets no `location` on its `CalendarView`, the two are equivalent, so behaviour is unchanged.

This also closes backlog item N1 ("getting the visible range is indirect") which turned out to be wrong: a first-class accessor already exists.

## Verification

- `flutter analyze` clean.
- `flutter test` green (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMkjy3nLUqGe2bMFCsq2r4