### PR TITLE
fix: compare every field in CalendarInteraction and HorizontalConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.24.0
+
+### Fixes
+
+- `CalendarInteraction` and `HorizontalConfiguration` compare every field in `==`. Four were missing, and both classes reach the calendar through a `ValueNotifier` that uses `==` to decide whether to notify, so changing only `throttleMilliseconds`, `createEventGesture`, `modifyEventGesture` or `allowSingleDayEvents` never reached the calendar. [#364](https://github.com/werner-scholtz/kalender/pull/364)
+
 ## 0.23.0
 
 Nothing in this release stops existing code from compiling. See [MIGRATION.md](MIGRATION.md#v022x--v0230) for what to change.

--- a/lib/src/models/calendar_interaction.dart
+++ b/lib/src/models/calendar_interaction.dart
@@ -182,12 +182,17 @@ class CalendarInteraction {
 
   @override
   operator ==(Object other) {
+    if (identical(this, other)) return true;
+
     return other is CalendarInteraction &&
         other.allowResizing == allowResizing &&
         other.allowRescheduling == allowRescheduling &&
         other.allowEventCreation == allowEventCreation &&
+        other.throttleMilliseconds == throttleMilliseconds &&
         other.inputMode == inputMode &&
-        other.allowHorizontalImpreciseResize == allowHorizontalImpreciseResize;
+        other.allowHorizontalImpreciseResize == allowHorizontalImpreciseResize &&
+        other.createEventGesture == createEventGesture &&
+        other.modifyEventGesture == modifyEventGesture;
   }
 
   @override
@@ -195,8 +200,11 @@ class CalendarInteraction {
         allowResizing,
         allowRescheduling,
         allowEventCreation,
+        throttleMilliseconds,
         inputMode,
         allowHorizontalImpreciseResize,
+        createEventGesture,
+        modifyEventGesture,
       );
 }
 

--- a/lib/src/models/view_configurations/view_configuration.dart
+++ b/lib/src/models/view_configurations/view_configuration.dart
@@ -226,7 +226,8 @@ abstract class HorizontalConfiguration {
         other.pageTriggerConfiguration == pageTriggerConfiguration &&
         other.generateMultiDayLayoutFrame == generateMultiDayLayoutFrame &&
         other.maximumNumberOfVerticalEvents == maximumNumberOfVerticalEvents &&
-        other.eventPadding == eventPadding;
+        other.eventPadding == eventPadding &&
+        other.allowSingleDayEvents == allowSingleDayEvents;
   }
 
   @override
@@ -238,6 +239,7 @@ abstract class HorizontalConfiguration {
       generateMultiDayLayoutFrame,
       maximumNumberOfVerticalEvents,
       eventPadding,
+      allowSingleDayEvents,
     );
   }
 }

--- a/test/models/value_equality_test.dart
+++ b/test/models/value_equality_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+/// Both classes reach the calendar through a [ValueNotifier], which uses `==`
+/// to decide whether to notify. A field left out of `==` therefore never
+/// reaches the calendar when it is the only thing that changed.
+void main() {
+  group('CalendarInteraction', () {
+    CalendarInteraction base() => CalendarInteraction(
+          allowResizing: true,
+          allowRescheduling: true,
+          allowEventCreation: true,
+          throttleMilliseconds: 16,
+          inputMode: InputMode.precise,
+          allowHorizontalImpreciseResize: false,
+          createEventGesture: CreateEventGesture.tap,
+          modifyEventGesture: CreateEventGesture.tap,
+        );
+
+    test('equal when every field matches', () {
+      expect(base(), base());
+      expect(base().hashCode, base().hashCode);
+    });
+
+    final changes = <String, CalendarInteraction Function(CalendarInteraction)>{
+      'allowResizing': (i) => i.copyWith(allowResizing: false),
+      'allowRescheduling': (i) => i.copyWith(allowRescheduling: false),
+      'allowEventCreation': (i) => i.copyWith(allowEventCreation: false),
+      'throttleMilliseconds': (i) => i.copyWith(throttleMilliseconds: 32),
+      'inputMode': (i) => i.copyWith(inputMode: InputMode.imprecise),
+      'allowHorizontalImpreciseResize': (i) => i.copyWith(allowHorizontalImpreciseResize: true),
+      'createEventGesture': (i) => i.copyWith(createEventGesture: CreateEventGesture.longPress),
+      'modifyEventGesture': (i) => i.copyWith(modifyEventGesture: CreateEventGesture.longPress),
+    };
+
+    for (final entry in changes.entries) {
+      test('unequal when ${entry.key} differs', () {
+        final changed = entry.value(base());
+        expect(changed, isNot(base()));
+        expect(changed.hashCode, isNot(base().hashCode));
+      });
+    }
+
+    test('copyWith keeps the fields it is not given', () {
+      final copy = base().copyWith(throttleMilliseconds: 32);
+      expect(copy.throttleMilliseconds, 32);
+      expect(copy.allowResizing, base().allowResizing);
+      expect(copy.inputMode, base().inputMode);
+      expect(copy.createEventGesture, base().createEventGesture);
+      expect(copy.modifyEventGesture, base().modifyEventGesture);
+    });
+  });
+
+  group('MultiDayHeaderConfiguration', () {
+    const base = MultiDayHeaderConfiguration(
+      showTiles: true,
+      tileHeight: 24,
+      maximumNumberOfVerticalEvents: 3,
+      eventPadding: EdgeInsets.all(1),
+      allowSingleDayEvents: false,
+    );
+
+    test('equal when every field matches', () {
+      expect(
+        base,
+        const MultiDayHeaderConfiguration(
+          showTiles: true,
+          tileHeight: 24,
+          maximumNumberOfVerticalEvents: 3,
+          eventPadding: EdgeInsets.all(1),
+          allowSingleDayEvents: false,
+        ),
+      );
+    });
+
+    final changes = <String, MultiDayHeaderConfiguration Function()>{
+      'showTiles': () => base.copyWith(showTiles: false),
+      'tileHeight': () => base.copyWith(tileHeight: 48),
+      'maximumNumberOfVerticalEvents': () => base.copyWith(maximumNumberOfVerticalEvents: 5),
+      'eventPadding': () => base.copyWith(eventPadding: const EdgeInsets.all(4)),
+      'allowSingleDayEvents': () => base.copyWith(allowSingleDayEvents: true),
+    };
+
+    for (final entry in changes.entries) {
+      test('unequal when ${entry.key} differs', () {
+        final changed = entry.value();
+        expect(changed, isNot(base));
+        expect(changed.hashCode, isNot(base.hashCode));
+      });
+    }
+  });
+}


### PR DESCRIPTION
Part of the 0.24.0 breaking sweep on the [roadmap](https://github.com/werner-scholtz/kalender/pull/362).

`CalendarInteraction.==` compared five of its eight fields, leaving out `throttleMilliseconds`, `createEventGesture` and `modifyEventGesture`. `HorizontalConfiguration.==` left out `allowSingleDayEvents`.

Both classes reach the calendar through a `ValueNotifier`, which uses `==` to decide whether to notify. Change only one of those four fields and nothing happens: the notifier sees the old and new values as equal and never fires. `CalendarInteraction` is double-gated by the same comparison, once in the notifier and again in `CalendarBody.didUpdateWidget`.

### Why this is safe

All eight fields are bools, ints or enums. Two configurations built with the same values are still equal, so nothing that worked before starts rebuilding now. The only change is that the four previously ignored fields now reach the calendar.

### Tests

Neither class had a single test covering `==` or `hashCode`, which is how three fields went missing in the first place. `test/models/value_equality_test.dart` adds 16: every field of both classes, checked one at a time.

### What these tests do not catch

They enumerate the fields that exist today, so they catch a field being dropped from `==` but not a new field being added and forgotten. Dart does not enforce that.

A source-level check does catch it. A throwaway version pointed at all of `lib/` found 26 classes declaring `==`, and two that still have fields missing after this change:

- `CalendarSnapping.eventSnapStrategy`
- `MultiDayViewConfiguration.type`, `initialTimeOfDay`, `initialHeightPerMinute`, `scrollResolver`, `zoomResolver`

Not all of those are bugs. `initialTimeOfDay` and `initialHeightPerMinute` are read once at setup, so comparing them would only cause a rebuild that changes nothing. The rest turn on a question the package has not answered: whether function-typed fields belong in `==` at all. `HorizontalConfiguration` already compares `generateMultiDayLayoutFrame`, a function typedef, while `MultiDayViewConfiguration` skips `scrollResolver` and `zoomResolver`. Comparing them means an inline lambda makes every configuration unequal and the notifier fires on every rebuild. Skipping them means a changed callback never arrives.

Left for the full-repo audits planned before 1.0.0, and recorded here so that survey does not have to be redone.
