### PR TITLE
ci: drop the redundant examples removal from the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,11 +25,6 @@ jobs:
         with:
           channel: 'stable' 
 
-      - name: Remove examples folder.
-        run: rm -rf examples/
-        shell: bash
-        working-directory: ./
-
       - name: Install dependencies
         run: flutter pub get
 


### PR DESCRIPTION
## What

Removes the `rm -rf examples/` step from `publish.yml`.

## Why

`.pubignore` already lists `examples/`, and `.pubignore` takes precedence over `.gitignore` for `pub publish`, so the examples never make it into the published archive regardless of this step.

Confirmed with a publish dry-run on `main`:

```
Total compressed archive size: 155 KB.
Package has 0 warnings.
```

Zero `examples/` paths appear in the packaged file list, so the step was doing nothing. This just trims dead workflow steps. Closes backlog item H2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMkjy3nLUqGe2bMFCsq2r4