### PR TITLE
docs: add a live demo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="https://pub.dev/packages/kalender"><img src="https://img.shields.io/pub/v/kalender.svg" alt="pub.dev version"></a>
   <a href="https://github.com/werner-scholtz/kalender/actions"><img src="https://github.com/werner-scholtz/kalender/actions/workflows/flutter_analyze_and_test.yml/badge.svg" alt="build status"></a>
+  <a href="https://werner-scholtz.github.io/kalender/"><img src="https://img.shields.io/badge/demo-live-blueviolet.svg" alt="live demo"></a>
   <a href="https://werner-scholtz.github.io/kalender/dev/bench/"><img src="https://img.shields.io/badge/benchmarks-live-blueviolet.svg" alt="benchmarks"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license: MIT"></a>
 </p>


### PR DESCRIPTION
The badge row had `benchmarks` but not the demo, while the text line underneath links both. So benchmarks was duplicated and the demo, which is the more useful link for anyone evaluating the package, only appeared once and lower down.

```
pub v0.23.0 | Analyze and Test passing | demo live | benchmarks live | license MIT
```

Given the same `blueviolet` as benchmarks on purpose: both are live gh-pages sites, so sharing a colour groups them against the pub, build and licence badges rather than adding a fifth unrelated one. Green would have collided with the build badge's `passing`.

Checked both the shields URL and the demo URL return 200.

Unrelated but visible in the same row: the `pub` badge is `img.shields.io/pub/v/kalender.svg`, which reads the version from pub.dev, so it moves from 0.22.0 to 0.23.0 on its own once the release publishes. Nothing to change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)