### PR TITLE
refactor: coalesce drag updates per frame and drop throttleMilliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.24.0
 
+### Breaking Changes
+
+- `CalendarInteraction.throttleMilliseconds` is removed. Drag updates are now coalesced to one per frame, so they follow the display's refresh rate instead of a fixed 16ms window and are no longer capped at 60 per second on a faster screen. Nothing replaces it: delete the argument. [#368](https://github.com/werner-scholtz/kalender/pull/368)
+
 ### Features
 
 - `MultiDayRule` decides whether an event belongs in the multi-day header or the day timeline. Pass one to `CalendarEvent`, or fix it for a whole app from your subclass's `super` call. `MultiDayRule.minimumDuration` is the default at 24 hours and matches the previous behaviour, and `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day. [#367](https://github.com/werner-scholtz/kalender/pull/367)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking Changes
 
 - `CalendarInteraction.throttleMilliseconds` is removed. Drag updates are now coalesced to one per frame, so they follow the display's refresh rate instead of a fixed 16ms window and are no longer capped at 60 per second on a faster screen. Nothing replaces it: delete the argument. [#368](https://github.com/werner-scholtz/kalender/pull/368)
+- `DragTargetUtilities` requires a `mounted` getter. A class applying the mixin to a `State` already satisfies it, so most code needs no change. Anything else has to supply one, because the mixin now defers work to the end of the frame and must know whether its context is still usable. [#368](https://github.com/werner-scholtz/kalender/pull/368)
 
 ### Features
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,19 @@
 
 ## v0.23.x → v0.24.0
 
+### `throttleMilliseconds` is gone
+
+```dart
+  CalendarInteraction(
+    allowResizing: true,
+-   throttleMilliseconds: 16,
+  )
+```
+
+Delete the argument. Nothing replaces it.
+
+Drag updates are now coalesced to one per frame rather than throttled against the clock, so they follow whatever rate the display refreshes at. The old default of 16ms assumed a 60Hz screen and capped updates at about 62 per second, which is half what a 120Hz display can show. There is no longer a value to choose.
+
 ### `isMultiDayEvent` became `spansMultipleDays`
 
 ```dart

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,6 +15,25 @@ Delete the argument. Nothing replaces it.
 
 Drag updates are now coalesced to one per frame rather than throttled against the clock, so they follow whatever rate the display refreshes at. The old default of 16ms assumed a 60Hz screen and capped updates at about 62 per second, which is half what a 120Hz display can show. There is no longer a value to choose.
 
+### `DragTargetUtilities` requires `mounted`
+
+Only affects you if you apply the mixin yourself. A `State` already provides `mounted`, so this is nothing to do:
+
+```dart
+class _MyDragTargetState extends State<MyDragTarget> with DragTargetUtilities { }
+```
+
+Anywhere else, supply it:
+
+```dart
+  class MyDragHandler with DragTargetUtilities {
++   @override
++   bool get mounted => true;
+  }
+```
+
+The mixin defers move handling to the end of the frame, so it can outlive disposal and has to know whether its context is still usable. Reading `State.context` after disposal throws rather than returning null, which is why the check cannot live inside the mixin.
+
 ### `isMultiDayEvent` became `spansMultipleDays`
 
 ```dart

--- a/lib/src/models/calendar_interaction.dart
+++ b/lib/src/models/calendar_interaction.dart
@@ -105,13 +105,6 @@ class CalendarInteraction {
   static const defaultModifyEventGesture = CreateEventGesture.tap;
   static const defaultMobileModifyEventGesture = CreateEventGesture.longPress;
 
-  /// The number of milliseconds to throttle the interaction events.
-  ///
-  /// This is used to prevent excessive updates during drag operations.
-  /// This can be adjusted based on the performance needs of the application.
-  final int throttleMilliseconds;
-  static const defaultThrottleMilliseconds = 16;
-
   /// The input mode for the calendar.
   ///
   /// This determines how resize handles are positioned and when they become visible.
@@ -146,7 +139,6 @@ class CalendarInteraction {
     this.allowResizing = defaultAllowResizing,
     this.allowRescheduling = defaultAllowRescheduling,
     this.allowEventCreation = defaultAllowEventCreation,
-    this.throttleMilliseconds = defaultThrottleMilliseconds,
     this.inputMode = defaultInputMode,
     this.allowHorizontalImpreciseResize = defaultAllowHorizontalImpreciseResize,
     CreateEventGesture? createEventGesture,
@@ -162,7 +154,6 @@ class CalendarInteraction {
     bool? allowResizing,
     bool? allowRescheduling,
     bool? allowEventCreation,
-    int? throttleMilliseconds,
     InputMode? inputMode,
     bool? allowHorizontalImpreciseResize,
     CreateEventGesture? createEventGesture,
@@ -172,7 +163,6 @@ class CalendarInteraction {
       allowResizing: allowResizing ?? this.allowResizing,
       allowRescheduling: allowRescheduling ?? this.allowRescheduling,
       allowEventCreation: allowEventCreation ?? this.allowEventCreation,
-      throttleMilliseconds: throttleMilliseconds ?? this.throttleMilliseconds,
       inputMode: inputMode ?? this.inputMode,
       allowHorizontalImpreciseResize: allowHorizontalImpreciseResize ?? this.allowHorizontalImpreciseResize,
       createEventGesture: createEventGesture ?? this.createEventGesture,
@@ -188,7 +178,6 @@ class CalendarInteraction {
         other.allowResizing == allowResizing &&
         other.allowRescheduling == allowRescheduling &&
         other.allowEventCreation == allowEventCreation &&
-        other.throttleMilliseconds == throttleMilliseconds &&
         other.inputMode == inputMode &&
         other.allowHorizontalImpreciseResize == allowHorizontalImpreciseResize &&
         other.createEventGesture == createEventGesture &&
@@ -200,7 +189,6 @@ class CalendarInteraction {
         allowResizing,
         allowRescheduling,
         allowEventCreation,
-        throttleMilliseconds,
         inputMode,
         allowHorizontalImpreciseResize,
         createEventGesture,

--- a/lib/src/models/mixins/drag_target_utils.dart
+++ b/lib/src/models/mixins/drag_target_utils.dart
@@ -7,16 +7,24 @@ typedef UpdatedEvent = (CalendarEvent, CalendarEvent);
 
 mixin DragTargetUtilities {
   BuildContext get context;
+
+  /// Whether [context] is still usable.
+  ///
+  /// Satisfied by [State.mounted]. Checked before any deferred work, since
+  /// reading [State.context] after disposal throws rather than returning null.
+  bool get mounted;
   CalendarController get controller;
   EventsController get eventsController;
   CalendarCallbacks? get callbacks;
   double get dayWidth;
   List<DateTime> get visibleDates;
   bool get multiDayDragTarget;
-  int get throttleMilliseconds => context.interaction.throttleMilliseconds;
 
-  /// The last timestamp when the [onMove] was called.
-  int _lastMoveTimestamp = 0;
+  /// The most recent move, waiting to be processed at the end of the frame.
+  DragTargetDetails<Object?>? _pendingMove;
+
+  /// Whether a callback is already registered for the pending move.
+  bool _moveScheduled = false;
 
   /// A copy of the event being created.
   CalendarEvent? newEvent;
@@ -54,13 +62,27 @@ mixin DragTargetUtilities {
     );
   }
 
-  /// Handle the [DragTarget.onMove] with throttling.
+  /// Handle the [DragTarget.onMove], processing at most one move per frame.
+  ///
+  /// Pointer moves can arrive faster than the display refreshes, and each one
+  /// processed rebuilds the preview. Only the newest is worth drawing, so the
+  /// rest are discarded rather than throttled against the clock.
   void onMove(DragTargetDetails<Object?> details) {
-    // Throttle the move events to prevent excessive updates.
-    final currentTime = DateTime.now().millisecondsSinceEpoch;
-    if (currentTime - _lastMoveTimestamp < throttleMilliseconds) return;
-    _lastMoveTimestamp = currentTime;
-    _processMove(details);
+    _pendingMove = details;
+    if (_moveScheduled) return;
+    _moveScheduled = true;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _moveScheduled = false;
+      final pending = _pendingMove;
+      _pendingMove = null;
+      if (pending == null || !mounted) return;
+      _processMove(pending);
+    });
+
+    // addPostFrameCallback does not schedule a frame, and without one the
+    // pending move would sit unprocessed.
+    WidgetsBinding.instance.scheduleFrame();
   }
 
   /// Handle the [DragTarget.onMove].
@@ -140,6 +162,8 @@ mixin DragTargetUtilities {
       resolveEvent: _resolveEvent,
     );
 
+    _cancelPendingMove();
+
     if (result == null) return;
     final originalEvent = result.$1;
     final updatedEvent = result.$2;
@@ -151,9 +175,17 @@ mixin DragTargetUtilities {
 
   /// Handle the [DragTarget.onLeave]
   void onLeave(Object? details) {
+    _cancelPendingMove();
     controller.deselectEvent();
     newEvent = null;
   }
+
+  /// Drop any move still waiting to be processed.
+  ///
+  /// A move queued during the drag would otherwise be processed after the drop
+  /// has already deselected the event, reselecting it and leaving the preview
+  /// behind as a duplicate of the event it was previewing.
+  void _cancelPendingMove() => _pendingMove = null;
 
   /// Reschedule an event.
   CalendarEvent? rescheduleEvent(CalendarEvent event, InternalDateTime cursorDateTime);

--- a/test/interactions/drag_target_utils_test.dart
+++ b/test/interactions/drag_target_utils_test.dart
@@ -14,6 +14,9 @@ class _DragUtilsHarness with DragTargetUtilities {
   BuildContext get context => throw UnimplementedError();
 
   @override
+  bool get mounted => true;
+
+  @override
   final CalendarController controller;
 
   @override

--- a/test/models/calendar_interaction_test.dart
+++ b/test/models/calendar_interaction_test.dart
@@ -85,7 +85,6 @@ void main() {
         allowResizing: true,
         allowRescheduling: true,
         allowEventCreation: true,
-        throttleMilliseconds: 16,
         inputMode: InputMode.precise,
         allowHorizontalImpreciseResize: false,
         createEventGesture: CreateEventGesture.tap,
@@ -94,13 +93,11 @@ void main() {
 
       final copy = original.copyWith(
         allowResizing: false,
-        throttleMilliseconds: 32,
         inputMode: InputMode.imprecise,
         modifyEventGesture: CreateEventGesture.longPress,
       );
 
       expect(copy.allowResizing, isFalse);
-      expect(copy.throttleMilliseconds, equals(32));
       expect(copy.inputMode, equals(InputMode.imprecise));
       expect(copy.modifyEventGesture, equals(CreateEventGesture.longPress));
       // Untouched fields are preserved.
@@ -113,13 +110,11 @@ void main() {
     test('copyWith with no arguments preserves every field', () {
       final original = CalendarInteraction(
         allowResizing: false,
-        throttleMilliseconds: 99,
         inputMode: InputMode.imprecise,
         createEventGesture: CreateEventGesture.longPress,
       );
       final copy = original.copyWith();
       expect(copy.allowResizing, equals(original.allowResizing));
-      expect(copy.throttleMilliseconds, equals(original.throttleMilliseconds));
       expect(copy.inputMode, equals(original.inputMode));
       expect(copy.createEventGesture, equals(original.createEventGesture));
     });
@@ -132,7 +127,6 @@ void main() {
           allowResizing: true,
           allowRescheduling: true,
           allowEventCreation: true,
-          throttleMilliseconds: 16,
           inputMode: InputMode.precise,
           allowHorizontalImpreciseResize: false,
           createEventGesture: CreateEventGesture.tap,
@@ -148,7 +142,6 @@ void main() {
       'allowResizing': (i) => i.copyWith(allowResizing: false),
       'allowRescheduling': (i) => i.copyWith(allowRescheduling: false),
       'allowEventCreation': (i) => i.copyWith(allowEventCreation: false),
-      'throttleMilliseconds': (i) => i.copyWith(throttleMilliseconds: 999),
       'inputMode': (i) => i.copyWith(inputMode: InputMode.imprecise),
       'allowHorizontalImpreciseResize': (i) => i.copyWith(allowHorizontalImpreciseResize: true),
       'createEventGesture': (i) => i.copyWith(createEventGesture: CreateEventGesture.longPress),

--- a/test/widgets/drag_move_coalescing_test.dart
+++ b/test/widgets/drag_move_coalescing_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/day_tile.dart' show DayEventTile;
+
+import '../utilities.dart';
+
+/// Pointer moves arrive faster than the display refreshes, so [DragTargetUtilities.onMove]
+/// keeps only the newest and processes it once per frame.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+  late String eventId;
+
+  final start = DateTime(2025, 3, 24);
+  final viewConfiguration = MultiDayViewConfiguration.singleDay(
+    initialTimeOfDay: const TimeOfDay(hour: 5, minute: 0),
+    initialHeightPerMinute: 1,
+    displayRange: DateTimeRange(start: start, end: DateTime(2025, 3, 31)),
+    initialDateTime: start,
+  );
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+    eventId = eventsController.addEvent(
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(start: start.copyWith(hour: 6), end: start.copyWith(hour: 8)),
+      ),
+    );
+  });
+
+  Future<void> pumpCalendar(WidgetTester tester) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: viewConfiguration,
+        callbacks: CalendarCallbacks(
+          onEventChanged: (event, updatedEvent) => eventsController.updateEvent(
+            event: event,
+            updatedEvent: updatedEvent,
+          ),
+        ),
+        body: CalendarBody(
+          interaction: CalendarInteraction(
+            inputMode: InputMode.precise,
+            createEventGesture: CreateEventGesture.tap,
+            modifyEventGesture: CreateEventGesture.tap,
+          ),
+          multiDayTileComponents: TileComponents(
+            tileBuilder: (event, tileRange) => Container(key: ValueKey(event.id), color: Colors.red),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Starts a reschedule drag and returns the gesture, past the point where the
+  /// draggable has been picked up.
+  Future<TestGesture> beginDrag(WidgetTester tester) async {
+    final tile = find.byKey(DayEventTile.tileKey(eventId));
+    expect(tile, findsOneWidget);
+
+    final gesture = await tester.startGesture(tester.getCenter(tile));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0, 40));
+    await tester.pumpAndSettle();
+    return gesture;
+  }
+
+  testWidgets('moves within one frame coalesce into a single update', (tester) async {
+    await pumpCalendar(tester);
+    final gesture = await beginDrag(tester);
+
+    var updates = 0;
+    calendarController.selectedEvent.addListener(() => updates++);
+
+    // Three moves with no frame between them.
+    await gesture.moveBy(const Offset(0, 20));
+    await gesture.moveBy(const Offset(0, 20));
+    await gesture.moveBy(const Offset(0, 20));
+    expect(updates, 0, reason: 'nothing is processed until the frame ends');
+
+    await tester.pump();
+    expect(updates, 1, reason: 'the three moves collapse into one update');
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('the update uses the newest move, not the first', (tester) async {
+    await pumpCalendar(tester);
+    final gesture = await beginDrag(tester);
+
+    final afterFirstMove = calendarController.selectedEvent.value!.start;
+
+    await gesture.moveBy(const Offset(0, 30));
+    await gesture.moveBy(const Offset(0, 30));
+    await tester.pump();
+
+    final coalesced = calendarController.selectedEvent.value!.start;
+    final movedBy = coalesced.difference(afterFirstMove);
+
+    // 60 logical pixels at 1 minute per pixel. Had the first move won, this
+    // would be half as much.
+    expect(movedBy.inMinutes, greaterThan(45), reason: 'the last move should win, not the first');
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('a move queued at the moment of the drop does not survive it', (tester) async {
+    await pumpCalendar(tester);
+    final gesture = await beginDrag(tester);
+
+    // Queue a move and drop before the frame that would process it.
+    await gesture.moveBy(const Offset(0, 20));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(
+      calendarController.selectedEvent.value,
+      isNull,
+      reason: 'a pending move must not reselect the event after the drop deselected it',
+    );
+    expect(find.byKey(DayEventTile.tileKey(eventId)), findsOneWidget, reason: 'the preview must not be left behind');
+  });
+}


### PR DESCRIPTION
**Stacked on #367 → #366 → #365 → #364. Merge those first, in order.**

Removes `CalendarInteraction.throttleMilliseconds` and coalesces drag updates to one per frame instead.

### What it was

```dart
final currentTime = DateTime.now().millisecondsSinceEpoch;
if (currentTime - _lastMoveTimestamp < throttleMilliseconds) return;
_lastMoveTimestamp = currentTime;
_processMove(details);
```

The default of 16 is a 60Hz frame. On a 120Hz display, frames are 8.3ms, so the drag preview updated **half as often as the screen could show it**. The intent was always "at most once per frame", and wall-clock milliseconds only expressed that on one class of hardware.

It was also the only `int`-typed time value in the package — `triggerDelay`, `animationDuration` and the rest are all `Duration` — and it sat on a class that otherwise describes what a user is *permitted* to do rather than how fast the package reacts.

### What it is now

Moves go into a pending slot; the newest is processed in a post-frame callback. Adapts to any refresh rate, always uses the latest position rather than the oldest in the window, and drops the `DateTime.now()` on every pointer event.

### Why the knob goes entirely

Its only correct value is the frame interval, which the framework knows and an app author does not. A setting whose only right answer is its default is an invitation to make things worse, and keeping it means documenting pointer-event coalescing to people who should never have to think about it.

Removed rather than deprecated. A field that still compiles but silently stops having any effect is worse than a compile error. That is the opposite of `isMultiDayEvent` in #367, where the deprecated getter still returns a correct answer and so earns a migration window.

### The bug this turned up

Deferring the work means a move can outlive the drag. Without cancellation, a queued move runs *after* the drop has called `deselectEvent()`, reselects the event, and leaves the preview behind. In `day_events_widget.dart` the preview is matched to the real event by `controller.selectedEventId`, which the drop has already cleared, so it is inserted instead of replacing — two entries with the same id:

```
COLLISION: children=2 entries=1 ids=[YXe0obiFiw, YXe0obiFiw]
```

`EventLayoutDelegate.calculateVerticalLayoutData` caches into a `Map<int, VerticalLayoutData>` keyed by `event.hashCode`, so the duplicates collapse to one entry while the children list still holds both, and layout asserts with *"forgot to lay out the following child"*. `onAcceptWithDetails` and `onLeave` now discard anything pending.

Worth noting the delegate's hashCode-keyed cache silently collapses any duplicate event, which is a sharp edge independent of this change. Not touched here.

`mounted` joins the mixin's requirements, since the callback can outlive disposal and reading `State.context` when unmounted throws rather than returning null. All three real users are `State` subclasses, so it costs them nothing.

### Checks

`flutter analyze` clean. **1,508 passing**, up from 1,506 on #367 — three new tests, minus the `throttleMilliseconds` equality case that no longer has a field.

`test/widgets/drag_move_coalescing_test.dart` gives this behaviour its first tests: several moves in one frame produce one update, that update reflects the last move rather than the first, and a move queued at the moment of the drop does not survive it. The third fails without the cancellation fix, verified by reverting it.
