### PR TITLE
chore: keep AGENTS.md out of the published package

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -9,3 +9,7 @@ readme_assets/
 examples/
 tool/
 benchmark/
+
+# Instructions for coding agents working on this repo, of no use to anyone
+# installing the package.
+AGENTS.md


### PR DESCRIPTION
`AGENTS.md` is instructions for coding agents working on this repo. It has no use to anyone installing kalender, and it was shipping as 12 KB of the published archive.

Verified with `flutter pub publish --dry-run`: the archive goes from 158 KB to 154 KB, `AGENTS.md` is gone from the file list, and it still reports 0 warnings.

Everything else at the archive root is deliberate — `CHANGELOG.md`, `CONTRIBUTING.md`, `LICENSE`, `MIGRATION.md`, `README.md`, `analysis_options.yaml`, `example/`, `lib/`, `pubspec.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)