### PR TITLE
ci: check the tag before publishing it

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+*' 
+    - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   release:
@@ -14,19 +14,47 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      # Full history so the tag can be checked against main.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # A published version is permanent, so refuse to publish a tag that never
+      # reached main.
+      - name: Check the tag is on main
+        run: |
+          git fetch --no-tags --quiet origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main \
+            || { echo "::error::$GITHUB_REF_NAME does not point at a commit on main"; exit 1; }
+
+      # The version lives in pubspec.yaml but the tag is what triggers this, so
+      # they are easy to get out of step.
+      - name: Check the version matches the tag
+        run: |
+          version=$(grep -m1 '^version:' pubspec.yaml | cut -d' ' -f2)
+          tag="${GITHUB_REF_NAME#v}"
+          [ "$version" = "$tag" ] \
+            || { echo "::error::pubspec.yaml is $version but the tag is $tag"; exit 1; }
 
       # For Flutter package
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
-      
+
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable' 
+          channel: 'stable'
 
       - name: Install dependencies
         run: flutter pub get
+
+      # The full timezone matrix already ran on main, this is a smoke check that
+      # the tagged commit is the one that passed.
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Test
+        run: flutter test
 
       - name: Publish
         run: flutter pub publish --force

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,32 @@ Mixins `DayEventTileUtils` and `MultiDayEventTileUtils` provide helper methods f
 
 This is a pre-1.0 package — breaking changes can occur in minor versions. Each breaking release includes a migration guide in [MIGRATION.md](MIGRATION.md).
 
+### Releasing
+
+Publishing is triggered by a tag, not by a merge. Bump `version` in `pubspec.yaml`, merge that to main, then tag the merge commit:
+
+```bash
+git tag v0.23.0 && git push origin v0.23.0
+```
+
+`publish.yml` refuses the tag unless it points at a commit on main and `pubspec.yaml` matches it, then analyzes, tests and publishes. A published version is permanent: it can be retracted within seven days, but the number can never be reused.
+
+### Pre-releases
+
+To ship a preview of the next version, add a `-dev.N` suffix:
+
+```bash
+git tag v0.24.0-dev.1 && git push origin v0.24.0-dev.1
+```
+
+pub.dev never resolves a pre-release as `latest`, so `dart pub add kalender` is unaffected and people opt in explicitly. This suits breaking releases, where the removals want trying before they are final.
+
+Patching an older release after main has moved on does not need a branch prepared in advance. Cut one from the tag when it is needed:
+
+```bash
+git branch release/0.23.x v0.23.0
+```
+
 Key breaking changes to be aware of:
 - **v0.16.0**: `CalendarEvent` removed generic type parameter (use subclassing instead of `CalendarEvent<T>`). Event IDs changed from `int` to `String`. `EventsController` refactored to abstract interface.
 - **v0.15.0**: Full timezone support added. `InternalDateTime` classes introduced. `ViewConfiguration.selectedDate` renamed to `initialDateTime`.


### PR DESCRIPTION
`publish.yml` went straight from `pub get` to `flutter pub publish --force`. Nothing checked what it was about to ship, and a published version is permanent — retractable within seven days, but the number can never be reused.

Three guards, all cheap:

**The tag must point at a commit on main.** Tags can be pushed from any branch and this workflow would have published one. Needs `fetch-depth: 0` on the checkout, since the default shallow clone can't do `merge-base`.

**`pubspec.yaml` must match the tag.** These live in different places and the version bump lands as its own PR, so they are easy to get out of step — exactly the mistake this release was set up to make.

**Analyze and test the tagged commit.** A single run, not the six-timezone matrix: that already ran on main, and the ancestor guard above means the tagged commit is one that went through it. This is a smoke check that the tag is that commit.

Verified the shell logic locally rather than by pushing tags: version parsing against both `0.23.0` and `0.24.0-dev.1`, tag stripping for both, mismatch correctly rejected, and `merge-base --is-ancestor` correctly accepting a merged commit and rejecting an unmerged branch tip.

## Also documents the release process

`AGENTS.md` had nothing on how to release. It now covers the tag-triggered flow, the `-dev.N` pre-release convention, and the note that a `release/0.23.x` branch can be cut from a tag whenever it is needed rather than prepared in advance.

The existing tag filter `v[0-9]+.[0-9]+.[0-9]+*` already matches `v0.24.0-dev.1`, so pre-releases need no workflow change. pub.dev never resolves a pre-release as `latest`, so they are opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)