### PR TITLE
docs: the overflow button no longer says "N more"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A highly customizable Flutter calendar widget with Day, MultiDay, Month, and Sch
 **[Live Demo](https://werner-scholtz.github.io/kalender/)** · **[Benchmarks](https://werner-scholtz.github.io/kalender/dev/bench/)** · **[Migration Guide](MIGRATION.md)**
 
 > [!WARNING]
-> This package is still in development. API changes may occur before version 1.0.0. So pin the package to a specific version e.g. 0.22.0
+> This package is still in development. API changes may occur before version 1.0.0, so pin an exact version in your `pubspec.yaml` rather than a caret range.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -820,9 +820,9 @@ Styles resolve in three layers, most specific first:
 
 Theme changes animate: because `KalenderThemeData` is a `ThemeExtension` with `lerp`, switching themes transitions the calendar's colors along with the rest of the app.
 
-### The "+N more" overlay
+### The overflow overlay
 
-The overlay that opens from a "+N more" button is themed the same way. Its card and close button take Flutter's own `CardThemeData` and `ButtonStyle`, so anything you can do to a `Card` or an `IconButton` you can do here.
+The overlay that opens from the `+3` button, which stands in for events that do not fit, is themed the same way. Its card and close button take Flutter's own `CardThemeData` and `ButtonStyle`, so anything you can do to a `Card` or an `IconButton` you can do here.
 
 ```dart
 KalenderThemeData(


### PR DESCRIPTION
The theming section still called it the `"+N more"` overlay and described the button by a label it no longer has. 0.23.0 changed it to `+3`.

Found during a final docs sweep before tagging. Two other things that sweep turned up, for the record:

- The `"+N more"` mentions in `CHANGELOG.md` are in the 0.19.x and 0.20.0 sections. Those correctly record what shipped at the time, so they stay.
- No doc comment in `lib/` referenced any of the moved or renamed fields.

Also verified every API name in `README.md` and `MIGRATION.md` resolves to something that exists in `lib/`, and that no internal link pointed at the renamed heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)