### PR TITLE
docs: add a draft roadmap (WIP, not for merge yet)

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -13,3 +13,8 @@ benchmark/
 # Instructions for coding agents working on this repo, of no use to anyone
 # installing the package.
 AGENTS.md
+
+# A draft of the intended direction, kept in the repository rather than published.
+# It describes work that has not happened, so a copy frozen into a release is
+# stale the moment the next one ships.
+ROADMAP.md

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,149 @@
+# Roadmap
+
+> [!WARNING]
+> Work in progress. This is a draft of the intended direction, not a commitment. Anything here can change or be dropped, and nothing in it should be planned around. [CHANGELOG.md](CHANGELOG.md) is the record of what has actually shipped.
+
+Where kalender is going, and what has to happen before 1.0.0.
+
+Nothing here carries a date. Work is sequenced by release, and a release ships when it is ready.
+
+## What 1.0.0 means
+
+kalender is pre-1.0, so a breaking change can land in a minor version. A caret range keeps you on the minor version you chose, which is where fixes land, and every minor bump has an entry in the [migration guide](MIGRATION.md).
+
+After 1.0.0 a breaking change needs a major version, so the API has to be one worth keeping first. That cuts two ways. Anything that would **change** existing API has to happen before the freeze, or it costs a 2.0.0. Anything that **adds** API wants to happen before it too, because a feature designed under a freeze has to live with whatever shape it was given on the first attempt.
+
+So "Before 1.0.0" holds both: the breaking work, and the features that introduce new surface. Some of it has a release attached and some does not. "Not blocking 1.0.0" is what changes no public API at all.
+
+## Before 1.0.0
+
+### 0.24.0, done
+
+All five items planned for this release shipped. See [CHANGELOG.md](CHANGELOG.md) for the full list, which is longer, since the release also absorbed work that was never planned here.
+
+- **Split the readme.** Reference material moved to `doc/` and the readme became the shop window.
+- **Remove the deprecated string builders,** along with `MonthDayHeaderStyle.textStyle`.
+- **Stop re-exporting the whole `timezone` package.** `Location` and `TZDateTime` stayed.
+- **Widen value equality on `CalendarInteraction` and `HorizontalConfiguration`.** Four missing fields, each one a change that never reached the calendar. This grew too. `CalendarSnapping` was dropping its snap strategy, and `ScheduleViewConfiguration` and `PageIndexCalculator` had no `==` at all, so every rebuild recreated the view controller and its layout caches.
+- **Fix what counts as a multi-day event.** This grew past the planned fix. Rather than correcting `isMultiDayEvent` in place, the decision became a `MultiDayRule` on the view configuration, with a per-event override, and the old getter is deprecated.
+
+Five further breaking changes landed that were not planned here: `throttleMilliseconds` was removed in favour of combining drag updates per frame, `DragTargetUtilities` became a `State`-only mixin, three long-deprecated members were removed, `ScheduleTileComponents` dropped three parameters that did nothing, and its two row builders moved to `ScheduleComponents`. Ten breaking changes in one release against the four this section planned is worth noting for the next one, since batching them was the reason the section existed.
+
+### 0.25.0, theming shape
+
+The theme extension arrived in 0.21.0 and the string builders moved out of the style classes in 0.23.0. What is left is where kalender still differs from Flutter's own component themes.
+
+- **`KalenderTheme` becomes an `InheritedWidget`.** Today it is a static lookup, so a theme cannot be scoped to part of the widget tree. Flutter's component themes can be, and the current name implies this one can too.
+- **Style classes become `Diagnosticable`,** so resolved values appear in Flutter devtools the way Material's theme classes do.
+- **Revisit how deeply the style containers nest.** Reaching a single style means `CalendarComponents` to `MultiDayComponentStyles` to `MultiDayHeaderComponentStyles` to `dayHeaderStyle`. Flutter puts the property on the widget instead. The containers on that path are also the only style classes with no `==`, which does not matter while nothing compares them and would start mattering if this work does.
+- **Decide how much of Material kalender should require.** `ThemeExtension` is a Material class, so the theming system depends on Material by construction, and `Theme.of` is read in 21 files. Past that the coupling is shallow. 88 of the 106 files in `lib/` import `material.dart`, but only seven Material widgets are used anywhere (`IconButton`, `Material`, `ListTile`, `Card`, `Icons`, `InkWell` and `Divider`), so most of those imports are reaching for what `material.dart` re-exports rather than for Material itself. Flutter continues to separate Material and Cupertino from the core framework. The likely outcome is that layout and interaction stay framework neutral and Material stays the default look.
+
+One unrelated removal rides along, because 0.24.0 promised it here. **`CalendarEvent.isMultiDayEvent` is removed,** as its deprecation message says. `spansMultipleDays` replaces it.
+
+### 0.26.0, the model
+
+Everything here is breaking and the pieces depend on each other in the order below. It follows 0.25.0 closely rather than sharing it, so each release is one migration rather than two at once. Going second also gives the first item more design time, since the exact shape of the subclass hook is the least settled part of either release.
+
+**1. Base class state stops routing through your `copyWith`.** Every field `CalendarEvent` carries that `copyWith` takes no parameter for is a field each subclass has to forward by hand. That is `id`, and `multiDayRule` since 0.24.0. 0.24.0 added a debug assert that reports the omission on the first drag, but the better fix is to make it unrepresentable. The base class owns identity, interaction and classification, and `copyWith` becomes a base implementation that calls a subclass hook for the subclass's own fields. This breaks every subclass that overrides `copyWith`, which is the largest single break in the release. It goes first because every field added after it would inherit the same problem.
+
+**2. Strategy function fields become classes.** [#380](https://github.com/werner-scholtz/kalender/issues/380) carries the full inventory. A function field that takes part in `==` reads as a change on every rebuild when it is written as an inline closure, and one left out of `==` means a change to it never reaches the calendar. Both failure modes have shipped. `eventLayoutStrategy` and `generateMultiDayLayoutFrame` are the two carrying the cost today, and `nowCallback` is smaller but real. `MultiDayRule` and `PageIndexCalculator` are the shape to follow.
+
+**3. Whether an event is all-day becomes something you can state.** Today the calendar infers it from duration through `MultiDayRule`, and the per-event rule override doubles as the way to force it, which that field's own documentation admits when it describes an event "all-day by nature rather than by duration". Every calendar format models it explicitly instead. RFC 5545 encodes it as a date-valued `DTSTART`, and the ICS example in this repository already receives that signal from `enough_icalendar` and discards it. The likely outcome is a flag on the event that decides when set, with the rule deciding for the events that carry none. It comes after the copy contract so it does not become a third field to forward by hand.
+
+**4. A shorter way to call `spansMultipleDays`.** It takes two required named arguments that callers fill from the same two places every time. Additive and small. It waits on the all-day decision, since that may change what the method consults.
+
+### Tests
+
+Coverage is 88.2% of lines, up from 84.4% at 0.23.0, and still uneven. It gates the composability work below. The backfill during 0.24.0 went where the known bugs were, so the models improved sharply and the widget directories did not move at all.
+
+Both columns are line coverage of the directory and everything under it, measured with `flutter test --coverage` at each of the two tags.
+
+| Area | 0.23.0 | Now | What is missing |
+|---|---|---|---|
+| `models/` | 75% | 87% | Covered during 0.24.0. `CalendarInteraction.==` had no test at all, which is how four missing fields went unnoticed. `calendar_callbacks.dart` at 29% is what is left. |
+| `models/mixins/` | 63% | 84% | `event_tile_utils.dart` was at zero and is now covered. |
+| `models/view_configurations/` | 78% | 83% | `schedule_view_configuration.dart` at 42% and `month_view_configuration.dart` at 68%. Two `copyWith` methods here were still silently dropping fields as late as 0.24.0. |
+| `widgets/drag_targets/` | 71% | 71% | Untouched. `schedule_drag_target.dart` covers 10 of its 87 lines, the largest single gap in the package. |
+| `widgets/event_tiles/` | 81% | 81% | Untouched. `multi_day_overlay_tile.dart` at 31% and `schedule_tile.dart` at 39%. |
+| `theme/` | 78% | 78% | Untouched, and 0.25.0 rewrites this code. The lowest covered area of the package going into the release that changes it most. |
+
+The rest runs from 79% to 100% with no large gap.
+
+The three rows that did not move are the next work, and `schedule_drag_target.dart` is the one to start with. The pattern worth taking from 0.24.0 is that every gap closed turned up a bug that was already shipped.
+
+### Composability
+
+No release attached yet. It reshapes public API, so the shape has to settle before 1.0.0, and it touches enough of the package that it waits on the test coverage above.
+
+Theming was the first slice of a larger idea: assembling a calendar from parts rather than configuring one whole. Three pieces are unbuilt.
+
+- **The state layer is closed.** The providers carrying calendar state are private, so nothing outside the package can read them.
+- **View types are hardcoded.** Three switches map a `ViewConfiguration` to its controller, body and header, so a view type cannot be added without forking.
+- **There are no cell or background slots.** The bodies and headers expose nowhere to draw behind or inside a cell.
+
+This is also the gate on most of the feature list below, which is the argument for doing it rather than leaving it under investigation. Five of the nine open feature issues are waiting on one of those three pieces.
+
+### Features
+
+Most of the open issues should land before 1.0.0 rather than after it. Each one adds public API, and 1.0.0 is the point where adding it stops being cheap. They are grouped by what they are waiting on rather than by demand, because the grouping is what decides the order.
+
+**Waiting on composability.** These cannot be built cleanly against the package as it stands.
+
+| Issue | Needs |
+|---|---|
+| [#215](https://github.com/werner-scholtz/kalender/issues/215) a portal for every cell in the month body | The state layer. The overlay portal controller is created privately. |
+| [#89](https://github.com/werner-scholtz/kalender/issues/89) customize each cell | Cell slots in the multi-day body, plus selection for its range-drag half. |
+| [#262](https://github.com/werner-scholtz/kalender/issues/262) select a cell | Selection as a concept the calendar knows about. Buildable in the month view today, not in the multi-day body. |
+| [#40](https://github.com/werner-scholtz/kalender/issues/40) yearly view | A view registry, and the state layer to build against. |
+| [#264](https://github.com/werner-scholtz/kalender/issues/264) mobile month view | The same two. A grid of days over a list, not a configuration of the current month view. |
+
+Selection is the thread through the middle three. There is no `selectedDate` on the controller and no `isSelected` on a cell, so it is app owned today, and one addition serves all of them.
+
+**Independent.** These wait on nothing and can land in any release.
+
+| Issue | Shape |
+|---|---|
+| [#90](https://github.com/werner-scholtz/kalender/issues/90) hide and show weekends | A view configuration option. Changes which dates a page carries, so it reaches the date arithmetic rather than only the layout. |
+| [#98](https://github.com/werner-scholtz/kalender/issues/98) named and uneditable time regions | A second thing the calendar draws besides events, that events sit on top of. The largest new model here. |
+| [#259](https://github.com/werner-scholtz/kalender/issues/259) drag to create over a locked event | A drag starting on an unmodifiable event should fall through to creation instead of doing nothing. Mostly behavior. |
+| [#280](https://github.com/werner-scholtz/kalender/issues/280) animated transitions between views | Opt-in, default off, reduced-motion aware, wrapping the controller swap in `CalendarView`. |
+
+Multi-column days, so several calendars can sit side by side within one day, is not filed yet and belongs in the first group.
+
+### 1.0.0
+
+When the list above is settled and the API has held still for a release or two. How much of the feature list lands first is a judgement call rather than a fixed bar, but the ones that add API are far cheaper before the freeze than after.
+
+## Not blocking 1.0.0
+
+Neither of these changes public API, so neither one is a reason to hold the release.
+
+### Performance
+
+Frame timings for every view and workload are tracked on the [benchmarks dashboard](https://werner-scholtz.github.io/kalender/dev/bench/).
+
+Slow frames come from the size of the widget, render and semantics tree, not from the layout algorithms. A week at fifty events per day is about 350 tiles, and navigating builds all of them. The levers are tile weight and doing less work per navigation.
+
+- **Deferred tile rendering for dense days.** A new column of many events renders no tiles on its first frame and fills them in on the next, moving the cost off the navigation. Prototyped, and opt-in because it changes render timing. One run measured week navigation at 30ms against 54ms, still to be confirmed over several runs.
+- **Lighter event tiles.** Every event builds a draggable, a gesture detector, resize handles and an entry in a parallel drop target column. Fewer widgets and semantics nodes per tile is the largest remaining lever. One attempt measured worse than what it replaced.
+- **A bounded version of `MultiDayBodyConfiguration.keepPagesAlive`,** which is currently unbounded and grows with the number of distinct pages visited.
+- **Recycling day tiles rather than culling them,** building on the geometry model added when culling landed. Culling only helps tiles that are off screen, so it does little for a desktop week at default zoom.
+- **Revisit the schedule view,** the slowest of the four when this work started and untouched by the fixes that followed.
+- **Explain the schedule rescheduling step change at 0.24.0.** The benchmark roughly doubled at the merge that replaced `throttleMilliseconds` with per-frame coalescing, to 1.97ms at ten events per day and 3.92ms at fifty. Part of it is expected, since the old throttle dropped moves and the average was taken over frames that did no work, but the missed frames in the same run are not explained by that.
+- [#222](https://github.com/werner-scholtz/kalender/issues/222) performance when swiping, still unconfirmed.
+
+### Documentation
+
+- Group the API reference. It lists 189 symbols in one alphabetical run with no categories, so nothing marks out the handful most people need.
+
+## Decided against
+
+Asked for often enough to be worth answering here.
+
+- **An event type that carries your data.** Attaching data means subclassing `CalendarEvent` and writing `copyWith`, `==`, `hashCode` and `layoutEquals` yourself. A generic version would save the typing, but those four methods are where calendar performance is won or lost, and hiding them invites a heavy payload and skipped equality checks. The readme documents the pattern.
+
+## Influencing this
+
+Within each group under "Features" the ordering follows demand. If something there matters to you, say so on its issue. If what you need is missing, [open one](https://github.com/werner-scholtz/kalender/issues/new).
+
+Anything that needs the API to change or to grow is far cheaper to act on before 1.0.0 than after it, so raise it now rather than later.


### PR DESCRIPTION
**Work in progress, not ready to merge.** Opened to have the direction written down somewhere reviewable, not to commit to it.

Collects what is planned into one document. Work is sequenced by release rather than by date, and a "Decided against" section gives recurring requests a published answer. The document opens with a warning saying it is a draft and that the changelog is the record of what actually shipped, so nothing in it reads as a promise if someone finds the file.

Nothing links to it, and `.pubignore` keeps it out of the published archive. A roadmap describes work that has not happened, so a copy frozen into a release is stale as soon as the next one ships. It stays a repository document until the direction is settled enough to advertise.

Rebuilt on current main rather than merged, since the branch predates the readme split and conflicted with it.

### Releases

The breaking work after 0.24.0 is split across two releases that follow each other closely, so each one is a single migration rather than two at once.

- **0.25.0, theming shape.** `KalenderTheme` becomes an `InheritedWidget`, style classes become `Diagnosticable`, the style container nesting is revisited, and how much Material the package requires gets decided. `CalendarEvent.isMultiDayEvent` is removed here too, because the shipped deprecation message names this version and removing a getter does not depend on anything else.
- **0.26.0, the model.** The `copyWith` contract first, then the strategy field conversions in #380, then the all-day question, then a shorter `spansMultipleDays`. The order matters: adding an all-day flag before the copy contract is fixed would make it a third field every subclass has to forward by hand.

Theming goes first because it does not depend on the rest. `KalenderThemeData` holds only leaf style classes and all thirteen define `==`, so making it an `InheritedWidget` does not run into the function-field equality problem that #380 is about. It also gives the copy contract another cycle to settle, which is the least designed item in either release.

### Corrections to the earlier draft

The figures in the first version of this document were written from an earlier measurement and did not all survive re-checking against main.

- Coverage was re-measured at `v0.23.0` and at current main with the same method, so both columns are comparable. Overall is 84.4% to 88.2%. `models/view_configurations/` is 83%, not the 88% first written. The `models/` row was labelled "value classes" but measured the whole directory, so it now reads 75% to 87% under an accurate label.
- Added a `theme/` row. It sits at 78%, has not moved at all, and is the least covered area of the package going into the release that rewrites it.
- 0.24.0 shipped **ten** breaking changes, not nine, and **five** were unplanned rather than four. The `DragTargetUtilities` mixin change was missing from the count.
- The Material coupling counts drifted with main. 88 of 106 files import `material.dart`, and **seven** Material widgets are used rather than five. `ListTile` and `Divider` were missed.

`schedule_drag_target.dart` covers 10 of its 87 lines and is still the largest single gap in the package.

### Open

The file name. "Roadmap" reads as a commitment with dates attached, which is why the document needs a warning banner telling readers it is not one. A name that does not need the disclaimer would be better, and it is cheap to change while nothing references the file.
