### PR TITLE
docs: move the 0.23.0 migration detail out of the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,26 @@
 ## 0.23.0
 
+Nothing in this release stops existing code from compiling. See [MIGRATION.md](MIGRATION.md#v022x--v0230) for what to change.
+
 ### Breaking Changes
 
-Nothing here stops existing code from compiling. Each one changes what an unchanged calendar renders.
+Each of these changes what an unchanged calendar renders.
 
-- The overlay button that stands in for events which do not fit is now labelled `+3` instead of `3 more`. The old label was English with no way for the calendar's locale to reach it, and a plus sign with the count needs no translation. The number is formatted with `intl` for the calendar's locale, so locales with their own numerals read correctly. Set `OverlayBuilders.multiDayPortalOverlayButtonStringBuilder` to get the old wording back. [#349](https://github.com/werner-scholtz/kalender/pull/349)
-
-- `MonthDayHeaderStyle.stringBuilder` was declared but never called, so setting it did nothing. Its replacement, `MonthBodyComponents.monthDayHeaderStringBuilder`, is wired up, which means a calendar that set the old field and worked around it having no effect will now see the day number change. [#349](https://github.com/werner-scholtz/kalender/pull/349)
-
-- The schedule view abbreviates day names the way the locale does, instead of cutting the full name at three characters. The cut only agrees with the real abbreviation in English, which is why it went unnoticed: German showed `Mit` where it should be `Mi`, Russian `сре` where it should be `ср`, Afrikaans `Woe` where it should be `Wo.`. Every other component that shows a short day name already used `DateFormat.E`, and the schedule view now does too. [#352](https://github.com/werner-scholtz/kalender/pull/352) [#354](https://github.com/werner-scholtz/kalender/pull/354)
-
-- The month body now falls back to `CalendarComponents.overlayBuilders` when `MonthBodyComponents` sets none of its own, so a global overlay builder that was silently ignored in the month view starts applying. `MonthBodyComponents.overlayBuilders` defaulted to an empty `OverlayBuilders` rather than null, and the month body resolves it as "the specific one, otherwise the global one", so the empty default always shadowed the global builders. The multi-day header was never affected. This is the builder-side twin of the style-side fix in 0.22.0. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+- The overflow button is labelled `+3` instead of `3 more`, with the number formatted for the calendar's locale so locales with their own numerals read correctly. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+- The schedule view abbreviates day names with `DateFormat.E` instead of cutting the full name at three characters, which was only correct in English. German reads `Mi` rather than `Mit`. [#354](https://github.com/werner-scholtz/kalender/pull/354)
+- `MonthDayHeaderStyle.stringBuilder` was declared but never called. Its replacement is wired up, so a calendar that set the old field will now see the day number change. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+- `MonthBodyComponents.overlayBuilders` defaults to null, so `CalendarComponents.overlayBuilders` applies in the month view instead of being shadowed by an empty default. The builder-side twin of the style-side fix in 0.22.0. [#349](https://github.com/werner-scholtz/kalender/pull/349)
 
 ### Deprecations
 
-- The string builders moved off the component style classes and onto the matching `*Components` classes, and each one now receives a `BuildContext` as its first argument. They are formatting and localization hooks, not visual style, and since the styles also live inside `KalenderThemeData` they were carrying callbacks into a theme extension, where they cannot interpolate and where an inline lambda breaks the style's value equality on every rebuild. Passing the context also fixes the older problem that a custom builder could not see the calendar's locale while the package's own defaults could. The old fields still work and are honoured whenever the new one is not set. They will be removed in 0.24.0, which is when the styles become interpolatable and comparable again. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+Both are removed in 0.24.0.
 
-  | Old | New |
-  | --- | --- |
-  | `DayHeaderStyle.stringBuilder` | `MultiDayHeaderComponents.dayHeaderStringBuilder` |
-  | `DayHeaderStyle.numberStringBuilder` | `MultiDayHeaderComponents.dayHeaderNumberStringBuilder` |
-  | `TimelineStyle.stringBuilder` | `MultiDayBodyComponents.timelineStringBuilder` |
-  | `MonthDayHeaderStyle.stringBuilder` | `MonthBodyComponents.monthDayHeaderStringBuilder` |
-  | `WeekDayHeaderStyle.stringBuilder` | `MonthHeaderComponents.weekDayHeaderStringBuilder` |
-  | `ScheduleDateStyle.stringBuilder` | `ScheduleComponents.leadingDateStringBuilder` |
-  | `MultiDayPortalOverlayButtonStyle.stringBuilder` | `OverlayBuilders.multiDayPortalOverlayButtonStringBuilder` |
-
-- `MonthDayHeaderStyle.textStyle` is deprecated and will be removed in 0.24.0. It has never had any effect: it is documented as styling the day name, but `MonthDayHeader` displays only a day number, which `numberTextStyle` styles. The Material 3 defaults no longer assign it either, so it reads as null rather than as something that is set but ignored. [#352](https://github.com/werner-scholtz/kalender/pull/352) [#354](https://github.com/werner-scholtz/kalender/pull/354)
+- The seven string builders moved from the component style classes to the matching `*Components` classes and gained a `BuildContext` parameter, so a custom builder can read the calendar's locale. The old fields still apply when the new one is not set. [#349](https://github.com/werner-scholtz/kalender/pull/349)
+- `MonthDayHeaderStyle.textStyle` has never had any effect. `MonthDayHeader` renders only a day number, styled by `numberTextStyle`. [#354](https://github.com/werner-scholtz/kalender/pull/354)
 
 ### Features
 
-- `context.calendarLocale` reads the locale of the enclosing calendar, which is the locale it formats its own dates and times with and not necessarily the app's. It is there so that a custom string builder can format text the same way the calendar does. [#349](https://github.com/werner-scholtz/kalender/pull/349)
-
+- `context.calendarLocale` reads the locale of the enclosing calendar, which is not necessarily the app's. [#349](https://github.com/werner-scholtz/kalender/pull/349)
 - `EventsController` gained `replaceEvents`, which swaps the whole event set in one call. `DefaultEventsController` does it atomically: a single notification and no intermediate empty state, which suits reloading events from a source such as an imported `.ics` file. The base class provides a default that clears then adds, so custom controllers keep working unchanged. [#344](https://github.com/werner-scholtz/kalender/pull/344)
 
 ### Fixes

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,89 @@
 # Migration Guide
 
+## v0.22.x → v0.23.0
+
+Nothing here stops existing code from compiling. The old fields still work and are deprecated, and the changes that need action are ones that alter what the calendar renders.
+
+### String builders moved off the style classes
+
+The `String Function(...)` fields on the component style classes moved to the matching `*Components` class, and each now takes a `BuildContext` as its first argument.
+
+They are formatting hooks, not visual style. Since 0.21.0 the style classes also live inside `KalenderThemeData`, a `ThemeExtension`, where a function field cannot interpolate during a theme animation and an inline lambda breaks the style's value equality on every rebuild. The `BuildContext` closes an older gap too: a custom builder could not read the calendar's locale, while the package's own defaults could.
+
+| Old | New |
+| --- | --- |
+| `DayHeaderStyle.stringBuilder` | `MultiDayHeaderComponents.dayHeaderStringBuilder` |
+| `DayHeaderStyle.numberStringBuilder` | `MultiDayHeaderComponents.dayHeaderNumberStringBuilder` |
+| `TimelineStyle.stringBuilder` | `MultiDayBodyComponents.timelineStringBuilder` |
+| `MonthDayHeaderStyle.stringBuilder` | `MonthBodyComponents.monthDayHeaderStringBuilder` |
+| `WeekDayHeaderStyle.stringBuilder` | `MonthHeaderComponents.weekDayHeaderStringBuilder` |
+| `ScheduleDateStyle.stringBuilder` | `ScheduleComponents.leadingDateStringBuilder` |
+| `MultiDayPortalOverlayButtonStyle.stringBuilder` | `OverlayBuilders.multiDayPortalOverlayButtonStringBuilder` |
+
+The old fields are used whenever the new one is not set, so there is no rush. They are removed in 0.24.0.
+
+**Before:**
+```dart
+CalendarComponents(
+  multiDayComponentStyles: MultiDayComponentStyles(
+    headerStyles: MultiDayHeaderComponentStyles(
+      dayHeaderStyle: DayHeaderStyle(
+        stringBuilder: (date) => DateFormat.E('de_DE').format(date),
+      ),
+    ),
+  ),
+)
+```
+
+**After:**
+```dart
+CalendarComponents(
+  multiDayComponents: MultiDayComponents(
+    headerComponents: MultiDayHeaderComponents(
+      dayHeaderStringBuilder: (context, date) => DateFormat.E(context.calendarLocale).format(date),
+    ),
+  ),
+)
+```
+
+Note the hardcoded locale is gone. `context.calendarLocale` is the locale the calendar formats with, which is not necessarily the app's.
+
+### The overflow button is labelled `+3`
+
+The button standing in for events that do not fit was labelled `3 more`. That was English, with no way for the calendar's locale to reach it. It is now a plus sign and the count, with the number formatted for the locale, so locales with their own numerals read correctly.
+
+To keep the old wording:
+
+```dart
+CalendarComponents(
+  overlayBuilders: OverlayBuilders(
+    multiDayPortalOverlayButtonStringBuilder: (context, count) => '$count more',
+  ),
+)
+```
+
+### Schedule day names use the locale's own abbreviation
+
+The schedule view built its abbreviation by cutting the full day name at three characters, which only matches the real abbreviation in English. German showed `Mit` instead of `Mi`, Russian `сре` instead of `ср`. It now uses `DateFormat.E`, like every other component.
+
+No action needed unless you relied on the three-character width for layout.
+
+### `MonthDayHeaderStyle.stringBuilder` now has an effect
+
+The field was declared but never called, so setting it did nothing. Its replacement, `MonthBodyComponents.monthDayHeaderStringBuilder`, is wired up.
+
+If you set the old field and worked around it doing nothing, the day number will now change. Remove the field, or move the value to the new builder.
+
+### `MonthDayHeaderStyle.textStyle` is deprecated
+
+It is documented as styling the day name, but `MonthDayHeader` renders only a day number, styled by `numberTextStyle`. It has never had any effect. Remove it. The Material 3 defaults no longer assign it either.
+
+### Global overlay builders now apply in the month view
+
+`MonthBodyComponents.overlayBuilders` defaulted to an empty `OverlayBuilders` rather than null, and the month body resolves the specific value before the global one, so the empty default always shadowed `CalendarComponents.overlayBuilders`.
+
+If you set overlay builders globally and worked around them not applying in the month view, that workaround can go.
+
 ## v0.18.x → v0.19.0
 
 ### Timeline gutter width is now a single value (`prototypeTimeLine` removed)


### PR DESCRIPTION
The 0.23.0 changelog was doing the migration guide's job, and 0.23.0 had no migration guide section at all.

`AGENTS.md` already assigns the roles:

> Each breaking release includes a migration guide in MIGRATION.md.
> **MIGRATION.md** — breaking-change migration guides between versions.
> **CHANGELOG.md** — version history.

## The numbers

Words per changelog entry:

| Version | Entries | Words | Per entry |
| --- | --- | --- | --- |
| 0.23.0 (before) | 9 | 714 | **79** |
| 0.23.0 (after) | 9 | 371 | **41** |
| 0.22.0 | 5 | 280 | 56 |
| 0.21.0 | 5 | 206 | 41 |
| 0.20.0 | 8 | 348 | 43 |
| 0.19.0 | 27 | 622 | 23 |

0.19.0 is the striking one: a much larger release, 27 entries, and fewer total words than 0.23.0 had for nine.

## What moved

New `## v0.22.x → v0.23.0` section in `MIGRATION.md`, matching the existing per-version format, covering:

- the string builder move, with the rename table and a before/after that shows the hardcoded locale being replaced by `context.calendarLocale`
- the `+3` label, with the snippet to restore the old wording
- the schedule abbreviation change
- `MonthDayHeaderStyle.stringBuilder` starting to have an effect
- the `textStyle` deprecation
- global overlay builders now applying in the month view

The changelog keeps one line per change and links to it.

## What I left alone

The `replaceEvents` and right-to-left overflow entries predate this work and already read like the rest of the file, so they are untouched. They are why the average is 41 rather than lower — the seven entries I rewrote average 32.

Docs only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)