### PR TITLE
ci: rebuild the web demo on release tags

### DIFF
--- a/.github/workflows/web_demo.yml
+++ b/.github/workflows/web_demo.yml
@@ -5,14 +5,28 @@ on:
     branches:
       - main
       - main-wip
+    # Release tags only. publish.yml allows a pre-release suffix, this does not:
+    # a dev preview goes to pub.dev without redirecting the public demo at it.
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: write
 
+# Every run deploys to the same gh-pages branch, and pushing main and then a tag
+# starts two within seconds of each other. Queue them rather than let them
+# interleave.
+concurrency:
+  group: web-demo-deploy
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: contains(github.event.head_commit.message, 'web demo')
+    # A release tag always rebuilds, so the demo matches the published package.
+    # On a branch, rebuild only when asked for, since main can be ahead of the
+    # latest release.
+    if: startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, 'web demo')
 
     steps:
       - uses: actions/checkout@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,8 @@ git tag v0.23.0 && git push origin v0.23.0
 
 `publish.yml` refuses the tag unless it points at a commit on main and `pubspec.yaml` matches it, then analyzes, tests and publishes. A published version is permanent: it can be retracted within seven days, but the number can never be reused.
 
+The same tag rebuilds the [live demo](https://werner-scholtz.github.io/kalender/), so it always shows the published package rather than whatever is on main. To rebuild it from main instead, push a commit whose message contains `web demo`.
+
 ### Pre-releases
 
 To ship a preview of the next version, add a `-dev.N` suffix:


### PR DESCRIPTION
The demo builds from whatever is at main's tip, and only when someone remembers to put `web demo` in a commit message. Two problems with that.

**It can show unpublished behaviour.** Merge the first 0.24.0 PR, trigger a rebuild, and the demo the README calls the showcase is demonstrating a version nobody can install. Building on a release tag makes it match what `flutter pub add kalender` gives you.

**Merges never trigger it.** The condition reads `head_commit.message`, and a merge commit says "Merge pull request #N from …". So every release so far has needed a hand-written empty commit, which is easy to forget and just as easy to get wrong.

## What changed

Tag trigger, stable releases only:

```yaml
tags:
  - 'v[0-9]+.[0-9]+.[0-9]+'
```

No trailing `*`, unlike `publish.yml`. Tag filters match the whole ref, so this catches `v0.23.0` but not `v0.24.0-dev.1` — a dev preview should reach pub.dev without redirecting the public demo at it.

The job condition has to widen, because on a tag push `head_commit` is the tagged commit and its message won't mention the demo:

```yaml
if: startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, 'web demo')
```

The `web demo` message still works, as the deliberate "show me what's on main" override.

Added a `concurrency` group as well. Pushing main and then a tag starts two runs seconds apart, and both deploy to `gh-pages` with `keep_files: true`, so they should queue rather than interleave. `cancel-in-progress: false` because cancelling a half-finished deploy is worse than waiting.

## Tradeoff

With both triggers the demo shows whichever fired last: tag it and it shows the release, push `web demo` afterwards and it shows main. That is intentional. If you would rather it only ever tracked releases, drop the `branches:` trigger and the `contains(...)` half of the condition.

`AGENTS.md` release notes updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)