### PR TITLE
chore: bump version to 0.23.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: This Flutter package offers a Calendar Widget featuring Day, MultiDay, Month and Schedule views. Moreover, it empowers you to tailor the visual aspects of the calendar widget.
-version: 0.22.0
+version: 0.23.0
 repository: https://github.com/werner-scholtz/kalender.git
 topics: 
   - calendar


### PR DESCRIPTION
Version bump for the 0.23.0 release. `flutter pub publish --dry-run` is clean: 154 KB, 0 warnings.

Merge this, then tag `v0.23.0` on `main` to trigger `publish.yml`.

Contents of the release are in [CHANGELOG.md](CHANGELOG.md) and [MIGRATION.md](MIGRATION.md#v022x--v0230). Four PRs since 0.22.0: #349, #353, #354, #356 (plus #355).

🤖 Generated with [Claude Code](https://claude.com/claude-code)