### PR TITLE
docs: forward super.id instead of patching it after construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ class Event extends CalendarEvent {
   final Color? color;
 
   Event({
+    super.id,
     required super.dateTimeRange,
     required this.title,
     this.description,
@@ -164,16 +165,14 @@ class Event extends CalendarEvent {
     String? description,
     Color? color,
   }) {
-    final updated = Event(
+    return Event(
+      id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       interaction: interaction ?? this.interaction,
       title: title ?? this.title,
       description: description ?? this.description,
       color: color ?? this.color,
     );
-    // Always carry the existing ID over to the new instance.
-    updated.id = id;
-    return updated;
   }
 
   // Override == and hashCode so that the calendar can detect when an event's

--- a/examples/advanced_example/lib/main.dart
+++ b/examples/advanced_example/lib/main.dart
@@ -14,6 +14,7 @@ class Event extends CalendarEvent {
   final Person person;
 
   Event({
+    super.id,
     required super.dateTimeRange,
     required this.title,
     required this.person,
@@ -42,14 +43,13 @@ class Event extends CalendarEvent {
     Person? person,
     String? title,
   }) {
-    final newEvent = Event(
+    return Event(
+      id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       interaction: interaction ?? this.interaction,
       title: title ?? this.title,
       person: person ?? this.person,
     );
-    newEvent.id = id;
-    return newEvent;
   }
 
   @override

--- a/examples/example/lib/main.dart
+++ b/examples/example/lib/main.dart
@@ -37,6 +37,7 @@ class MyApp extends StatelessWidget {
 /// A custom event that extends [CalendarEvent] with a title and color.
 class Event extends CalendarEvent {
   Event({
+    super.id,
     required super.dateTimeRange,
     required this.title,
     this.color,
@@ -53,14 +54,13 @@ class Event extends CalendarEvent {
     String? title,
     Color? color,
   }) {
-    final newEvent = Event(
+    return Event(
+      id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       interaction: interaction ?? this.interaction,
       title: title ?? this.title,
       color: color ?? this.color,
     );
-    newEvent.id = id;
-    return newEvent;
   }
 
   @override

--- a/examples/ics/lib/ics_event.dart
+++ b/examples/ics/lib/ics_event.dart
@@ -6,6 +6,7 @@ import 'package:kalender/kalender.dart';
 /// One recurring VEVENT expands into many [IcsEvent]s that share a [uid].
 class IcsEvent extends CalendarEvent {
   IcsEvent({
+    super.id,
     required super.dateTimeRange,
     required this.uid,
     required this.title,
@@ -28,7 +29,8 @@ class IcsEvent extends CalendarEvent {
     String? description,
     Color? color,
   }) {
-    final copy = IcsEvent(
+    return IcsEvent(
+      id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       interaction: interaction ?? this.interaction,
       uid: uid ?? this.uid,
@@ -36,8 +38,6 @@ class IcsEvent extends CalendarEvent {
       description: description ?? this.description,
       color: color ?? this.color,
     );
-    copy.id = id;
-    return copy;
   }
 
   @override

--- a/examples/recurrence/lib/recurring_event.dart
+++ b/examples/recurrence/lib/recurring_event.dart
@@ -6,6 +6,7 @@ class RecurringCalendarEvent extends CalendarEvent {
   final String groupId;
 
   RecurringCalendarEvent({
+    super.id,
     required this.groupId,
     required super.dateTimeRange,
     super.interaction,
@@ -17,13 +18,12 @@ class RecurringCalendarEvent extends CalendarEvent {
     DateTimeRange? dateTimeRange,
     EventInteraction? interaction,
   }) {
-    final copy = RecurringCalendarEvent(
+    return RecurringCalendarEvent(
+      id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       groupId: groupId,
       interaction: interaction ?? this.interaction,
     );
-    copy.id = id;
-    return copy;
   }
 
   @override

--- a/examples/testing/lib/test_configuration.dart
+++ b/examples/testing/lib/test_configuration.dart
@@ -61,6 +61,7 @@ class TestConfiguration {
 /// Represents an event with a title and color.
 class Event extends CalendarEvent {
   Event({
+    super.id,
     required super.dateTimeRange,
     required this.title,
     this.description,
@@ -85,16 +86,14 @@ class Event extends CalendarEvent {
     String? description,
     Color? color,
   }) {
-    final newEvent = Event(
+    return Event(
+      id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       interaction: interaction ?? this.interaction,
       title: title ?? this.title,
       description: description ?? this.description,
       color: color ?? this.color,
     );
-    newEvent.id = id;
-
-    return newEvent;
   }
 }
 

--- a/examples/web_demo/lib/models/event.dart
+++ b/examples/web_demo/lib/models/event.dart
@@ -6,7 +6,14 @@ import 'package:kalender/kalender.dart';
 /// It contains the [title], [description], and [color] of the event.
 class Event extends CalendarEvent {
   /// Creates an [Event].
-  Event({required super.dateTimeRange, required this.title, this.description, this.color, super.interaction});
+  Event({
+    super.id,
+    required super.dateTimeRange,
+    required this.title,
+    this.description,
+    this.color,
+    super.interaction,
+  });
 
   /// The title of the [Event].
   final String title;
@@ -26,12 +33,13 @@ class Event extends CalendarEvent {
     Color? color,
   }) =>
       Event(
+        id: id,
         dateTimeRange: dateTimeRange ?? this.dateTimeRange,
         interaction: interaction ?? this.interaction,
         title: title ?? this.title,
         description: description ?? this.description,
         color: color ?? this.color,
-      )..id = id;
+      );
 
   @override
   operator ==(Object other) {

--- a/lib/src/models/calendar_events/calendar_event.dart
+++ b/lib/src/models/calendar_events/calendar_event.dart
@@ -11,16 +11,17 @@ import 'package:kalender/kalender_extensions.dart';
 ///
 /// ```dart
 /// class Event extends CalendarEvent {
-///   Event({required super.dateTimeRange, required this.title, super.interaction});
+///   Event({super.id, required super.dateTimeRange, required this.title, super.interaction});
 ///   final String title;
 ///
 ///   @override
 ///   Event copyWith({DateTimeRange? dateTimeRange, EventInteraction? interaction, String? title}) =>
 ///       Event(
+///         id: id,
 ///         dateTimeRange: dateTimeRange ?? this.dateTimeRange,
 ///         interaction: interaction ?? this.interaction,
 ///         title: title ?? this.title,
-///       )..id = id;
+///       );
 ///
 ///   @override
 ///   bool operator ==(Object other) =>
@@ -100,9 +101,10 @@ class CalendarEvent {
     EventInteraction? interaction,
   }) {
     return CalendarEvent(
+      id: id,
       dateTimeRange: dateTimeRange ?? DateTimeRange(start: start, end: end),
       interaction: interaction ?? this.interaction,
-    )..id = id;
+    );
   }
 
   @override


### PR DESCRIPTION
The custom event examples all built a new instance and then reached back in to fix the id:

```dart
final updated = Event(dateTimeRange: ..., title: ...);
// Always carry the existing ID over to the new instance.
updated.id = id;
return updated;
```

That only works because `CalendarEvent.id` is `late String` rather than `final`, and it reads like the id is special. It is not. `id` has been a constructor parameter since the ids became strings, so the subclass can forward it:

```dart
Event({super.id, required super.dateTimeRange, required this.title});

@override
Event copyWith({...}) => Event(
      id: id,
      dateTimeRange: dateTimeRange ?? this.dateTimeRange,
      title: title ?? this.title,
    );
```

Same behaviour, no mutation, and the comment explaining the trick is no longer needed.

## What changed

Nothing in the package's behaviour. The readme example, the `CalendarEvent` class doc, the base `copyWith`, and the six examples that all taught the same pattern.

## What did not change

`DefaultEventsController.updateEvent` still does `updatedEvent.id = event.id`. That is load-bearing: the store's update is `removeEvent` then `addEvent`, and `addEvent` keys on the new event's id, so without the re-stamp a `copyWith` that forgot the id would file the event under a new key and the old one would disappear. It stays as the safety net.

Making `id` final would mean deleting that net, which turns a silently corrected mistake into a broken update. That is a breaking change and belongs with the 0.24.0 batch, not here.

## Checks

`flutter analyze` and 1377 tests pass on the package. All seven examples analyze clean and their tests pass.
