### PR TITLE
refactor: move the string builders off the style classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
 ## 0.23.0
 
-### Breaking changes
+### Breaking Changes
 
-- The string builders moved off the component style classes and onto the matching `*Components` classes, and each one now receives a `BuildContext` as its first argument. They are formatting and localization hooks, not visual style, and since the styles also live inside `KalenderThemeData` they were carrying callbacks into a theme extension, where they cannot interpolate and where an inline lambda breaks the style's value equality on every rebuild. Passing the context also fixes the older problem that a custom builder could not see the calendar's locale while the package's own defaults could. The old fields still work and are honoured whenever the new one is not set, but they are deprecated and will be removed in 0.24.0. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+Nothing here stops existing code from compiling. Each one changes what an unchanged calendar renders.
+
+- The overlay button that stands in for events which do not fit is now labelled `+3` instead of `3 more`. The old label was English with no way for the calendar's locale to reach it, and a plus sign with the count needs no translation. The number is formatted with `intl` for the calendar's locale, so locales with their own numerals read correctly. Set `OverlayBuilders.multiDayPortalOverlayButtonStringBuilder` to get the old wording back. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+
+- `MonthDayHeaderStyle.stringBuilder` was declared but never called, so setting it did nothing. Its replacement, `MonthBodyComponents.monthDayHeaderStringBuilder`, is wired up, which means a calendar that set the old field and worked around it having no effect will now see the day number change. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+
+- The month body now falls back to `CalendarComponents.overlayBuilders` when `MonthBodyComponents` sets none of its own, so a global overlay builder that was silently ignored in the month view starts applying. `MonthBodyComponents.overlayBuilders` defaulted to an empty `OverlayBuilders` rather than null, and the month body resolves it as "the specific one, otherwise the global one", so the empty default always shadowed the global builders. The multi-day header was never affected. This is the builder-side twin of the style-side fix in 0.22.0. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+
+### Deprecations
+
+- The string builders moved off the component style classes and onto the matching `*Components` classes, and each one now receives a `BuildContext` as its first argument. They are formatting and localization hooks, not visual style, and since the styles also live inside `KalenderThemeData` they were carrying callbacks into a theme extension, where they cannot interpolate and where an inline lambda breaks the style's value equality on every rebuild. Passing the context also fixes the older problem that a custom builder could not see the calendar's locale while the package's own defaults could. The old fields still work and are honoured whenever the new one is not set. They will be removed in 0.24.0, which is when the styles become interpolatable and comparable again. [#349](https://github.com/werner-scholtz/kalender/pull/349)
 
   | Old | New |
   | --- | --- |
@@ -14,10 +24,6 @@
   | `ScheduleDateStyle.stringBuilder` | `ScheduleComponents.leadingDateStringBuilder` |
   | `MultiDayPortalOverlayButtonStyle.stringBuilder` | `OverlayBuilders.multiDayPortalOverlayButtonStringBuilder` |
 
-- The overlay button that stands in for events which do not fit is now labelled `+3` instead of `3 more`. The old label was English with no way for the calendar's locale to reach it, and a plus sign with the count needs no translation. The number is formatted with `intl` for the calendar's locale, so locales with their own numerals read correctly. Set `OverlayBuilders.multiDayPortalOverlayButtonStringBuilder` to get the old wording back. [#349](https://github.com/werner-scholtz/kalender/pull/349)
-
-- `MonthDayHeaderStyle.stringBuilder` was declared but never called, so setting it did nothing. Its replacement, `MonthBodyComponents.monthDayHeaderStringBuilder`, is wired up, which means a calendar that set the old field and worked around it having no effect will now see the day number change. [#349](https://github.com/werner-scholtz/kalender/pull/349)
-
 ### Features
 
 - `context.calendarLocale` reads the locale of the enclosing calendar, which is the locale it formats its own dates and times with and not necessarily the app's. It is there so that a custom string builder can format text the same way the calendar does. [#349](https://github.com/werner-scholtz/kalender/pull/349)
@@ -25,8 +31,6 @@
 - `EventsController` gained `replaceEvents`, which swaps the whole event set in one call. `DefaultEventsController` does it atomically: a single notification and no intermediate empty state, which suits reloading events from a source such as an imported `.ics` file. The base class provides a default that clears then adds, so custom controllers keep working unchanged. [#344](https://github.com/werner-scholtz/kalender/pull/344)
 
 ### Fixes
-
-- The month body now falls back to `CalendarComponents.overlayBuilders` when `MonthBodyComponents` sets none of its own. `MonthBodyComponents.overlayBuilders` defaulted to an empty `OverlayBuilders` rather than null, and the month body resolves it as "the specific one, otherwise the global one", so the empty default always shadowed the global builders. The multi-day header was never affected. This is the builder-side twin of the style-side fix in 0.22.0. [#349](https://github.com/werner-scholtz/kalender/pull/349)
 
 - The overflow button is now attributed to the day its events are on in right-to-left layouts. The layout frame orders its columns by text direction, but read them back as if they always ran left to right, so every button landed on the mirrored date. In a right-to-left month view with events on Wednesday the 29th, the buttons appeared on the 30th and 31st. `MultiDayLayoutFrame` gained an optional `textDirection`, which defaults to left to right, so a custom frame generator is unaffected. [#334](https://github.com/werner-scholtz/kalender/pull/334)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,34 @@
 ## 0.23.0
 
+### Breaking changes
+
+- The string builders moved off the component style classes and onto the matching `*Components` classes, and each one now receives a `BuildContext` as its first argument. They are formatting and localization hooks, not visual style, and since the styles also live inside `KalenderThemeData` they were carrying callbacks into a theme extension, where they cannot interpolate and where an inline lambda breaks the style's value equality on every rebuild. Passing the context also fixes the older problem that a custom builder could not see the calendar's locale while the package's own defaults could. The old fields still work and are honoured whenever the new one is not set, but they are deprecated and will be removed in 0.24.0. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+
+  | Old | New |
+  | --- | --- |
+  | `DayHeaderStyle.stringBuilder` | `MultiDayHeaderComponents.dayHeaderStringBuilder` |
+  | `DayHeaderStyle.numberStringBuilder` | `MultiDayHeaderComponents.dayHeaderNumberStringBuilder` |
+  | `TimelineStyle.stringBuilder` | `MultiDayBodyComponents.timelineStringBuilder` |
+  | `MonthDayHeaderStyle.stringBuilder` | `MonthBodyComponents.monthDayHeaderStringBuilder` |
+  | `WeekDayHeaderStyle.stringBuilder` | `MonthHeaderComponents.weekDayHeaderStringBuilder` |
+  | `ScheduleDateStyle.stringBuilder` | `ScheduleComponents.leadingDateStringBuilder` |
+  | `MultiDayPortalOverlayButtonStyle.stringBuilder` | `OverlayBuilders.multiDayPortalOverlayButtonStringBuilder` |
+
+- The overlay button that stands in for events which do not fit is now labelled `+3` instead of `3 more`. The old label was English with no way for the calendar's locale to reach it, and a plus sign with the count needs no translation. The number is formatted with `intl` for the calendar's locale, so locales with their own numerals read correctly. Set `OverlayBuilders.multiDayPortalOverlayButtonStringBuilder` to get the old wording back. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+
+- `MonthDayHeaderStyle.stringBuilder` was declared but never called, so setting it did nothing. Its replacement, `MonthBodyComponents.monthDayHeaderStringBuilder`, is wired up, which means a calendar that set the old field and worked around it having no effect will now see the day number change. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+
 ### Features
+
+- `context.calendarLocale` reads the locale of the enclosing calendar, which is the locale it formats its own dates and times with and not necessarily the app's. It is there so that a custom string builder can format text the same way the calendar does. [#349](https://github.com/werner-scholtz/kalender/pull/349)
 
 - `EventsController` gained `replaceEvents`, which swaps the whole event set in one call. `DefaultEventsController` does it atomically: a single notification and no intermediate empty state, which suits reloading events from a source such as an imported `.ics` file. The base class provides a default that clears then adds, so custom controllers keep working unchanged. [#344](https://github.com/werner-scholtz/kalender/pull/344)
 
 ### Fixes
 
-- The "+N more" overflow button is now attributed to the day its events are on in right-to-left layouts. The layout frame orders its columns by text direction, but read them back as if they always ran left to right, so every button landed on the mirrored date. In a right-to-left month view with events on Wednesday the 29th, the buttons appeared on the 30th and 31st. `MultiDayLayoutFrame` gained an optional `textDirection`, which defaults to left to right, so a custom frame generator is unaffected. [#334](https://github.com/werner-scholtz/kalender/pull/334)
+- The month body now falls back to `CalendarComponents.overlayBuilders` when `MonthBodyComponents` sets none of its own. `MonthBodyComponents.overlayBuilders` defaulted to an empty `OverlayBuilders` rather than null, and the month body resolves it as "the specific one, otherwise the global one", so the empty default always shadowed the global builders. The multi-day header was never affected. This is the builder-side twin of the style-side fix in 0.22.0. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+
+- The overflow button is now attributed to the day its events are on in right-to-left layouts. The layout frame orders its columns by text direction, but read them back as if they always ran left to right, so every button landed on the mirrored date. In a right-to-left month view with events on Wednesday the 29th, the buttons appeared on the 30th and 31st. `MultiDayLayoutFrame` gained an optional `textDirection`, which defaults to left to right, so a custom frame generator is unaffected. [#334](https://github.com/werner-scholtz/kalender/pull/334)
 
 ## 0.22.0
 

--- a/README.md
+++ b/README.md
@@ -1053,23 +1053,10 @@ CalendarView(
 )
 ```
 
-Day and month names come from `intl`, but the two strings the calendar writes itself default to English. Override them to translate them.
-
-For the overlay "N more" button text:
-
-```dart
-CalendarView(
-  components: CalendarComponents(
-    overlayStyles: OverlayStyles(
-      multiDayPortalOverlayButtonStyle: MultiDayPortalOverlayButtonStyle(
-        stringBuilder: (n) => '$n something',
-      ),
-    ),
-  ),
-)
-```
-
-For the week number's tooltip, which appears in the month view's week number gutter and in the multi-day header:
+Day and month names come from `intl`. The overlay button that stands in for events
+that do not fit is labelled with a plus sign and the count, `+3`, with the number
+formatted for the calendar's locale, so it needs no translation. The week number's
+tooltip is the one string that still defaults to English:
 
 ```dart
 MaterialApp(
@@ -1083,7 +1070,37 @@ MaterialApp(
 )
 ```
 
-Both can be set either way: on a single `CalendarView` through `CalendarComponents`, or once for the whole app through [`KalenderThemeData`](#theming).
+It can be set either way: on a single `CalendarView` through `CalendarComponents`, or
+once for the whole app through [`KalenderThemeData`](#theming).
+
+### Custom text
+
+Every string the calendar writes can be replaced with a string builder on the
+matching `*Components` class. Each one receives the `BuildContext`, so it can read
+the calendar's own locale with `context.calendarLocale`, which is not necessarily
+the app's locale:
+
+```dart
+CalendarView(
+  locale: 'af_ZA',
+  components: CalendarComponents(
+    multiDayComponents: MultiDayComponents(
+      headerComponents: MultiDayHeaderComponents(
+        dayHeaderStringBuilder: (context, date) => DateFormat.E(context.calendarLocale).format(date),
+      ),
+    ),
+    overlayBuilders: OverlayBuilders(
+      multiDayPortalOverlayButtonStringBuilder: (context, n) => '$n meer',
+    ),
+  ),
+)
+```
+
+The builders are `dayHeaderStringBuilder` and `dayHeaderNumberStringBuilder` on
+`MultiDayHeaderComponents`, `timelineStringBuilder` on `MultiDayBodyComponents`,
+`monthDayHeaderStringBuilder` on `MonthBodyComponents`, `weekDayHeaderStringBuilder`
+on `MonthHeaderComponents`, `leadingDateStringBuilder` on `ScheduleComponents`, and
+`multiDayPortalOverlayButtonStringBuilder` on `OverlayBuilders`.
 
 ---
 

--- a/lib/kalender.dart
+++ b/lib/kalender.dart
@@ -45,6 +45,7 @@ export 'package:kalender/src/models/components/multi_day_components.dart';
 export 'package:kalender/src/models/components/multi_day_styles.dart';
 export 'package:kalender/src/models/components/schedule_components.dart';
 export 'package:kalender/src/models/components/schedule_styles.dart';
+export 'package:kalender/src/models/components/string_builders.dart';
 export 'package:kalender/src/models/components/tile_components.dart';
 export 'package:kalender/src/widgets/components/schedule_date.dart';
 export 'package:kalender/src/widgets/components/schedule_tile_highlight.dart';

--- a/lib/src/models/components/components.dart
+++ b/lib/src/models/components/components.dart
@@ -5,6 +5,7 @@ import 'package:kalender/src/models/components/multi_day_components.dart';
 import 'package:kalender/src/models/components/multi_day_styles.dart';
 import 'package:kalender/src/models/components/schedule_components.dart';
 import 'package:kalender/src/models/components/schedule_styles.dart';
+import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/widgets/components/multi_day_overlay.dart';
 import 'package:kalender/src/widgets/components/multi_day_overlay_portal.dart';
 import 'package:kalender/src/widgets/components/multi_day_overlay_portal_button.dart';
@@ -65,10 +66,17 @@ class OverlayBuilders {
   /// The builder for the multi day overlay portal button.
   final MultiDayPortalOverlayButtonBuilder? multiDayPortalOverlayButtonBuilder;
 
+  /// Builds the label of the multi day overlay portal button.
+  ///
+  /// Defaults to a plus sign followed by the number of hidden events, with the
+  /// number formatted for the calendar's locale.
+  final HiddenEventCountStringBuilder? multiDayPortalOverlayButtonStringBuilder;
+
   const OverlayBuilders({
     this.multiDayOverlayBuilder,
     this.multiDayOverlayPortalBuilder,
     this.multiDayPortalOverlayButtonBuilder,
+    this.multiDayPortalOverlayButtonStringBuilder,
   });
 }
 

--- a/lib/src/models/components/month_components.dart
+++ b/lib/src/models/components/month_components.dart
@@ -1,4 +1,5 @@
 import 'package:kalender/src/models/components/components.dart';
+import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/widgets/components/month_day_cell.dart';
 import 'package:kalender/src/widgets/components/month_day_header.dart';
 import 'package:kalender/src/widgets/components/month_grid.dart';
@@ -31,6 +32,11 @@ class MonthBodyComponents {
   /// A function that builds the month day header widget.
   final MonthDayHeaderBuilder monthDayHeaderBuilder;
 
+  /// Builds the day number displayed by the month day header.
+  ///
+  /// Defaults to [DateTime.day].
+  final DateStringBuilder? monthDayHeaderStringBuilder;
+
   /// A function that builds the background of each day cell.
   ///
   /// Called once per cell; use it to style individual days, e.g. to gray out
@@ -53,11 +59,12 @@ class MonthBodyComponents {
   const MonthBodyComponents({
     this.monthGridBuilder = MonthGrid.builder,
     this.monthDayHeaderBuilder = MonthDayHeader.builder,
+    this.monthDayHeaderStringBuilder,
     this.monthDayCellBuilder = MonthDayCell.builder,
     this.weekNumberBuilder = WeekNumber.builder,
     this.leftTriggerBuilder,
     this.rightTriggerBuilder,
-    this.overlayBuilders = const OverlayBuilders(),
+    this.overlayBuilders,
   });
 }
 
@@ -68,8 +75,14 @@ class MonthHeaderComponents {
   /// A function that builds the week day header widget.
   final WeekDayHeaderBuilder weekDayHeaderBuilder;
 
+  /// Builds the day name displayed by the week day header.
+  ///
+  /// Defaults to the full day name in the calendar's locale.
+  final DateStringBuilder? weekDayHeaderStringBuilder;
+
   /// Creates overrides for the default components used by the [MonthHeader].
   const MonthHeaderComponents({
     this.weekDayHeaderBuilder = WeekDayHeader.builder,
+    this.weekDayHeaderStringBuilder,
   });
 }

--- a/lib/src/models/components/multi_day_components.dart
+++ b/lib/src/models/components/multi_day_components.dart
@@ -1,4 +1,5 @@
 import 'package:kalender/src/models/components/components.dart';
+import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/widgets/components/day_header.dart';
 import 'package:kalender/src/widgets/components/day_separator.dart';
 import 'package:kalender/src/widgets/components/hour_lines.dart';
@@ -29,6 +30,16 @@ class MultiDayHeaderComponents {
   /// A function that builds the day header widget.
   final DayHeaderBuilder dayHeaderBuilder;
 
+  /// Builds the day name displayed under the day number.
+  ///
+  /// Defaults to the short day name in the calendar's locale.
+  final DateStringBuilder? dayHeaderStringBuilder;
+
+  /// Builds the day number displayed by the day header.
+  ///
+  /// Defaults to [DateTime.day].
+  final DateStringBuilder? dayHeaderNumberStringBuilder;
+
   /// A function that builds the week number widget.
   final WeekNumberBuilder weekNumberBuilder;
 
@@ -44,6 +55,8 @@ class MultiDayHeaderComponents {
   /// Creates overrides for the default components used by the [MultiDayHeader].
   const MultiDayHeaderComponents({
     this.dayHeaderBuilder = DayHeader.builder,
+    this.dayHeaderStringBuilder,
+    this.dayHeaderNumberStringBuilder,
     this.weekNumberBuilder = WeekNumber.builder,
     this.leftTriggerBuilder,
     this.rightTriggerBuilder,
@@ -64,6 +77,13 @@ class MultiDayBodyComponents {
   /// header, body and drag overlay always align. Build the timeline to fill the
   /// width [timelineWidth] resolves to.
   final TimeLineBuilder timeline;
+
+  /// Builds the labels displayed by the timeline.
+  ///
+  /// Defaults to [TimeOfDay.format] in the calendar's locale. The gutter width
+  /// measures every label this can produce, so a builder whose output varies per
+  /// minute still gets a gutter wide enough for it.
+  final TimeOfDayStringBuilder? timelineStringBuilder;
 
   /// Resolves the width of the timeline gutter.
   ///
@@ -94,6 +114,7 @@ class MultiDayBodyComponents {
   const MultiDayBodyComponents({
     this.hourLines = HourLines.builder,
     this.timeline = TimeLine.builder,
+    this.timelineStringBuilder,
     this.timelineWidth = defaultTimelineWidth,
     this.daySeparator = DaySeparator.builder,
     this.timeIndicator = TimeIndicator.builder,

--- a/lib/src/models/components/schedule_components.dart
+++ b/lib/src/models/components/schedule_components.dart
@@ -1,3 +1,4 @@
+import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/widgets/components/schedule_date.dart';
 import 'package:kalender/src/widgets/components/schedule_tile_highlight.dart';
 
@@ -6,11 +7,17 @@ class ScheduleComponents {
   /// A function that builds the day header widget.
   final ScheduleDateBuilder leadingDateBuilder;
 
+  /// Builds the day name displayed above the day number.
+  ///
+  /// Defaults to the first three characters of the day name in the calendar's locale.
+  final DateStringBuilder? leadingDateStringBuilder;
+
   /// A function that builds the highlight tile widget.
   final ScheduleTileHighlightBuilder scheduleTileHighlightBuilder;
 
   const ScheduleComponents({
     this.leadingDateBuilder = ScheduleDate.builder,
+    this.leadingDateStringBuilder,
     this.scheduleTileHighlightBuilder = ScheduleTileHighlight.builder,
   });
 }

--- a/lib/src/models/components/string_builders.dart
+++ b/lib/src/models/components/string_builders.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:kalender/src/models/providers/calendar_provider.dart';
+
+/// Builds the text displayed for [date].
+///
+/// The [date] is a wall-clock [DateTime] in the calendar's configured location.
+/// Read the calendar's locale from the [context] with
+/// [CalendarLocale.calendarLocale].
+typedef DateStringBuilder = String Function(BuildContext context, DateTime date);
+
+/// Builds the text displayed for [time].
+///
+/// Read the calendar's locale from the [context] with
+/// [CalendarLocale.calendarLocale].
+typedef TimeOfDayStringBuilder = String Function(BuildContext context, TimeOfDay time);
+
+/// Builds the text displayed on the overlay button that opens the hidden events.
+///
+/// Read the calendar's locale from the [context] with
+/// [CalendarLocale.calendarLocale].
+typedef HiddenEventCountStringBuilder = String Function(BuildContext context, int numberOfHiddenEvents);
+
+/// Gives a string builder access to the locale of the calendar it is building for.
+extension CalendarLocale on BuildContext {
+  /// The locale of the enclosing calendar, as passed to `CalendarView.locale`.
+  ///
+  /// This is the locale the calendar formats its own dates and times with, which
+  /// is not necessarily the app's locale. Pass it to `intl`'s [DateFormat] or
+  /// [NumberFormat], or to the localized extensions on [DateTime].
+  dynamic get calendarLocale => LocaleProvider.of(this);
+}

--- a/lib/src/widgets/components/day_header.dart
+++ b/lib/src/widgets/components/day_header.dart
@@ -30,11 +30,19 @@ class DayHeaderStyle {
   /// Use this function to customize the string used for the day number.
   ///
   /// By default, the [DateTime.day] is used to get the day number.
+  @Deprecated(
+    'Moved to MultiDayHeaderComponents.dayHeaderNumberStringBuilder, which also receives a BuildContext. '
+    'Will be removed in 0.24.0.',
+  )
   final String Function(DateTime date)? numberStringBuilder;
 
   /// Use this function to customize the sting displayed under the day number.
   ///
   /// By default, the [DateTimeExtensions.dayNameShortLocalized] is used to get the short name of the day in the current locale.
+  @Deprecated(
+    'Moved to MultiDayHeaderComponents.dayHeaderStringBuilder, which also receives a BuildContext. '
+    'Will be removed in 0.24.0.',
+  )
   final String Function(DateTime date)? stringBuilder;
 
   /// Creates a new [DayHeaderStyle].
@@ -132,13 +140,18 @@ class DayHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final style = (KalenderTheme.of(context).dayHeaderStyle ?? const DayHeaderStyle()).merge(this.style);
+    final components = context.components.multiDayComponents.headerComponents;
+
+    final localDate = InternalDateTime.fromExternal(date, location: context.location);
+    final displayDate = localDate.forLocation(location: context.location);
 
     final numberText = Text(
-      style.numberStringBuilder?.call(date) ?? date.day.toString(),
+      components.dayHeaderNumberStringBuilder?.call(context, displayDate) ??
+          style.numberStringBuilder?.call(date) ??
+          date.day.toString(),
       style: style.numberTextStyle,
     );
 
-    final localDate = InternalDateTime.fromExternal(date, location: context.location);
     final button = DayNumber(
       number: numberText,
       isToday: context.isToday(localDate),
@@ -146,7 +159,9 @@ class DayHeader extends StatelessWidget {
     );
 
     final dayName = Text(
-      style.stringBuilder?.call(localDate) ?? localDate.dayNameShortLocalized(context.locale),
+      components.dayHeaderStringBuilder?.call(context, displayDate) ??
+          style.stringBuilder?.call(localDate) ??
+          localDate.dayNameShortLocalized(context.locale),
       style: style.textStyle,
     );
 

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -28,6 +28,10 @@ class MonthDayHeaderStyle {
   final TextStyle? textStyle;
 
   /// Use this function to customize the sting displayed by the [MonthDayHeader].
+  @Deprecated(
+    'Moved to MonthBodyComponents.monthDayHeaderStringBuilder, which also receives a BuildContext. '
+    'Will be removed in 0.24.0.',
+  )
   final String Function(DateTime date)? stringBuilder;
 
   /// The [TextStyle] used by the [MonthDayHeader] widget to display the day number of the week.
@@ -122,11 +126,15 @@ class MonthDayHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final style = (KalenderTheme.of(context).monthDayHeaderStyle ?? const MonthDayHeaderStyle()).merge(this.style);
     final localDate = InternalDateTime.fromExternal(date, location: context.location);
+    final stringBuilder = context.components.monthComponents.bodyComponents.monthDayHeaderStringBuilder;
+    final displayDate = localDate.forLocation(location: context.location);
+    final numberText =
+        stringBuilder?.call(context, displayDate) ?? style.stringBuilder?.call(displayDate) ?? date.day.toString();
 
     return Padding(
       padding: style.margin ?? EdgeInsets.zero,
       child: DayNumber(
-        number: Text(date.day.toString(), style: style.numberTextStyle),
+        number: Text(numberText, style: style.numberTextStyle),
         isToday: context.isToday(localDate),
         todayKey: todayKey,
         size: style.buttonSize,

--- a/lib/src/widgets/components/multi_day_overlay_portal.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal.dart
@@ -127,6 +127,7 @@ class _MultiDayOverlayPortalState extends State<MultiDayOverlayPortal> {
             portalController: _portalController,
             numberOfHiddenRows: widget.numberOfHiddenRows,
             style: widget.overlayStyles?.multiDayPortalOverlayButtonStyle,
+            stringBuilder: widget.overlayBuilders?.multiDayPortalOverlayButtonStringBuilder,
           ),
     );
   }

--- a/lib/src/widgets/components/multi_day_overlay_portal_button.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal_button.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:kalender/src/models/components/string_builders.dart';
+import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
 
 /// The builder used to create the button for the [MultiDayPortalOverlayButton].
@@ -23,6 +26,10 @@ class MultiDayPortalOverlayButtonStyle {
   final TextOverflow? textOverflow;
 
   /// A function that builds a string based on the number of hidden rows.
+  @Deprecated(
+    'Moved to OverlayBuilders.multiDayPortalOverlayButtonStringBuilder, which also receives a BuildContext. '
+    'Will be removed in 0.24.0.',
+  )
   final String Function(int numberOfHiddenRows)? stringBuilder;
 
   const MultiDayPortalOverlayButtonStyle({this.textStyle, this.textPadding, this.stringBuilder, this.textOverflow});
@@ -91,12 +98,23 @@ class MultiDayPortalOverlayButton extends StatelessWidget {
   final OverlayPortalController portalController;
   final int numberOfHiddenRows;
 
+  /// Builds the button's label. Resolved from the [OverlayBuilders] that apply
+  /// to this view, so it follows the same precedence as [style].
+  final HiddenEventCountStringBuilder? stringBuilder;
+
   const MultiDayPortalOverlayButton({
     super.key,
     required this.portalController,
     required this.numberOfHiddenRows,
     required this.style,
+    this.stringBuilder,
   });
+
+  /// The default label: a plus sign and the count, with the number formatted for
+  /// the calendar's locale so locales with their own numerals read correctly.
+  static String defaultLabel(BuildContext context, int numberOfHiddenRows) {
+    return '+${NumberFormat.decimalPattern(context.locale).format(numberOfHiddenRows)}';
+  }
 
   /// Returns a [Key] for the button based on the date.
   static Key getKey(DateTime date) {
@@ -114,7 +132,9 @@ class MultiDayPortalOverlayButton extends StatelessWidget {
       child: Padding(
         padding: style.textPadding ?? const EdgeInsets.symmetric(horizontal: 4.0),
         child: Text(
-          style.stringBuilder?.call(numberOfHiddenRows) ?? '$numberOfHiddenRows more',
+          stringBuilder?.call(context, numberOfHiddenRows) ??
+              style.stringBuilder?.call(numberOfHiddenRows) ??
+              defaultLabel(context, numberOfHiddenRows),
           style: style.textStyle,
           overflow: style.textOverflow,
           key: textKey,

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -28,6 +28,10 @@ class ScheduleDateStyle {
   final TextStyle? textStyle;
 
   /// Use this function to customize the sting displayed by the [ScheduleDate].
+  @Deprecated(
+    'Moved to ScheduleComponents.leadingDateStringBuilder, which also receives a BuildContext. '
+    'Will be removed in 0.24.0.',
+  )
   final String Function(DateTime date)? stringBuilder;
 
   /// The [TextStyle] used by the [ScheduleDate] widget to display the day number of the week.
@@ -100,8 +104,12 @@ class ScheduleDate extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final style = (KalenderTheme.of(context).scheduleDateStyle ?? const ScheduleDateStyle()).merge(this.style);
+    final stringBuilder = context.components.scheduleComponents.leadingDateStringBuilder;
+    final displayDate = date.forLocation(location: context.location);
     final text = Text(
-      style.stringBuilder?.call(date) ?? date.dayNameLocalized(context.locale).characters.take(3).toString(),
+      stringBuilder?.call(context, displayDate) ??
+          style.stringBuilder?.call(date) ??
+          date.dayNameLocalized(context.locale).characters.take(3).toString(),
       style: style.textStyle,
     );
 

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -37,8 +37,8 @@ typedef TimelineWidthBuilder = double Function(
 /// timeline can show across the day and uses the widest, plus the horizontal
 /// text padding. Measuring all labels (rather than a single sample) keeps the
 /// gutter correct regardless of the locale's time format, the hour's digit
-/// count, and any custom [TimelineStyle.stringBuilder]. Honors the ambient
-/// [MediaQuery.textScaler] so it reserves enough room for scaled text.
+/// count, and any custom [MultiDayBodyComponents.timelineStringBuilder]. Honors
+/// the ambient [MediaQuery.textScaler] so it reserves enough room for scaled text.
 double defaultTimelineWidth(BuildContext context, TimeOfDayRange timeOfDayRange, TimelineStyle style) {
   if (style.width != null) return style.width!;
 
@@ -51,19 +51,22 @@ double defaultTimelineWidth(BuildContext context, TimeOfDayRange timeOfDayRange,
     textScaler: MediaQuery.textScalerOf(context),
   );
 
+  final stringBuilder = context.components.multiDayComponents.bodyComponents.timelineStringBuilder;
+
   // With the default label the minute slot is always two digits, so one minute
-  // value per hour is representative. A custom stringBuilder can vary per
+  // value per hour is representative. A custom string builder can vary per
   // minute, so sample every 5-minute mark the timeline can show (its finest
   // segment is 5 minutes).
   const defaultMinutes = [59];
   const customMinutes = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
-  final minutes = style.stringBuilder == null ? defaultMinutes : customMinutes;
+  final hasCustomLabels = stringBuilder != null || style.stringBuilder != null;
+  final minutes = hasCustomLabels ? customMinutes : defaultMinutes;
 
   var widest = 0.0;
   for (var hour = 0; hour < TimeOfDay.hoursPerDay; hour++) {
     for (final minute in minutes) {
       final time = TimeOfDay(hour: hour, minute: minute);
-      final text = style.stringBuilder?.call(time) ?? time.format(context);
+      final text = stringBuilder?.call(context, time) ?? style.stringBuilder?.call(time) ?? time.format(context);
       painter.text = TextSpan(text: text, style: textStyle);
       painter.layout();
       if (painter.width > widest) widest = painter.width;
@@ -98,6 +101,10 @@ class TimelineStyle {
   final double? width;
 
   /// The function that will be used to build the string.
+  @Deprecated(
+    'Moved to MultiDayBodyComponents.timelineStringBuilder, which also receives a BuildContext. '
+    'Will be removed in 0.24.0.',
+  )
   final String Function(TimeOfDay timeOfDay)? stringBuilder;
 
   /// The decoration for the event start time.
@@ -214,6 +221,14 @@ mixin TimeLineUtils {
   TimelineStyle effectiveStyle(BuildContext context) =>
       (KalenderTheme.of(context).timelineStyle ?? const TimelineStyle()).merge(timelineStyle);
 
+  /// The label shown for [time].
+  String timelineString(BuildContext context, TimeOfDay time) {
+    final stringBuilder = context.components.multiDayComponents.bodyComponents.timelineStringBuilder;
+    return stringBuilder?.call(context, time) ??
+        effectiveStyle(context).stringBuilder?.call(time) ??
+        time.format(context);
+  }
+
   /// The [TextStyle] that will be used for the text.
   TextStyle textStyle(BuildContext context) =>
       effectiveStyle(context).textStyle ?? Theme.of(context).textTheme.labelMedium!;
@@ -228,7 +243,7 @@ mixin TimeLineUtils {
   /// The [Size] of the largest text.
   Size largestTextSize(BuildContext context, TextStyle textStyle, EdgeInsets padding) {
     const displayTime = TimeOfDay(hour: 23, minute: 59);
-    final text = effectiveStyle(context).stringBuilder?.call(displayTime) ?? displayTime.format(context);
+    final text = timelineString(context, displayTime);
     final textSize = _textSize(text, textStyle, textDirection(context));
     return Size(textSize.width + padding.horizontal, textSize.height + padding.vertical);
   }
@@ -346,7 +361,7 @@ class TimeLine extends StatelessWidget with TimeLineUtils {
 
       // The time to display is the next hour.
       final displayTime = range.start;
-      final text = style.stringBuilder?.call(displayTime) ?? displayTime.format(context);
+      final text = timelineString(context, displayTime);
 
       return Positioned(
         top: pos - textXOffset,
@@ -393,8 +408,8 @@ class TimeLine extends StatelessWidget with TimeLineUtils {
 
             final startTime = TimeOfDay.fromDateTime(start);
             final endTime = TimeOfDay.fromDateTime(end);
-            final startText = style.stringBuilder?.call(startTime) ?? startTime.format(context);
-            final endText = style.stringBuilder?.call(endTime) ?? endTime.format(context);
+            final startText = timelineString(context, startTime);
+            final endText = timelineString(context, endTime);
 
             return Stack(
               children: [

--- a/lib/src/widgets/components/week_day_header.dart
+++ b/lib/src/widgets/components/week_day_header.dart
@@ -24,6 +24,10 @@ class WeekDayHeaderStyle {
   final TextStyle? textStyle;
 
   /// Use this function to customize the sting displayed by the [WeekDayHeader].
+  @Deprecated(
+    'Moved to MonthHeaderComponents.weekDayHeaderStringBuilder, which also receives a BuildContext. '
+    'Will be removed in 0.24.0.',
+  )
   final String Function(DateTime date)? stringBuilder;
 
   /// The padding around the [WeekDayHeader] widget.
@@ -93,7 +97,9 @@ class WeekDayHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final style = (KalenderTheme.of(context).weekDayHeaderStyle ?? const WeekDayHeaderStyle()).merge(this.style);
     final padding = style.padding ?? const EdgeInsets.symmetric(vertical: 2);
-    final dateText = style.stringBuilder?.call(date) ?? date.dayNameLocalized(context.locale);
+    final stringBuilder = context.components.monthComponents.headerComponents.weekDayHeaderStringBuilder;
+    final dateText =
+        stringBuilder?.call(context, date) ?? style.stringBuilder?.call(date) ?? date.dayNameLocalized(context.locale);
     return Padding(padding: padding, child: Center(child: Text(dateText, style: style.textStyle)));
   }
 }

--- a/test/layout/multi_day_event_layout_test.dart
+++ b/test/layout/multi_day_event_layout_test.dart
@@ -195,9 +195,9 @@ void main() {
       // One overflow button should appear.
       expect(find.byType(MultiDayPortalOverlayButton), findsOneWidget);
 
-      // The button must show '1 more' (one hidden event).
+      // The button must show '+1' (one hidden event).
       final buttonText = (find.byKey(MultiDayPortalOverlayButton.textKey).evaluate().single.widget as Text).data!;
-      expect(buttonText, equals('1 more'));
+      expect(buttonText, equals('+1'));
     });
 
     testWidgets('Drop target layout uses the selected event span during horizontal resize', (tester) async {
@@ -361,11 +361,11 @@ void main() {
       // Three overflow buttons expected (one per overflowing column).
       expect(find.byType(MultiDayPortalOverlayButton), findsNWidgets(3));
 
-      // Each button must display exactly '1 more'.
+      // Each button must display exactly '+1'.
       for (final element in find.byKey(MultiDayPortalOverlayButton.textKey).evaluate()) {
         final text = (element.widget as Text).data;
         expect(text, isNotNull, reason: 'Button text should not be null');
-        expect(text, equals('1 more'), reason: 'Expected "1 more" but found "$text"');
+        expect(text, equals('+1'), reason: 'Expected "+1" but found "$text"');
       }
     });
 
@@ -432,7 +432,7 @@ void main() {
       expect(find.byType(MultiDayPortalOverlayButton), findsOneWidget);
 
       final buttonText = (find.byKey(MultiDayPortalOverlayButton.textKey).evaluate().single.widget as Text).data!;
-      expect(buttonText, equals('1 more'));
+      expect(buttonText, equals('+1'));
 
       // Verify vertical ordering: events[1] (earliest start) is topmost,
       // then events[2], then events[0].
@@ -511,7 +511,7 @@ void main() {
       expect(find.byType(MultiDayPortalOverlayButton), findsOneWidget);
 
       final buttonText = (find.byKey(MultiDayPortalOverlayButton.textKey).evaluate().single.widget as Text).data!;
-      expect(buttonText, equals('1 more'));
+      expect(buttonText, equals('+1'));
 
       // Verify vertical ordering by end time (earliest end = topmost row):
       // events[2] ends at 04:00, events[1] at 08:00, events[0] at 12:00.

--- a/test/widgets/overlay_style_precedence_test.dart
+++ b/test/widgets/overlay_style_precedence_test.dart
@@ -10,24 +10,33 @@ import '../utilities.dart';
 // resolved them correctly. CalendarComponents documents that the more specific
 // value wins.
 void main() {
-  /// Builds an [OverlayStyles] whose "+N more" button is labelled with [label],
-  /// which is what these tests read back to see which style was resolved. The
-  /// hidden-event count is left out on purpose, it varies with the cell height.
-  OverlayStyles stylesLabelled(String label) => OverlayStyles(
+  /// Builds an [OverlayStyles] that colours the overflow button's text with
+  /// [color], which is what these tests read back to see which style resolved.
+  OverlayStyles stylesColoured(Color color) => OverlayStyles(
         multiDayPortalOverlayButtonStyle: MultiDayPortalOverlayButtonStyle(
-          stringBuilder: (numberOfHiddenRows) => label,
+          textStyle: TextStyle(color: color),
         ),
       );
 
-  /// The distinct labels of every rendered "+N more" button.
-  ///
-  /// Adjacent pages are built too, and a neighbouring month's grid can include
-  /// the same day, so more than one button can exist for it.
-  Set<String> buttonLabels(WidgetTester tester) {
+  /// Builds an [OverlayBuilders] whose overflow button is labelled [label]. The
+  /// hidden-event count is left out on purpose, it varies with the cell height.
+  OverlayBuilders buildersLabelled(String label) => OverlayBuilders(
+        multiDayPortalOverlayButtonStringBuilder: (context, numberOfHiddenEvents) => label,
+      );
+
+  /// Every rendered overflow button, of which there can be more than one: adjacent
+  /// pages are built too, and a neighbouring month's grid can include the same day.
+  Iterable<Text> buttonTexts(WidgetTester tester) {
     final texts = tester.widgetList<Text>(find.byKey(MultiDayPortalOverlayButton.textKey));
-    expect(texts, isNotEmpty, reason: 'the day should overflow and show a "+N more" button');
-    return texts.map((text) => text.data!).toSet();
+    expect(texts, isNotEmpty, reason: 'the day should overflow and show an overflow button');
+    return texts;
   }
+
+  /// The distinct text colours of every rendered overflow button.
+  Set<Color?> buttonColors(WidgetTester tester) => buttonTexts(tester).map((text) => text.style?.color).toSet();
+
+  /// The distinct labels of every rendered overflow button.
+  Set<String> buttonLabels(WidgetTester tester) => buttonTexts(tester).map((text) => text.data!).toSet();
 
   /// Adds enough events on [day] to overflow the cell and show the button.
   DefaultEventsController controllerWithOverflowOn(DateTime day) {
@@ -63,20 +72,43 @@ void main() {
       await pumpMonthView(
         tester,
         components: CalendarComponents(
-          overlayStyles: stylesLabelled('global'),
+          overlayStyles: stylesColoured(Colors.red),
           monthComponentStyles: MonthComponentStyles(
-            bodyStyles: MonthBodyComponentStyles(overlayStyles: stylesLabelled('specific')),
+            bodyStyles: MonthBodyComponentStyles(overlayStyles: stylesColoured(Colors.green)),
           ),
         ),
       );
 
-      expect(buttonLabels(tester), {'specific'}, reason: 'the more specific month body style should win');
+      expect(buttonColors(tester), {Colors.green}, reason: 'the more specific month body style should win');
     });
 
     testWidgets('the global style is used when the month body sets none', (tester) async {
-      await pumpMonthView(tester, components: CalendarComponents(overlayStyles: stylesLabelled('global')));
+      await pumpMonthView(tester, components: CalendarComponents(overlayStyles: stylesColoured(Colors.red)));
 
-      expect(buttonLabels(tester), {'global'}, reason: 'the global style should still apply as a fallback');
+      expect(buttonColors(tester), {Colors.red}, reason: 'the global style should still apply as a fallback');
+    });
+
+    testWidgets('the month body builders win over the global builders', (tester) async {
+      await pumpMonthView(
+        tester,
+        components: CalendarComponents(
+          overlayBuilders: buildersLabelled('global'),
+          monthComponents: MonthComponents(
+            bodyComponents: MonthBodyComponents(overlayBuilders: buildersLabelled('specific')),
+          ),
+        ),
+      );
+
+      expect(buttonLabels(tester), {'specific'}, reason: 'the more specific month body builder should win');
+    });
+
+    // MonthBodyComponents.overlayBuilders defaulted to a non-null empty
+    // OverlayBuilders, and the month body resolves it with `?? global`, so the
+    // empty default always shadowed the global builders.
+    testWidgets('the global builders are used when the month body sets none', (tester) async {
+      await pumpMonthView(tester, components: CalendarComponents(overlayBuilders: buildersLabelled('global')));
+
+      expect(buttonLabels(tester), {'global'}, reason: 'the global builder should still apply as a fallback');
     });
   });
 
@@ -104,14 +136,28 @@ void main() {
       await pumpWeekView(
         tester,
         components: CalendarComponents(
-          overlayStyles: stylesLabelled('global'),
+          overlayStyles: stylesColoured(Colors.red),
           multiDayComponentStyles: MultiDayComponentStyles(
-            headerStyles: MultiDayHeaderComponentStyles(overlayStyles: stylesLabelled('specific')),
+            headerStyles: MultiDayHeaderComponentStyles(overlayStyles: stylesColoured(Colors.green)),
           ),
         ),
       );
 
-      expect(buttonLabels(tester), {'specific'}, reason: 'the more specific header style should win');
+      expect(buttonColors(tester), {Colors.green}, reason: 'the more specific header style should win');
+    });
+
+    testWidgets('the header builders win over the global builders', (tester) async {
+      await pumpWeekView(
+        tester,
+        components: CalendarComponents(
+          overlayBuilders: buildersLabelled('global'),
+          multiDayComponents: MultiDayComponents(
+            headerComponents: MultiDayHeaderComponents(overlayBuilders: buildersLabelled('specific')),
+          ),
+        ),
+      );
+
+      expect(buttonLabels(tester), {'specific'}, reason: 'the more specific header builder should win');
     });
   });
 }

--- a/test/widgets/string_builders_test.dart
+++ b/test/widgets/string_builders_test.dart
@@ -1,0 +1,302 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+/// The string builders used to live on the component style classes, which put
+/// formatting inside the themeable KalenderThemeData and gave custom builders no
+/// way to see the calendar's locale. They now live on the *Components classes and
+/// receive a BuildContext. The style fields stay until 0.24.0 as a fallback.
+void main() {
+  final tiles = TileComponents(tileBuilder: (event, tileRange) => const SizedBox());
+  final scheduleTiles = ScheduleTileComponents(tileBuilder: (event, tileRange) => const SizedBox());
+  final day = DateTime.utc(2025, 1, 15);
+
+  Future<void> pumpView(
+    WidgetTester tester, {
+    required ViewConfiguration viewConfiguration,
+    CalendarComponents? components,
+    EventsController? eventsController,
+    Widget? header,
+    Widget? body,
+  }) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController ?? DefaultEventsController(),
+        calendarController: CalendarController(),
+        viewConfiguration: viewConfiguration,
+        components: components,
+        header: header,
+        body: body,
+      ),
+    );
+  }
+
+  Future<void> pumpWeek(WidgetTester tester, CalendarComponents components) {
+    return pumpView(
+      tester,
+      viewConfiguration: MultiDayViewConfiguration.week(
+        displayRange: year2025DisplayRange,
+        initialDateTime: day,
+      ),
+      components: components,
+      header: CalendarHeader(multiDayTileComponents: tiles),
+      body: CalendarBody(multiDayTileComponents: tiles),
+    );
+  }
+
+  Future<void> pumpMonth(WidgetTester tester, CalendarComponents components) {
+    return pumpView(
+      tester,
+      viewConfiguration: MonthViewConfiguration.singleMonth(
+        displayRange: year2025DisplayRange,
+        initialDateTime: day,
+      ),
+      components: components,
+      header: CalendarHeader(multiDayTileComponents: tiles),
+      body: CalendarBody(multiDayTileComponents: tiles),
+    );
+  }
+
+  group('DayHeader', () {
+    testWidgets('the components string builders replace the day name and the day number', (tester) async {
+      await pumpWeek(
+        tester,
+        CalendarComponents(
+          multiDayComponents: MultiDayComponents(
+            headerComponents: MultiDayHeaderComponents(
+              dayHeaderStringBuilder: (context, date) => 'name',
+              dayHeaderNumberStringBuilder: (context, date) => 'number',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('name'), findsWidgets);
+      expect(find.text('number'), findsWidgets);
+    });
+
+    testWidgets('the deprecated style builders still apply when no components ones are set', (tester) async {
+      await pumpWeek(
+        tester,
+        CalendarComponents(
+          multiDayComponentStyles: MultiDayComponentStyles(
+            headerStyles: MultiDayHeaderComponentStyles(
+              dayHeaderStyle: DayHeaderStyle(
+                stringBuilder: (date) => 'old name',
+                numberStringBuilder: (date) => 'old number',
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('old name'), findsWidgets);
+      expect(find.text('old number'), findsWidgets);
+    });
+
+    testWidgets('the components builder wins over the deprecated style one', (tester) async {
+      await pumpWeek(
+        tester,
+        CalendarComponents(
+          multiDayComponents: MultiDayComponents(
+            headerComponents: MultiDayHeaderComponents(dayHeaderStringBuilder: (context, date) => 'new'),
+          ),
+          multiDayComponentStyles: MultiDayComponentStyles(
+            headerStyles: MultiDayHeaderComponentStyles(
+              dayHeaderStyle: DayHeaderStyle(stringBuilder: (date) => 'old'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('new'), findsWidgets);
+      expect(find.text('old'), findsNothing);
+    });
+
+    testWidgets('both builders receive the same date', (tester) async {
+      final nameDates = <DateTime>[];
+      final numberDates = <DateTime>[];
+
+      await pumpWeek(
+        tester,
+        CalendarComponents(
+          multiDayComponents: MultiDayComponents(
+            headerComponents: MultiDayHeaderComponents(
+              dayHeaderStringBuilder: (context, date) {
+                nameDates.add(date);
+                return '';
+              },
+              dayHeaderNumberStringBuilder: (context, date) {
+                numberDates.add(date);
+                return '';
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(nameDates, isNotEmpty);
+      expect(numberDates, nameDates, reason: 'the two builders used to be handed different DateTime flavours');
+    });
+  });
+
+  group('WeekDayHeader', () {
+    testWidgets('the components string builder replaces the day name', (tester) async {
+      await pumpMonth(
+        tester,
+        CalendarComponents(
+          monthComponents: MonthComponents(
+            headerComponents: MonthHeaderComponents(weekDayHeaderStringBuilder: (context, date) => 'wd'),
+          ),
+        ),
+      );
+
+      expect(find.text('wd'), findsWidgets);
+    });
+
+    testWidgets('the deprecated style builder still applies', (tester) async {
+      await pumpMonth(
+        tester,
+        CalendarComponents(
+          monthComponentStyles: MonthComponentStyles(
+            headerStyles: MonthHeaderComponentStyles(
+              weekDayHeaderStyle: WeekDayHeaderStyle(stringBuilder: (date) => 'old wd'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('old wd'), findsWidgets);
+    });
+  });
+
+  group('MonthDayHeader', () {
+    // MonthDayHeaderStyle.stringBuilder was declared but never called, so setting
+    // it did nothing. The replacement is wired up.
+    testWidgets('the components string builder replaces the day number', (tester) async {
+      await pumpMonth(
+        tester,
+        CalendarComponents(
+          monthComponents: MonthComponents(
+            bodyComponents: MonthBodyComponents(monthDayHeaderStringBuilder: (context, date) => 'md'),
+          ),
+        ),
+      );
+
+      expect(find.text('md'), findsWidgets);
+      expect(find.text('15'), findsNothing, reason: 'the day number should be replaced, not appended');
+    });
+  });
+
+  group('ScheduleDate', () {
+    testWidgets('the components string builder replaces the day name', (tester) async {
+      final eventsController = DefaultEventsController()
+        ..addEvent(CalendarEvent(dateTimeRange: DateTimeRange(start: day, end: day.add(const Duration(hours: 1)))));
+
+      await pumpView(
+        tester,
+        viewConfiguration: ScheduleViewConfiguration.continuous(
+          displayRange: year2025DisplayRange,
+          initialDateTime: day,
+        ),
+        eventsController: eventsController,
+        components: CalendarComponents(
+          scheduleComponents: ScheduleComponents(leadingDateStringBuilder: (context, date) => 'sd'),
+        ),
+        body: CalendarBody(scheduleTileComponents: scheduleTiles),
+      );
+
+      expect(find.text('sd'), findsWidgets);
+    });
+  });
+
+  group('Overflow button label', () {
+    /// Adds enough events on [day] to overflow the cell and show the button.
+    DefaultEventsController controllerWithOverflowOn(DateTime day) {
+      final eventsController = DefaultEventsController();
+      for (var i = 0; i < 8; i++) {
+        eventsController.addEvent(
+          CalendarEvent(dateTimeRange: DateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+        );
+      }
+      return eventsController;
+    }
+
+    Future<void> pumpOverflowingWeek(
+      WidgetTester tester, {
+      CalendarComponents? components,
+      TextDirection textDirection = TextDirection.ltr,
+    }) {
+      return pumpAndSettleWithMaterialApp(
+        tester,
+        Directionality(
+          textDirection: textDirection,
+          child: CalendarView(
+            eventsController: controllerWithOverflowOn(day),
+            calendarController: CalendarController(),
+            viewConfiguration: MultiDayViewConfiguration.week(
+              displayRange: year2025DisplayRange,
+              initialDateTime: day,
+            ),
+            components: components,
+            header: const CalendarHeader(
+              multiDayHeaderConfiguration: MultiDayHeaderConfiguration(maximumNumberOfVerticalEvents: 1),
+            ),
+          ),
+        ),
+      );
+    }
+
+    Set<String> labels(WidgetTester tester) {
+      final texts = tester.widgetList<Text>(find.byKey(MultiDayPortalOverlayButton.textKey));
+      expect(texts, isNotEmpty, reason: 'the day should overflow and show an overflow button');
+      return texts.map((text) => text.data!).toSet();
+    }
+
+    // The default used to be the English '$n more'. It is now a plus sign and the
+    // count, which needs no translation.
+    testWidgets('defaults to a plus sign and the count', (tester) async {
+      await pumpOverflowingWeek(tester);
+
+      expect(labels(tester), everyElement(matches(RegExp(r'^\+\d+$'))));
+    });
+
+    testWidgets('keeps the plus in front of the count in right-to-left', (tester) async {
+      await pumpOverflowingWeek(tester, textDirection: TextDirection.rtl);
+
+      expect(labels(tester), everyElement(matches(RegExp(r'^\+\d+$'))));
+    });
+
+    testWidgets('the deprecated style builder still applies', (tester) async {
+      await pumpOverflowingWeek(
+        tester,
+        components: CalendarComponents(
+          overlayStyles: OverlayStyles(
+            multiDayPortalOverlayButtonStyle: MultiDayPortalOverlayButtonStyle(stringBuilder: (n) => 'old $n'),
+          ),
+        ),
+      );
+
+      expect(labels(tester), everyElement(startsWith('old ')));
+    });
+
+    testWidgets('the components builder wins over the deprecated style one', (tester) async {
+      await pumpOverflowingWeek(
+        tester,
+        components: CalendarComponents(
+          overlayBuilders: OverlayBuilders(
+            multiDayPortalOverlayButtonStringBuilder: (context, n) => 'new $n',
+          ),
+          overlayStyles: OverlayStyles(
+            multiDayPortalOverlayButtonStyle: MultiDayPortalOverlayButtonStyle(stringBuilder: (n) => 'old $n'),
+          ),
+        ),
+      );
+
+      expect(labels(tester), everyElement(startsWith('new ')));
+    });
+  });
+}

--- a/test/widgets/timeline_alignment_test.dart
+++ b/test/widgets/timeline_alignment_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/widgets/internal_components/expandable_page_view.dart' show ExpandablePageView;
 
@@ -25,6 +26,7 @@ void main() {
     WidgetTester tester, {
     CalendarComponents? components,
     TextDirection textDirection = TextDirection.ltr,
+    dynamic locale,
   }) async {
     final view = CalendarView(
       eventsController: eventsController,
@@ -33,6 +35,7 @@ void main() {
         displayRange: DateTimeRange(start: DateTime(2025), end: DateTime(2025, 2)),
       ),
       components: components,
+      locale: locale,
       header: CalendarHeader(multiDayTileComponents: tiles),
       body: CalendarBody(multiDayTileComponents: tiles),
     );
@@ -63,6 +66,17 @@ void main() {
         ),
       );
 
+  CalendarComponents withTimelineStringBuilder(TimeOfDayStringBuilder builder) => CalendarComponents(
+        multiDayComponents: MultiDayComponents(
+          bodyComponents: MultiDayBodyComponents(timelineStringBuilder: builder),
+        ),
+      );
+
+  /// The label of the timeline entry for [hour]:00.
+  String labelAt(WidgetTester tester, int hour) {
+    return tester.widget<Text>(find.byKey(TimeLine.getTimeKey(hour, 0)).first).data!;
+  }
+
   testWidgets('default timeline: header and body columns align', (tester) async {
     await pumpWeek(tester);
     expectAligned(tester);
@@ -78,13 +92,13 @@ void main() {
   });
 
   testWidgets('measures every label, so the widest hour fits even when it is not 23:59', (tester) async {
-    // A stringBuilder whose widest output is at noon, not at 23:59. Sampling
+    // A string builder whose widest output is at noon, not at 23:59. Sampling
     // only 23:59 (which here returns the short 'x') would under-size the gutter
     // and clip the noon label. Measuring all labels must accommodate it.
     const wide = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'; // 40 chars
-    String labels(TimeOfDay time) => time.hour == 12 ? wide : 'x';
+    String labels(BuildContext context, TimeOfDay time) => time.hour == 12 ? wide : 'x';
 
-    await pumpWeek(tester, components: withTimelineStyle(TimelineStyle(stringBuilder: labels)));
+    await pumpWeek(tester, components: withTimelineStringBuilder(labels));
 
     expect(
       gutterWidth(tester),
@@ -118,9 +132,38 @@ void main() {
   testWidgets('columns stay aligned in right-to-left', (tester) async {
     await pumpWeek(
       tester,
-      components: withTimelineStyle(TimelineStyle(stringBuilder: (_) => 'X')),
+      components: withTimelineStringBuilder((context, time) => 'X'),
       textDirection: TextDirection.rtl,
     );
     expectAligned(tester);
+  });
+
+  testWidgets('the components string builder wins over the deprecated style one', (tester) async {
+    await pumpWeek(
+      tester,
+      components: CalendarComponents(
+        multiDayComponents: MultiDayComponents(
+          bodyComponents: MultiDayBodyComponents(timelineStringBuilder: (context, time) => 'components'),
+        ),
+        multiDayComponentStyles: MultiDayComponentStyles(
+          bodyStyles: MultiDayBodyComponentStyles(timelineStyle: TimelineStyle(stringBuilder: (_) => 'style')),
+        ),
+      ),
+    );
+
+    expect(labelAt(tester, 1), 'components');
+  });
+
+  // The calendar's own locale, which is not necessarily the app's, was not
+  // reachable from a custom label before it was handed a BuildContext.
+  testWidgets('the string builder receives a context it can read the calendar locale from', (tester) async {
+    await initializeDateFormatting('de_DE');
+    await pumpWeek(
+      tester,
+      components: withTimelineStringBuilder((context, time) => '${context.calendarLocale}'),
+      locale: 'de_DE',
+    );
+
+    expect(labelAt(tester, 1), 'de_DE');
   });
 }


### PR DESCRIPTION
Closes #318.

The component style classes carried `String Function(...)` fields alongside their visual fields. Since the theming work (#314-#317) those styles also live inside `KalenderThemeData`, a `ThemeExtension`, so "what the day is called" travelled in the same themeable object as "what colour it is". Three problems followed: formatting is not visual style, a function field cannot interpolate during a theme animation and an inline lambda breaks the style's value equality on every rebuild, and a custom builder received only the date or time so it could not see the calendar's locale while the package's own defaults could.

Each builder moves to the `*Components` class that already holds its widget builder, and takes a `BuildContext` first. This follows the direction settled during the theming work: the theme extension holds data, callbacks stay component-shaped.

| Old | New |
| --- | --- |
| `DayHeaderStyle.stringBuilder` | `MultiDayHeaderComponents.dayHeaderStringBuilder` |
| `DayHeaderStyle.numberStringBuilder` | `MultiDayHeaderComponents.dayHeaderNumberStringBuilder` |
| `TimelineStyle.stringBuilder` | `MultiDayBodyComponents.timelineStringBuilder` |
| `MonthDayHeaderStyle.stringBuilder` | `MonthBodyComponents.monthDayHeaderStringBuilder` |
| `WeekDayHeaderStyle.stringBuilder` | `MonthHeaderComponents.weekDayHeaderStringBuilder` |
| `ScheduleDateStyle.stringBuilder` | `ScheduleComponents.leadingDateStringBuilder` |
| `MultiDayPortalOverlayButtonStyle.stringBuilder` | `OverlayBuilders.multiDayPortalOverlayButtonStringBuilder` |

The old fields stay, deprecated, and are honoured whenever the new one is unset. They come out in 0.24.0, which is when the styles actually become interpolatable and equatable again.

## Found while touching every call site

**`MonthDayHeaderStyle.stringBuilder` never worked.** It was declared but `MonthDayHeader.build` rendered `Text(date.day.toString())` and never called it, so setting it did nothing. Its replacement is wired up, which means a calendar that set the old field and worked around it having no effect will now see the day number change.

**The builders were handed different `DateTime` flavours.** The day header's two got a location-adjusted date and a UTC-flagged `InternalDateTime` respectively, and the schedule date got a raw one. The calendar fields matched, so day numbers and names always came out right, but `isUtc`, `timeZoneName` and any `DateFormat` pattern touching the zone disagreed between them. Every builder now gets the location-adjusted wall-clock value, which is what `MonthDayHeaderBuilder`'s doc comment already promised.

**The month body ignored the global overlay builders.** `MonthBodyComponents.overlayBuilders` defaulted to an empty `OverlayBuilders()` rather than null, and the month body resolves it as "the specific one, otherwise the global one", so the empty default always shadowed `CalendarComponents.overlayBuilders`. The multi-day header was never affected because its field has no default. This is the builder-side twin of the style-side fix in 0.22.0, and it mattered here because the month view is where the overflow button shows up most.

## The overflow button label

The default was `'$n more'`, hardcoded English with no way for the calendar's locale to reach it. It is now `+3`, with the number formatted through `intl`'s `NumberFormat` for the calendar's locale, so locales with their own numerals read correctly. Genuinely translating the word would mean taking on `flutter_localizations`, ARB files and a delegate apps must register; dropping it needs none of that. Set `multiDayPortalOverlayButtonStringBuilder` for the old wording.

`context.calendarLocale` is new. Handing a builder a `BuildContext` is pointless if the calendar's locale is not reachable from it, and `CalendarView.locale` is not necessarily the app's locale, so `Localizations.localeOf` is not a substitute.

## Tests

New `test/widgets/string_builders_test.dart` covers each moved builder, the deprecated field still applying as a fallback, the new one winning over it, the day header's two builders receiving the same date, and the `+N` label in both text directions. `overlay_style_precedence_test.dart` used the button's `stringBuilder` as its probe for which *style* resolved; since that builder moved to a different resolution path it now probes a visual field, and the builder precedence gets its own tests, one of which fails without the `overlayBuilders` default fix.

`flutter analyze` clean, 1373 tests pass, all six example apps' tests pass. The web demo builds and runs; I could not capture a screenshot of it in this environment, so the visual check rests on the widget tests.

## Follow-ups

Two dead-code twins of what this PR fixes turned up while touching these files. Both are left out of this PR on purpose and are filed separately:

- **#350** — `MonthDayHeaderStyle.textStyle` is dead the same way `stringBuilder` was: `MonthDayHeader` renders only a day number, never a day name, yet `KalenderThemeData.defaults` sets a value for it. Removing it is breaking, so it belongs with the 0.24.0 wave that also drops the string builders deprecated here.
- **#351** — `ScheduleDate` abbreviates day names by cutting the full name at three characters instead of using `DateFormat.E`, which is wrong in most locales (German gives `Mit` rather than `Mi`). Small and self-contained, could ride along with 0.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
