### PR TITLE
fix: schedule day-name abbreviation, deprecate the dead MonthDayHeaderStyle.textStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Nothing here stops existing code from compiling. Each one changes what an unchan
 
 - `MonthDayHeaderStyle.stringBuilder` was declared but never called, so setting it did nothing. Its replacement, `MonthBodyComponents.monthDayHeaderStringBuilder`, is wired up, which means a calendar that set the old field and worked around it having no effect will now see the day number change. [#349](https://github.com/werner-scholtz/kalender/pull/349)
 
+- The schedule view abbreviates day names the way the locale does, instead of cutting the full name at three characters. The cut only agrees with the real abbreviation in English, which is why it went unnoticed: German showed `Mit` where it should be `Mi`, Russian `сре` where it should be `ср`, Afrikaans `Woe` where it should be `Wo.`. Every other component that shows a short day name already used `DateFormat.E`, and the schedule view now does too. [#352](https://github.com/werner-scholtz/kalender/pull/352)
+
 - The month body now falls back to `CalendarComponents.overlayBuilders` when `MonthBodyComponents` sets none of its own, so a global overlay builder that was silently ignored in the month view starts applying. `MonthBodyComponents.overlayBuilders` defaulted to an empty `OverlayBuilders` rather than null, and the month body resolves it as "the specific one, otherwise the global one", so the empty default always shadowed the global builders. The multi-day header was never affected. This is the builder-side twin of the style-side fix in 0.22.0. [#349](https://github.com/werner-scholtz/kalender/pull/349)
 
 ### Deprecations
@@ -23,6 +25,8 @@ Nothing here stops existing code from compiling. Each one changes what an unchan
   | `WeekDayHeaderStyle.stringBuilder` | `MonthHeaderComponents.weekDayHeaderStringBuilder` |
   | `ScheduleDateStyle.stringBuilder` | `ScheduleComponents.leadingDateStringBuilder` |
   | `MultiDayPortalOverlayButtonStyle.stringBuilder` | `OverlayBuilders.multiDayPortalOverlayButtonStringBuilder` |
+
+- `MonthDayHeaderStyle.textStyle` is deprecated and will be removed in 0.24.0. It has never had any effect: it is documented as styling the day name, but `MonthDayHeader` displays only a day number, which `numberTextStyle` styles. The Material 3 defaults no longer assign it either, so it reads as null rather than as something that is set but ignored. [#352](https://github.com/werner-scholtz/kalender/pull/352)
 
 ### Features
 

--- a/lib/src/theme/kalender_theme.dart
+++ b/lib/src/theme/kalender_theme.dart
@@ -137,7 +137,6 @@ class KalenderThemeData extends ThemeExtension<KalenderThemeData> {
         thickness: 0,
       ),
       monthDayHeaderStyle: MonthDayHeaderStyle(
-        textStyle: textTheme.bodySmall,
         numberTextStyle: textTheme.bodyMedium,
         // Keeps the today highlight clear of the gridline above it and the
         // event tiles below it.

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -24,7 +24,9 @@ class MonthDayHeaderStyle {
     this.margin,
   });
 
-  /// The [TextStyle] used by the [MonthDayHeader] widget to display the name of the day.
+  /// Has never had any effect. [MonthDayHeader] displays only a day number,
+  /// which is styled by [numberTextStyle], and no day name.
+  @Deprecated('Has no effect, MonthDayHeader displays no day name. Will be removed in 0.24.0.')
   final TextStyle? textStyle;
 
   /// Use this function to customize the sting displayed by the [MonthDayHeader].

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -109,7 +109,7 @@ class ScheduleDate extends StatelessWidget {
     final text = Text(
       stringBuilder?.call(context, displayDate) ??
           style.stringBuilder?.call(date) ??
-          date.dayNameLocalized(context.locale).characters.take(3).toString(),
+          date.dayNameShortLocalized(context.locale),
       style: style.textStyle,
     );
 

--- a/test/widgets/day_name_abbreviation_test.dart
+++ b/test/widgets/day_name_abbreviation_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+/// [ScheduleDate] abbreviated the day name by cutting the full name at three
+/// characters, which only happens to be right in English. Every other component
+/// that shows a short day name uses `DateFormat.E` through
+/// [DateTimeExtensions.dayNameShortLocalized].
+void main() {
+  // 15 January 2025 is a Wednesday, whose abbreviation differs from the first
+  // three letters of its full name in several locales.
+  final wednesday = InternalDateTime(2025, 1, 15);
+
+  Future<void> pumpScheduleDate(WidgetTester tester, dynamic locale) async {
+    await initializeDateFormatting('$locale');
+    await pumpAndSettleWithMaterialApp(
+      tester,
+      TestProvider(
+        calendarController: CalendarController(),
+        eventsController: DefaultEventsController(),
+        tileComponents: TileComponents(tileBuilder: (event, tileRange) => const SizedBox()),
+        locale: locale,
+        child: ScheduleDate(date: wednesday),
+      ),
+    );
+  }
+
+  testWidgets('uses the locale\'s own abbreviation, not the first three letters', (tester) async {
+    await pumpScheduleDate(tester, 'de');
+
+    expect(find.text('Mi'), findsOneWidget);
+    expect(find.text('Mit'), findsNothing, reason: 'Mittwoch cut at three characters is not how German abbreviates it');
+  });
+
+  testWidgets('English is unchanged, which is why this went unnoticed', (tester) async {
+    await pumpScheduleDate(tester, 'en');
+
+    expect(find.text('Wed'), findsOneWidget);
+  });
+
+  testWidgets('keeps abbreviations that are not three characters long', (tester) async {
+    // Russian abbreviates Wednesday to two characters, and the cut produced three.
+    await pumpScheduleDate(tester, 'ru');
+
+    expect(find.text('ср'), findsOneWidget);
+    expect(find.text('сре'), findsNothing);
+  });
+
+  testWidgets('matches what the multi-day day header shows for the same date', (tester) async {
+    await initializeDateFormatting('de');
+    await pumpAndSettleWithMaterialApp(
+      tester,
+      TestProvider(
+        calendarController: CalendarController(),
+        eventsController: DefaultEventsController(),
+        tileComponents: TileComponents(tileBuilder: (event, tileRange) => const SizedBox()),
+        locale: 'de',
+        child: Column(children: [ScheduleDate(date: wednesday), DayHeader(date: wednesday)]),
+      ),
+    );
+
+    expect(find.text('Mi'), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
Closes #351. Closes #350.

Stacked on #349 — the two follow-ups that came out of it, kept separate so #349 stays about the string builders. **Base is `refactor/string-builders-to-components`, so merge #349 first.**

## #351 — the schedule view abbreviated day names by cutting at three characters

`ScheduleDate` built its abbreviation as `dayNameLocalized(...).characters.take(3)`. That only agrees with the real abbreviation in English, which is why nobody noticed:

| Locale | Full name | Cut at 3 | `DateFormat.E` |
| --- | --- | --- | --- |
| en | Wednesday | `Wed` | `Wed` |
| de | Mittwoch | `Mit` | `Mi` |
| fr | mercredi | `mer` | `mer.` |
| es | miércoles | `mié` | `mié` |
| ru | среда | `сре` | `ср` |
| af | Woensdag | `Woe` | `Wo.` |

(Measured, not guessed — that table is the output of running both against `intl`.)

Every other component that shows a short day name already used `DateTimeExtensions.dayNameShortLocalized`, which is `DateFormat.E`. `ScheduleDate` was the only holdout, so it now matches. New `test/widgets/day_name_abbreviation_test.dart` covers German and Russian, pins English as unchanged, and asserts the schedule view and the multi-day day header agree on the same date. Three of its four tests fail without the fix; the English one passes either way, which is the whole point.

## #350 — `MonthDayHeaderStyle.textStyle` never did anything

Documented as "the `TextStyle` used by the `MonthDayHeader` widget to display the name of the day", but `MonthDayHeader` displays no day name — its `build` renders a single day number styled by `numberTextStyle`. Nothing has ever read `textStyle`.

The issue suggested removing it. I deprecated it instead, so that 0.23.0 breaks no builds at all and the field comes out in 0.24.0 alongside the string builders deprecated in #349 — one breaking wave rather than two. The deprecation message says plainly that it has no effect, which is more informative than a compile error would be.

The Material 3 defaults no longer assign it, since a default value on a field nothing reads is what made it look supported. This is safe to change now rather than at removal: nothing in the package reads it, and a custom `monthDayHeaderBuilder` is handed the *configured* style (`MonthComponentStyles.bodyStyles.monthDayHeaderStyle`), not the theme-resolved one — the theme merge happens inside `MonthDayHeader.build`. So no custom builder can observe the difference. Only code calling `KalenderTheme.of(context).monthDayHeaderStyle?.textStyle` directly would see null where it previously saw `bodySmall`, and that is code reading a field documented as having no effect.

## Changelog

The abbreviation change went under `Breaking Changes`, since it changes what an unchanged calendar renders in non-English locales, and the deprecation under `Deprecations`. Happy to move the abbreviation entry down to `Fixes` if you would rather it read as the bug fix it also is — same question as the `overlayBuilders` entry in #349.

`flutter analyze` clean, 1377 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)