### PR TITLE
feat: keep the header drop target following a multi-day drag over the body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `MultiDayRule` decides whether an event belongs in the multi-day header or the day timeline. Pass one to `CalendarEvent`, or fix it for a whole app from your subclass's `super` call. `MultiDayRule.minimumDuration` is the default at 24 hours and matches the previous behaviour, `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day, and `MultiDayRule.always` suits events that are all-day by nature. [#367](https://github.com/werner-scholtz/kalender/pull/367)
+- `MultiDayRule` decides whether an event belongs in the multi-day header or the day timeline. Pass one to `CalendarEvent`, or fix it for a whole app from your subclass's `super` call. `MultiDayRule.minimumDuration` is the default at 24 hours and matches the previous behaviour, and `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day. [#367](https://github.com/werner-scholtz/kalender/pull/367)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.24.0
 
+### Breaking Changes
+
+- `CalendarInteraction.throttleMilliseconds` is removed. Drag updates are now coalesced to one per frame, so they follow the display's refresh rate instead of a fixed 16ms window and are no longer capped at 60 per second on a faster screen. Nothing replaces it: delete the argument. [#368](https://github.com/werner-scholtz/kalender/pull/368)
+
 ### Features
 
 - `MultiDayRule` decides whether an event belongs in the multi-day header or the day timeline. Pass one to `CalendarEvent`, or fix it for a whole app from your subclass's `super` call. `MultiDayRule.minimumDuration` is the default at 24 hours and matches the previous behaviour, and `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day. [#367](https://github.com/werner-scholtz/kalender/pull/367)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking Changes
 
 - `CalendarInteraction.throttleMilliseconds` is removed. Drag updates are now coalesced to one per frame, so they follow the display's refresh rate instead of a fixed 16ms window and are no longer capped at 60 per second on a faster screen. Nothing replaces it: delete the argument. [#368](https://github.com/werner-scholtz/kalender/pull/368)
+- `DragTargetUtilities` requires a `mounted` getter. A class applying the mixin to a `State` already satisfies it, so most code needs no change. Anything else has to supply one, because the mixin now defers work to the end of the frame and must know whether its context is still usable. [#368](https://github.com/werner-scholtz/kalender/pull/368)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 0.24.0
 
+### Features
+
+- `MultiDayRule` decides whether an event belongs in the multi-day header or the day timeline. Pass one to `CalendarEvent`, or fix it for a whole app from your subclass's `super` call. `MultiDayRule.minimumDuration` is the default at 24 hours and matches the previous behaviour, `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day, and `MultiDayRule.always` suits events that are all-day by nature. [#367](https://github.com/werner-scholtz/kalender/pull/367)
+
+### Deprecations
+
+- `CalendarEvent.isMultiDayEvent` is replaced by `spansMultipleDays(location:)`. The getter could not take a location, so it measured calendar days in UTC. Removed in 0.25.0. See [MIGRATION.md](MIGRATION.md#v023x--v0240). [#367](https://github.com/werner-scholtz/kalender/pull/367)
+
 ### Fixes
 
 - `CalendarInteraction` and `HorizontalConfiguration` compare every field in `==`. Four were missing, and both classes reach the calendar through a `ValueNotifier` that uses `==` to decide whether to notify, so changing only `throttleMilliseconds`, `createEventGesture`, `modifyEventGesture` or `allowSingleDayEvents` never reached the calendar. [#364](https://github.com/werner-scholtz/kalender/pull/364)
@@ -7,6 +15,7 @@
 - `ScrollTriggerConfiguration.copyWith` keeps `scrollAmount`. It had no such parameter, so every copy reset the drag-scroll distance to the default. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - Removing an event no longer throws when its date index was never populated for that location. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - Tapping the trailing edge of an event tile resolves to the last visible day instead of one day past it. [#366](https://github.com/werner-scholtz/kalender/pull/366)
+- The two drag-target guards that decide whether an event may be dropped in the header or the body now use the calendar's location. They ignored it, so they could disagree with the rest of the calendar near midnight and across daylight saving changes. [#367](https://github.com/werner-scholtz/kalender/pull/367)
 
 ## 0.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Features
 
+- Dragging a multi-day event down over the body keeps moving its drop target in the header, instead of freezing it until the cursor returns. Releasing over the body commits the date. Only the date changes, so the time of day and duration are untouched. [#369](https://github.com/werner-scholtz/kalender/pull/369)
 - `MultiDayRule` decides whether an event belongs in the multi-day header or the day timeline. Pass one to `CalendarEvent`, or fix it for a whole app from your subclass's `super` call. `MultiDayRule.minimumDuration` is the default at 24 hours and matches the previous behaviour, and `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day. [#367](https://github.com/werner-scholtz/kalender/pull/367)
 
 ### Deprecations

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,19 @@
 
 ## v0.23.x → v0.24.0
 
+### `throttleMilliseconds` is gone
+
+```dart
+  CalendarInteraction(
+    allowResizing: true,
+-   throttleMilliseconds: 16,
+  )
+```
+
+Delete the argument. Nothing replaces it.
+
+Drag updates are now coalesced to one per frame rather than throttled against the clock, so they follow whatever rate the display refreshes at. The old default of 16ms assumed a 60Hz screen and capped updates at about 62 per second, which is half what a 120Hz display can show. There is no longer a value to choose.
+
 ### `isMultiDayEvent` became `spansMultipleDays`
 
 ```dart

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,47 @@
 # Migration Guide
 
+## v0.23.x → v0.24.0
+
+### `isMultiDayEvent` became `spansMultipleDays`
+
+```dart
+- if (event.isMultiDayEvent) { ... }
++ if (event.spansMultipleDays(location: context.location)) { ... }
+```
+
+The old getter still works and is removed in 0.25.0. It answers as if the calendar were in UTC, because a getter cannot take a location.
+
+The name had to change. Dart rejects a class declaring both a getter and a method called `isMultiDayEvent`, so reusing the name would have meant no deprecation period at all. Worse, `event.isMultiDayEvent` would have kept compiling anywhere a `dynamic` is accepted, silently becoming a function object rather than a boolean.
+
+### Choosing what counts as multi-day
+
+The rule is now a `MultiDayRule` on the event. The default is `MultiDayRule.minimumDuration(Duration(hours: 24))`, which is exactly the previous behaviour, so nothing renders differently until you change it.
+
+| Rule | Multi-day when |
+| --- | --- |
+| `MultiDayRule.minimumDuration(d)` | the event lasts at least `d` |
+| `MultiDayRule.calendarDays()` | the event covers part of more than one calendar day |
+| `MultiDayRule.always()` | always, for events that are all-day by nature |
+
+Set it for one event:
+
+```dart
+CalendarEvent(dateTimeRange: range, multiDayRule: const MultiDayRule.calendarDays())
+```
+
+Or for your whole app, from the subclass you already have:
+
+```dart
+class Event extends CalendarEvent {
+  Event({required super.dateTimeRange, required this.title})
+      : super(multiDayRule: const MultiDayRule.calendarDays());
+}
+```
+
+For a rule none of these express, override `spansMultipleDays` instead.
+
+`multiDayRule` takes part in `layoutEquals`, so two events differing only in their rule are not equal. A subclass overriding `layoutEquals` does not need to do anything, since `super`'s comparison already covers it.
+
 ## v0.22.x → v0.23.0
 
 Nothing here stops existing code from compiling. The old fields still work and are deprecated, and the changes that need action are ones that alter what the calendar renders.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -42,6 +42,8 @@ For a rule none of these express, override `spansMultipleDays` instead.
 
 `multiDayRule` takes part in `layoutEquals`, so two events differing only in their rule are not equal. A subclass overriding `layoutEquals` does not need to do anything, since `super`'s comparison already covers it.
 
+Your `copyWith` override needs no change either. `multiDayRule` is deliberately not a parameter on it: adding one to `CalendarEvent.copyWith` would make every subclass override invalid, since an override has to accept every named parameter its supertype accepts. The rule is carried through automatically. Set it in the constructor, and construct a new event on the rare occasion you need to change it.
+
 ## v0.22.x → v0.23.0
 
 Nothing here stops existing code from compiling. The old fields still work and are deprecated, and the changes that need action are ones that alter what the calendar renders.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,7 +21,6 @@ The rule is now a `MultiDayRule` on the event. The default is `MultiDayRule.mini
 | --- | --- |
 | `MultiDayRule.minimumDuration(d)` | the event lasts at least `d` |
 | `MultiDayRule.calendarDays()` | the event covers part of more than one calendar day |
-| `MultiDayRule.always()` | always, for events that are all-day by nature |
 
 Set it for one event:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,6 +15,25 @@ Delete the argument. Nothing replaces it.
 
 Drag updates are now coalesced to one per frame rather than throttled against the clock, so they follow whatever rate the display refreshes at. The old default of 16ms assumed a 60Hz screen and capped updates at about 62 per second, which is half what a 120Hz display can show. There is no longer a value to choose.
 
+### `DragTargetUtilities` requires `mounted`
+
+Only affects you if you apply the mixin yourself. A `State` already provides `mounted`, so this is nothing to do:
+
+```dart
+class _MyDragTargetState extends State<MyDragTarget> with DragTargetUtilities { }
+```
+
+Anywhere else, supply it:
+
+```dart
+  class MyDragHandler with DragTargetUtilities {
++   @override
++   bool get mounted => true;
+  }
+```
+
+The mixin defers move handling to the end of the frame, so it can outlive disposal and has to know whether its context is still usable. Reading `State.context` after disposal throws rather than returning null, which is why the check cannot live inside the mixin.
+
 ### `isMultiDayEvent` became `spansMultipleDays`
 
 ```dart

--- a/lib/kalender.dart
+++ b/lib/kalender.dart
@@ -24,6 +24,7 @@ export 'package:kalender/src/models/controllers/events_controller.dart';
 export 'package:kalender/src/models/view_configurations/view_configuration.dart';
 export 'package:kalender/src/models/calendar_callbacks.dart';
 export 'package:kalender/src/models/calendar_events/calendar_event.dart';
+export 'package:kalender/src/models/calendar_events/multi_day_rule.dart';
 export 'package:kalender/src/models/calendar_interaction.dart';
 export 'package:kalender/src/models/controllers/view_controller.dart';
 export 'package:kalender/src/models/view_transition.dart';

--- a/lib/src/models/calendar_events/calendar_event.dart
+++ b/lib/src/models/calendar_events/calendar_event.dart
@@ -117,17 +117,18 @@ class CalendarEvent {
   /// Returns a copy with the given fields replaced.
   ///
   /// The [id] is preserved so that selection and layout lookups continue to
-  /// reference the same logical event.
+  /// reference the same logical event. [multiDayRule] is carried over too, and
+  /// is deliberately not a parameter: adding one here would invalidate every
+  /// subclass's override of this method.
   CalendarEvent copyWith({
     DateTimeRange? dateTimeRange,
     EventInteraction? interaction,
-    MultiDayRule? multiDayRule,
   }) {
     return CalendarEvent(
       id: id,
       dateTimeRange: dateTimeRange ?? DateTimeRange(start: start, end: end),
       interaction: interaction ?? this.interaction,
-      multiDayRule: multiDayRule ?? this.multiDayRule,
+      multiDayRule: multiDayRule,
     );
   }
 

--- a/lib/src/models/calendar_events/calendar_event.dart
+++ b/lib/src/models/calendar_events/calendar_event.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart' show EventInteraction;
 import 'package:kalender/kalender_extensions.dart';
+import 'package:kalender/src/models/calendar_events/multi_day_rule.dart';
 
 /// Base class for events displayed in the calendar.
 ///
@@ -44,6 +45,14 @@ class CalendarEvent {
   /// Unique identifier. Auto-generated if not provided.
   late String id;
 
+  /// Decides whether this event belongs in the multi-day header lane.
+  ///
+  /// Defaults to [MultiDayRule.minimumDuration] of 24 hours.
+  final MultiDayRule multiDayRule;
+
+  /// The default rule: 24 hours or longer.
+  static const defaultMultiDayRule = MultiDayRule.minimumDuration(Duration(hours: 24));
+
   /// Creates a [CalendarEvent].
   ///
   /// [dateTimeRange] is stored in UTC. A unique [id] is generated if omitted.
@@ -52,10 +61,12 @@ class CalendarEvent {
     String? id,
     required DateTimeRange dateTimeRange,
     EventInteraction? interaction,
+    MultiDayRule? multiDayRule,
   })  : id = id ?? _createUniqueId(),
         start = dateTimeRange.start.toUtc(),
         end = dateTimeRange.end.toUtc(),
-        interaction = interaction ?? EventInteraction.fromCanModify(true);
+        interaction = interaction ?? EventInteraction.fromCanModify(true),
+        multiDayRule = multiDayRule ?? defaultMultiDayRule;
 
   // TODO: consider using a UUID package for more robust ID generation.
   static String _createUniqueId() {
@@ -86,8 +97,19 @@ class CalendarEvent {
   /// Total duration (UTC-based).
   Duration get duration => dateTimeRange.duration;
 
+  /// Whether this event belongs in the multi-day header lane rather than the
+  /// day timeline, with calendar days measured in [location].
+  ///
+  /// Applies [multiDayRule]. Override for a rule no [MultiDayRule] expresses.
+  bool spansMultipleDays({required Location? location}) => multiDayRule.test(this, location: location);
+
   /// Whether this event spans more than one day.
-  bool get isMultiDayEvent => duration.inDays > 0;
+  ///
+  /// Cannot take a location, so it measures calendar days in UTC. That is why
+  /// it is deprecated: rules such as [MultiDayRule.calendarDays] give the wrong
+  /// answer near midnight and across daylight saving changes without one.
+  @Deprecated('Use spansMultipleDays, which takes a location. Will be removed in 0.25.0.')
+  bool get isMultiDayEvent => spansMultipleDays(location: null);
 
   /// All dates this event spans, adjusted for [location].
   List<InternalDateTime> datesSpanned({Location? location}) => internalRange(location: location).dates();
@@ -99,11 +121,13 @@ class CalendarEvent {
   CalendarEvent copyWith({
     DateTimeRange? dateTimeRange,
     EventInteraction? interaction,
+    MultiDayRule? multiDayRule,
   }) {
     return CalendarEvent(
       id: id,
       dateTimeRange: dateTimeRange ?? DateTimeRange(start: start, end: end),
       interaction: interaction ?? this.interaction,
+      multiDayRule: multiDayRule ?? this.multiDayRule,
     );
   }
 
@@ -119,12 +143,20 @@ class CalendarEvent {
   bool operator ==(Object other) => other is CalendarEvent && layoutEquals(other);
 
   @override
-  int get hashCode => Object.hash(id, start, end, interaction);
+  int get hashCode => Object.hash(id, start, end, interaction, multiDayRule);
 
-  /// Compares layout-affecting properties ([id], [start], [end], [interaction]).
+  /// Compares layout-affecting properties ([id], [start], [end], [interaction],
+  /// [multiDayRule]).
+  ///
+  /// [multiDayRule] counts because it decides whether the event renders in the
+  /// header or the day timeline.
   ///
   /// Override in subclasses that add properties affecting rendering.
   bool layoutEquals(CalendarEvent other) {
-    return id == other.id && start == other.start && end == other.end && interaction == other.interaction;
+    return id == other.id &&
+        start == other.start &&
+        end == other.end &&
+        interaction == other.interaction &&
+        multiDayRule == other.multiDayRule;
   }
 }

--- a/lib/src/models/calendar_events/multi_day_rule.dart
+++ b/lib/src/models/calendar_events/multi_day_rule.dart
@@ -30,12 +30,6 @@ abstract class MultiDayRule {
   /// boundaries fall, so a short event crossing midnight counts.
   const factory MultiDayRule.calendarDays() = CalendarDaysRule;
 
-  /// Always multi-day, whatever the times say.
-  ///
-  /// For events that are all-day by nature rather than by duration, such as an
-  /// `.ics` event with `DTSTART;VALUE=DATE`.
-  const factory MultiDayRule.always() = AlwaysMultiDayRule;
-
   /// Whether [event] is multi-day, with calendar days measured in [location].
   bool test(CalendarEvent event, {required Location? location});
 }
@@ -79,18 +73,4 @@ class CalendarDaysRule extends MultiDayRule {
 
   @override
   int get hashCode => (CalendarDaysRule).hashCode;
-}
-
-/// Always multi-day.
-class AlwaysMultiDayRule extends MultiDayRule {
-  const AlwaysMultiDayRule();
-
-  @override
-  bool test(CalendarEvent event, {required Location? location}) => true;
-
-  @override
-  bool operator ==(Object other) => other is AlwaysMultiDayRule;
-
-  @override
-  int get hashCode => (AlwaysMultiDayRule).hashCode;
 }

--- a/lib/src/models/calendar_events/multi_day_rule.dart
+++ b/lib/src/models/calendar_events/multi_day_rule.dart
@@ -1,0 +1,96 @@
+import 'package:kalender/kalender_extensions.dart';
+import 'package:kalender/src/models/calendar_events/calendar_event.dart';
+
+/// Decides whether an event belongs in the multi-day header lane rather than
+/// the day timeline.
+///
+/// Set it per event, or fix it for a whole app by passing it from a subclass:
+///
+/// ```dart
+/// class Event extends CalendarEvent {
+///   Event({required super.dateTimeRange})
+///       : super(multiDayRule: const MultiDayRule.calendarDays());
+/// }
+/// ```
+///
+/// This is a class rather than a function so that it has value equality.
+/// Configurations holding a rule are compared with `==` to decide whether the
+/// calendar needs to rebuild, and a function field would defeat that.
+abstract class MultiDayRule {
+  const MultiDayRule();
+
+  /// Multi-day when the event lasts at least [minimum].
+  ///
+  /// The default, with a [minimum] of 24 hours.
+  const factory MultiDayRule.minimumDuration(Duration minimum) = MinimumDurationRule;
+
+  /// Multi-day when the event covers part of more than one calendar day.
+  ///
+  /// Unlike [MultiDayRule.minimumDuration] this depends on where the day
+  /// boundaries fall, so a short event crossing midnight counts.
+  const factory MultiDayRule.calendarDays() = CalendarDaysRule;
+
+  /// Always multi-day, whatever the times say.
+  ///
+  /// For events that are all-day by nature rather than by duration, such as an
+  /// `.ics` event with `DTSTART;VALUE=DATE`.
+  const factory MultiDayRule.always() = AlwaysMultiDayRule;
+
+  /// Whether [event] is multi-day, with calendar days measured in [location].
+  bool test(CalendarEvent event, {required Location? location});
+}
+
+/// Multi-day when the event lasts at least [minimum]. Ignores [Location],
+/// since duration does not depend on where the day boundaries fall.
+class MinimumDurationRule extends MultiDayRule {
+  const MinimumDurationRule(this.minimum);
+
+  /// The shortest duration that counts as multi-day.
+  final Duration minimum;
+
+  @override
+  bool test(CalendarEvent event, {required Location? location}) => event.duration >= minimum;
+
+  @override
+  bool operator ==(Object other) => other is MinimumDurationRule && other.minimum == minimum;
+
+  @override
+  int get hashCode => minimum.hashCode;
+}
+
+/// Multi-day when the event covers part of more than one calendar day.
+class CalendarDaysRule extends MultiDayRule {
+  const CalendarDaysRule();
+
+  @override
+  bool test(CalendarEvent event, {required Location? location}) {
+    final range = event.internalRange(location: location);
+    if (range.dates().length > 1) return true;
+
+    // `dates()` is half-open, so a full day (00:00 to the next 00:00) counts as
+    // one day above. Keep it multi-day so all-day events stay in the header.
+    final start = range.start;
+    final end = range.end;
+    return start == start.startOfDay && end == end.startOfDay && end.isAfter(start);
+  }
+
+  @override
+  bool operator ==(Object other) => other is CalendarDaysRule;
+
+  @override
+  int get hashCode => (CalendarDaysRule).hashCode;
+}
+
+/// Always multi-day.
+class AlwaysMultiDayRule extends MultiDayRule {
+  const AlwaysMultiDayRule();
+
+  @override
+  bool test(CalendarEvent event, {required Location? location}) => true;
+
+  @override
+  bool operator ==(Object other) => other is AlwaysMultiDayRule;
+
+  @override
+  int get hashCode => (AlwaysMultiDayRule).hashCode;
+}

--- a/lib/src/models/calendar_interaction.dart
+++ b/lib/src/models/calendar_interaction.dart
@@ -105,13 +105,6 @@ class CalendarInteraction {
   static const defaultModifyEventGesture = CreateEventGesture.tap;
   static const defaultMobileModifyEventGesture = CreateEventGesture.longPress;
 
-  /// The number of milliseconds to throttle the interaction events.
-  ///
-  /// This is used to prevent excessive updates during drag operations.
-  /// This can be adjusted based on the performance needs of the application.
-  final int throttleMilliseconds;
-  static const defaultThrottleMilliseconds = 16;
-
   /// The input mode for the calendar.
   ///
   /// This determines how resize handles are positioned and when they become visible.
@@ -146,7 +139,6 @@ class CalendarInteraction {
     this.allowResizing = defaultAllowResizing,
     this.allowRescheduling = defaultAllowRescheduling,
     this.allowEventCreation = defaultAllowEventCreation,
-    this.throttleMilliseconds = defaultThrottleMilliseconds,
     this.inputMode = defaultInputMode,
     this.allowHorizontalImpreciseResize = defaultAllowHorizontalImpreciseResize,
     CreateEventGesture? createEventGesture,
@@ -162,7 +154,6 @@ class CalendarInteraction {
     bool? allowResizing,
     bool? allowRescheduling,
     bool? allowEventCreation,
-    int? throttleMilliseconds,
     InputMode? inputMode,
     bool? allowHorizontalImpreciseResize,
     CreateEventGesture? createEventGesture,
@@ -172,7 +163,6 @@ class CalendarInteraction {
       allowResizing: allowResizing ?? this.allowResizing,
       allowRescheduling: allowRescheduling ?? this.allowRescheduling,
       allowEventCreation: allowEventCreation ?? this.allowEventCreation,
-      throttleMilliseconds: throttleMilliseconds ?? this.throttleMilliseconds,
       inputMode: inputMode ?? this.inputMode,
       allowHorizontalImpreciseResize: allowHorizontalImpreciseResize ?? this.allowHorizontalImpreciseResize,
       createEventGesture: createEventGesture ?? this.createEventGesture,
@@ -188,7 +178,6 @@ class CalendarInteraction {
         other.allowResizing == allowResizing &&
         other.allowRescheduling == allowRescheduling &&
         other.allowEventCreation == allowEventCreation &&
-        other.throttleMilliseconds == throttleMilliseconds &&
         other.inputMode == inputMode &&
         other.allowHorizontalImpreciseResize == allowHorizontalImpreciseResize &&
         other.createEventGesture == createEventGesture &&
@@ -200,7 +189,6 @@ class CalendarInteraction {
         allowResizing,
         allowRescheduling,
         allowEventCreation,
-        throttleMilliseconds,
         inputMode,
         allowHorizontalImpreciseResize,
         createEventGesture,

--- a/lib/src/models/controllers/events_controller/default_events_controller.dart
+++ b/lib/src/models/controllers/events_controller/default_events_controller.dart
@@ -126,7 +126,7 @@ class DefaultEventsController extends EventsController {
   ) {
     return events.where((event) {
       // If the event is not a multi day event, return false.
-      if (!event.isMultiDayEvent) return false;
+      if (!event.spansMultipleDays(location: location)) return false;
       return event.internalRange(location: location).overlaps(dateTimeRange);
     });
   }
@@ -139,7 +139,7 @@ class DefaultEventsController extends EventsController {
   ) {
     return events.where((event) {
       // If the event is a multi day event, return false.
-      if (event.isMultiDayEvent) return false;
+      if (event.spansMultipleDays(location: location)) return false;
 
       // If the event is a zero duration event at the start of the day, we should check for touching.
       final touching = _checkTouching(event, location);

--- a/lib/src/models/mixins/drag_target_utils.dart
+++ b/lib/src/models/mixins/drag_target_utils.dart
@@ -7,16 +7,24 @@ typedef UpdatedEvent = (CalendarEvent, CalendarEvent);
 
 mixin DragTargetUtilities {
   BuildContext get context;
+
+  /// Whether [context] is still usable.
+  ///
+  /// Satisfied by [State.mounted]. Checked before any deferred work, since
+  /// reading [State.context] after disposal throws rather than returning null.
+  bool get mounted;
   CalendarController get controller;
   EventsController get eventsController;
   CalendarCallbacks? get callbacks;
   double get dayWidth;
   List<DateTime> get visibleDates;
   bool get multiDayDragTarget;
-  int get throttleMilliseconds => context.interaction.throttleMilliseconds;
 
-  /// The last timestamp when the [onMove] was called.
-  int _lastMoveTimestamp = 0;
+  /// The most recent move, waiting to be processed at the end of the frame.
+  DragTargetDetails<Object?>? _pendingMove;
+
+  /// Whether a callback is already registered for the pending move.
+  bool _moveScheduled = false;
 
   /// A copy of the event being created.
   CalendarEvent? newEvent;
@@ -54,13 +62,27 @@ mixin DragTargetUtilities {
     );
   }
 
-  /// Handle the [DragTarget.onMove] with throttling.
+  /// Handle the [DragTarget.onMove], processing at most one move per frame.
+  ///
+  /// Pointer moves can arrive faster than the display refreshes, and each one
+  /// processed rebuilds the preview. Only the newest is worth drawing, so the
+  /// rest are discarded rather than throttled against the clock.
   void onMove(DragTargetDetails<Object?> details) {
-    // Throttle the move events to prevent excessive updates.
-    final currentTime = DateTime.now().millisecondsSinceEpoch;
-    if (currentTime - _lastMoveTimestamp < throttleMilliseconds) return;
-    _lastMoveTimestamp = currentTime;
-    _processMove(details);
+    _pendingMove = details;
+    if (_moveScheduled) return;
+    _moveScheduled = true;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _moveScheduled = false;
+      final pending = _pendingMove;
+      _pendingMove = null;
+      if (pending == null || !mounted) return;
+      _processMove(pending);
+    });
+
+    // addPostFrameCallback does not schedule a frame, and without one the
+    // pending move would sit unprocessed.
+    WidgetsBinding.instance.scheduleFrame();
   }
 
   /// Handle the [DragTarget.onMove].
@@ -140,6 +162,8 @@ mixin DragTargetUtilities {
       resolveEvent: _resolveEvent,
     );
 
+    _cancelPendingMove();
+
     if (result == null) return;
     final originalEvent = result.$1;
     final updatedEvent = result.$2;
@@ -151,9 +175,17 @@ mixin DragTargetUtilities {
 
   /// Handle the [DragTarget.onLeave]
   void onLeave(Object? details) {
+    _cancelPendingMove();
     controller.deselectEvent();
     newEvent = null;
   }
+
+  /// Drop any move still waiting to be processed.
+  ///
+  /// A move queued during the drag would otherwise be processed after the drop
+  /// has already deselected the event, reselecting it and leaving the preview
+  /// behind as a duplicate of the event it was previewing.
+  void _cancelPendingMove() => _pendingMove = null;
 
   /// Reschedule an event.
   CalendarEvent? rescheduleEvent(CalendarEvent event, InternalDateTime cursorDateTime);

--- a/lib/src/models/mixins/drag_target_utils.dart
+++ b/lib/src/models/mixins/drag_target_utils.dart
@@ -296,4 +296,23 @@ mixin DragTargetUtilities {
     if (start.isAfter(end)) (start, end) = (end, start);
     return DateTimeRange(start: start, end: end);
   }
+
+  /// Moves [event] to the date of [cursorDateTime], keeping its time of day and
+  /// duration.
+  ///
+  /// Used where only the date can meaningfully change: the header, and a
+  /// multi-day event dragged across the body.
+  CalendarEvent rescheduleToDate(CalendarEvent event, InternalDateTime cursorDateTime) {
+    final start = event.internalStart(location: context.location);
+    final newStart = cursorDateTime.copyWith(
+      hour: start.hour,
+      minute: start.minute,
+      second: start.second,
+      millisecond: start.millisecond,
+      microsecond: start.microsecond,
+    );
+
+    final range = InternalDateTimeRange(start: newStart, end: newStart.add(event.duration));
+    return event.copyWith(dateTimeRange: toLocationDateTimeRange(range));
+  }
 }

--- a/lib/src/models/view_configurations/view_configuration.dart
+++ b/lib/src/models/view_configurations/view_configuration.dart
@@ -96,7 +96,10 @@ abstract class ViewConfiguration {
 
 /// The base class for all vertical views of the calendar.
 abstract class VerticalConfiguration {
-  /// Whether to show events that are longer than 1 day.
+  /// Whether to show multi-day events in the body.
+  ///
+  /// Which events count is decided per event by [CalendarEvent.multiDayRule],
+  /// 24 hours or longer by default.
   final bool showMultiDayEvents;
 
   /// The horizontal padding between events and the edge of the day column.
@@ -190,7 +193,10 @@ abstract class HorizontalConfiguration {
   /// The padding used around events.
   final EdgeInsets eventPadding;
 
-  /// Whether to display events shorter than 24 hours.
+  /// Whether to display single-day events in this horizontal lane.
+  ///
+  /// Which events count is decided per event by [CalendarEvent.multiDayRule],
+  /// shorter than 24 hours by default.
   final bool allowSingleDayEvents;
 
   /// The configuration for the page navigation triggers.

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -392,7 +392,7 @@ class TimeLine extends StatelessWidget with TimeLineUtils {
 
             // Multi-day events belong in the header, not the body.
             // Don't show timeline tooltips for them.
-            if (eventBeingDragged.isMultiDayEvent) return const SizedBox();
+            if (eventBeingDragged.spansMultipleDays(location: context.location)) return const SizedBox();
 
             // Ensure that the event is visible.
             final eventRange = eventBeingDragged.internalRange(location: context.location);

--- a/lib/src/widgets/drag_targets/horizontal_drag_target.dart
+++ b/lib/src/widgets/drag_targets/horizontal_drag_target.dart
@@ -45,7 +45,10 @@ class HorizontalDragTarget extends StatefulWidget {
       onReschedule: (event) {
         // If the configuration does not allow single-day events (e.g., multi-day header),
         // reject single-day events. They belong in the body, not the header.
-        if (!configuration.allowSingleDayEvents && !event.isMultiDayEvent) return false;
+        if (!configuration.allowSingleDayEvents &&
+            !event.spansMultipleDays(location: controller.viewController?.location)) {
+          return false;
+        }
         return true;
       },
       onOther: () => false,
@@ -186,7 +189,9 @@ class _HorizontalDragTargetState extends State<HorizontalDragTarget> with DragTa
   CalendarEvent? rescheduleEvent(CalendarEvent event, InternalDateTime cursorDateTime) {
     // If the configuration does not allow single-day events (e.g., multi-day header),
     // return null to prevent updating the selection while dragging over this area.
-    if (!widget.configuration.allowSingleDayEvents && !event.isMultiDayEvent) return null;
+    if (!widget.configuration.allowSingleDayEvents && !event.spansMultipleDays(location: context.location)) {
+      return null;
+    }
 
     // Calculate the new dateTimeRange for the event.
     final start = event.internalStart(location: context.location);

--- a/lib/src/widgets/drag_targets/horizontal_drag_target.dart
+++ b/lib/src/widgets/drag_targets/horizontal_drag_target.dart
@@ -193,20 +193,7 @@ class _HorizontalDragTargetState extends State<HorizontalDragTarget> with DragTa
       return null;
     }
 
-    // Calculate the new dateTimeRange for the event.
-    final start = event.internalStart(location: context.location);
-    final newStartTime = cursorDateTime.copyWith(
-      hour: start.hour,
-      minute: start.minute,
-      second: start.second,
-      millisecond: start.millisecond,
-      microsecond: start.microsecond,
-    );
-    final duration = event.duration;
-    final endTime = newStartTime.add(duration);
-    final newRange = InternalDateTimeRange(start: newStartTime, end: endTime);
-
-    return event.copyWith(dateTimeRange: toLocationDateTimeRange(newRange));
+    return rescheduleToDate(event, cursorDateTime);
   }
 
   @override

--- a/lib/src/widgets/drag_targets/schedule_drag_target.dart
+++ b/lib/src/widgets/drag_targets/schedule_drag_target.dart
@@ -197,7 +197,7 @@ class _ScheduleDragTargetState extends State<ScheduleDragTarget> with DragTarget
       start: cursorDateTime,
       end: cursorDateTime.add(rangeAsUtc.duration),
     );
-    if (event.isMultiDayEvent) {
+    if (event.spansMultipleDays(location: context.location)) {
       final duration = rangeAsUtc.duration;
       final endTime = cursorDateTime.add(duration);
       final newRange = InternalDateTimeRange(start: cursorDateTime, end: endTime);

--- a/lib/src/widgets/drag_targets/vertical_drag_target.dart
+++ b/lib/src/widgets/drag_targets/vertical_drag_target.dart
@@ -54,9 +54,10 @@ class VerticalDragTarget extends StatefulWidget {
       onCreate: (controllerId) => controllerId == controller.id,
       onResize: (event, direction) => direction.vertical,
       onReschedule: (event) {
-        // Multi-day events belong in the header, not the body.
-        // They should be rescheduled via HorizontalDragTarget, not VerticalDragTarget.
-        if (event.spansMultipleDays(location: controller.viewController?.location)) return false;
+        // A multi-day event stays in the header, so the time of day range does
+        // not constrain it. Accepted so that dropping here commits the date the
+        // header has been previewing.
+        if (event.spansMultipleDays(location: controller.viewController?.location)) return true;
 
         // Check if the event will fit within the time of day range.
         if (!timeOfDayRange.isAllDay && event.duration > timeOfDayRange.duration) return false;
@@ -288,9 +289,12 @@ class _VerticalDragTargetState extends State<VerticalDragTarget> with SnapPoints
   /// Update the [CalendarEvent] based on the [Offset] delta.
   @override
   CalendarEvent? rescheduleEvent(CalendarEvent event, InternalDateTime cursorDateTime) {
-    // Multi-day events belong in the header, not the body.
-    // Return null to prevent updating the selection while dragging over this area.
-    if (event.spansMultipleDays(location: context.location)) return null;
+    // A multi-day event is laid out in the header, so dragging it across the
+    // body can only change which date it starts on. Updating it here is what
+    // moves the header's drop target as the cursor crosses day columns.
+    if (event.spansMultipleDays(location: context.location)) {
+      return rescheduleToDate(event, cursorDateTime);
+    }
 
     InternalDateTime start;
 

--- a/lib/src/widgets/drag_targets/vertical_drag_target.dart
+++ b/lib/src/widgets/drag_targets/vertical_drag_target.dart
@@ -56,7 +56,7 @@ class VerticalDragTarget extends StatefulWidget {
       onReschedule: (event) {
         // Multi-day events belong in the header, not the body.
         // They should be rescheduled via HorizontalDragTarget, not VerticalDragTarget.
-        if (event.isMultiDayEvent) return false;
+        if (event.spansMultipleDays(location: controller.viewController?.location)) return false;
 
         // Check if the event will fit within the time of day range.
         if (!timeOfDayRange.isAllDay && event.duration > timeOfDayRange.duration) return false;
@@ -290,7 +290,7 @@ class _VerticalDragTargetState extends State<VerticalDragTarget> with SnapPoints
   CalendarEvent? rescheduleEvent(CalendarEvent event, InternalDateTime cursorDateTime) {
     // Multi-day events belong in the header, not the body.
     // Return null to prevent updating the selection while dragging over this area.
-    if (event.isMultiDayEvent) return null;
+    if (event.spansMultipleDays(location: context.location)) return null;
 
     InternalDateTime start;
 

--- a/lib/src/widgets/events_widgets/day_events_widget.dart
+++ b/lib/src/widgets/events_widgets/day_events_widget.dart
@@ -405,7 +405,7 @@ class _DayDropTargetColumnState extends State<DayDropTargetColumn> {
     }
 
     // If the configuration does not allow multi-day events and the selected event is a multi-day event, clear the state.
-    if (!widget.configuration.showMultiDayEvents && selectedEvent.isMultiDayEvent) {
+    if (!widget.configuration.showMultiDayEvents && selectedEvent.spansMultipleDays(location: widget.location)) {
       if (_selectedEvent != null) setState(() => _selectedEvent = null);
       return;
     }

--- a/lib/src/widgets/events_widgets/multi_day_events_widget.dart
+++ b/lib/src/widgets/events_widgets/multi_day_events_widget.dart
@@ -302,7 +302,9 @@ class _MultiDayEventLayoutWidgetState extends State<MultiDayEventLayoutWidget> {
       valueListenable: context.calendarController.selectedEvent,
       builder: (context, event, child) {
         if (event == null) return const SizedBox();
-        if (!widget.configuration.allowSingleDayEvents && !event.isMultiDayEvent) return const SizedBox();
+        if (!widget.configuration.allowSingleDayEvents && !event.spansMultipleDays(location: context.location)) {
+          return const SizedBox();
+        }
         if (!event.internalRange(location: context.location).overlaps(widget.internalDateTimeRange)) {
           return const SizedBox();
         }

--- a/test/interactions/drag_target_utils_test.dart
+++ b/test/interactions/drag_target_utils_test.dart
@@ -14,6 +14,9 @@ class _DragUtilsHarness with DragTargetUtilities {
   BuildContext get context => throw UnimplementedError();
 
   @override
+  bool get mounted => true;
+
+  @override
   final CalendarController controller;
 
   @override

--- a/test/models/calendar_event_test.dart
+++ b/test/models/calendar_event_test.dart
@@ -243,16 +243,6 @@ void main() {
     });
   });
 
-  group('MultiDayRule.always', () {
-    test('classifies a two-minute event as multi-day', () {
-      final event = CalendarEvent(
-        dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 1, 15, 9), end: DateTime.utc(2024, 1, 15, 9, 2)),
-        multiDayRule: const MultiDayRule.always(),
-      );
-      expect(event.spansMultipleDays(location: utcLocation), isTrue);
-    });
-  });
-
   group('choosing a rule', () {
     test('per event, via the constructor', () {
       final crossing = DateTimeRange(start: DateTime.utc(2024, 1, 15, 23), end: DateTime.utc(2024, 1, 16, 1));
@@ -282,12 +272,12 @@ void main() {
       // which is the documented way to attach data to an event.
       final event = CalendarEvent(
         dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 1, 15), end: DateTime.utc(2024, 1, 16)),
-        multiDayRule: const MultiDayRule.always(),
+        multiDayRule: const MultiDayRule.calendarDays(),
       );
-      expect(event.copyWith().multiDayRule, const MultiDayRule.always());
+      expect(event.copyWith().multiDayRule, const MultiDayRule.calendarDays());
       expect(
         event.copyWith(dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 2), end: DateTime.utc(2024, 2, 2))),
-        isA<CalendarEvent>().having((e) => e.multiDayRule, 'multiDayRule', const MultiDayRule.always()),
+        isA<CalendarEvent>().having((e) => e.multiDayRule, 'multiDayRule', const MultiDayRule.calendarDays()),
       );
     });
 
@@ -303,7 +293,6 @@ void main() {
   group('MultiDayRule equality', () {
     test('the same rule compares equal', () {
       expect(const MultiDayRule.calendarDays(), const MultiDayRule.calendarDays());
-      expect(const MultiDayRule.always(), const MultiDayRule.always());
       expect(
         const MultiDayRule.minimumDuration(Duration(hours: 24)),
         const MultiDayRule.minimumDuration(Duration(hours: 24)),
@@ -311,7 +300,7 @@ void main() {
     });
 
     test('different rules do not', () {
-      expect(const MultiDayRule.calendarDays(), isNot(const MultiDayRule.always()));
+      expect(const MultiDayRule.calendarDays(), isNot(const MultiDayRule.minimumDuration(Duration(hours: 24))));
       expect(
         const MultiDayRule.minimumDuration(Duration(hours: 24)),
         isNot(const MultiDayRule.minimumDuration(Duration(hours: 12))),

--- a/test/models/calendar_event_test.dart
+++ b/test/models/calendar_event_test.dart
@@ -277,15 +277,17 @@ void main() {
       expect(_StrictMultiDayEvent(dateTimeRange: fullDay).spansMultipleDays(location: utcLocation), isFalse);
     });
 
-    test('copyWith carries the rule', () {
+    test('copyWith carries the rule, and takes no parameter for it', () {
+      // A parameter here would invalidate every subclass override of copyWith,
+      // which is the documented way to attach data to an event.
       final event = CalendarEvent(
         dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 1, 15), end: DateTime.utc(2024, 1, 16)),
         multiDayRule: const MultiDayRule.always(),
       );
       expect(event.copyWith().multiDayRule, const MultiDayRule.always());
       expect(
-        event.copyWith(multiDayRule: const MultiDayRule.calendarDays()).multiDayRule,
-        const MultiDayRule.calendarDays(),
+        event.copyWith(dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 2), end: DateTime.utc(2024, 2, 2))),
+        isA<CalendarEvent>().having((e) => e.multiDayRule, 'multiDayRule', const MultiDayRule.always()),
       );
     });
 

--- a/test/models/calendar_event_test.dart
+++ b/test/models/calendar_event_test.dart
@@ -168,50 +168,165 @@ void main() {
     });
   });
 
-  // ─── isMultiDayEvent ─────────────────────────────────────────────────────────
-  //
-  // CHARACTERIZATION of the *current* implementation, which is defined purely on
-  // the UTC `duration.inDays > 0`. This is location-independent and ignores
-  // calendar-day boundaries. The `skip`ped group below records the agreed-upon
-  // *desired* (location/calendar-day-aware) behaviour for when the getter is
-  // reworked — see calendar_event.dart:89 and AGENTS.md "isMultiDayEvent".
+  // ─── spansMultipleDays ───────────────────────────────────────────────────────
 
-  group('isMultiDayEvent (current UTC-duration behaviour)', () {
+  group('the default rule, minimumDuration(24h)', () {
     test('a short same-day event is not multi-day', () {
-      expect(eventUtc(DateTime.utc(2024, 1, 15, 9), DateTime.utc(2024, 1, 15, 10)).isMultiDayEvent, isFalse);
+      final event = eventUtc(DateTime.utc(2024, 1, 15, 9), DateTime.utc(2024, 1, 15, 10));
+      expect(event.spansMultipleDays(location: utcLocation), isFalse);
     });
 
-    test('an event of exactly 24h is multi-day (inDays == 1)', () {
-      expect(eventUtc(DateTime.utc(2024, 1, 15), DateTime.utc(2024, 1, 16)).isMultiDayEvent, isTrue);
+    test('exactly 24h is multi-day', () {
+      final event = eventUtc(DateTime.utc(2024, 1, 15), DateTime.utc(2024, 1, 16));
+      expect(event.spansMultipleDays(location: utcLocation), isTrue);
     });
 
-    test('an event longer than 24h is multi-day', () {
-      expect(eventUtc(DateTime.utc(2024, 1, 15, 9), DateTime.utc(2024, 1, 17, 9)).isMultiDayEvent, isTrue);
+    test('longer than 24h is multi-day', () {
+      final event = eventUtc(DateTime.utc(2024, 1, 15, 9), DateTime.utc(2024, 1, 17, 9));
+      expect(event.spansMultipleDays(location: utcLocation), isTrue);
     });
 
-    test('a short event crossing midnight is NOT classed as multi-day (known limitation)', () {
-      // 23:00 -> 01:00 next day is only 2h, so inDays == 0, even though it
-      // occupies two calendar days. This is the cross-midnight bug.
+    test('a short event crossing midnight is not multi-day', () {
+      // 2h long, so under the duration rule it stays in the day timeline even
+      // though it occupies two calendar days. Use MultiDayRule.calendarDays()
+      // to classify it the other way.
       final event = eventUtc(DateTime.utc(2024, 1, 15, 23), DateTime.utc(2024, 1, 16, 1));
-      expect(event.isMultiDayEvent, isFalse);
+      expect(event.datesSpanned(location: utcLocation), hasLength(2));
+      expect(event.spansMultipleDays(location: utcLocation), isFalse);
+    });
+
+    test('matches the duration.inDays > 0 rule it replaced', () {
+      // The evidence that swapping the getter for the rule changed no rendering.
+      final ranges = [
+        [DateTime.utc(2024, 1, 15, 9), DateTime.utc(2024, 1, 15, 10)],
+        [DateTime.utc(2024, 1, 15, 8), DateTime.utc(2024, 1, 15, 18)],
+        [DateTime.utc(2024, 1, 15, 23), DateTime.utc(2024, 1, 16, 1)],
+        [DateTime.utc(2024, 1, 15), DateTime.utc(2024, 1, 16)],
+        [DateTime.utc(2024, 1, 15, 9), DateTime.utc(2024, 1, 17, 9)],
+        [DateTime.utc(2024, 1, 15), DateTime.utc(2024, 1, 15)],
+        // Spring forward in Europe/Amsterdam, 2024-03-31.
+        [DateTime.utc(2024, 3, 30, 23), DateTime.utc(2024, 3, 31, 22)],
+      ];
+
+      for (final range in ranges) {
+        final event = eventUtc(range.first, range.last);
+        expect(
+          event.spansMultipleDays(location: utcLocation),
+          equals(event.duration.inDays > 0),
+          reason: 'changed for ${range.first} to ${range.last}',
+        );
+      }
     });
   });
 
-  group('isMultiDayEvent (desired location/calendar-day-aware behaviour)', () {
-    test('a short event crossing midnight should be multi-day (spans two calendar days)', () {
-      // 23:00 -> 01:00 next day occupies Jan 15 and Jan 16 in UTC.
-      final event = eventUtc(DateTime.utc(2024, 1, 15, 23), DateTime.utc(2024, 1, 16, 1));
-      expect(event.datesSpanned(location: utcLocation), hasLength(2));
-      expect(event.isMultiDayEvent, isTrue);
+  group('MultiDayRule.calendarDays', () {
+    CalendarEvent event(DateTime start, DateTime end) {
+      return CalendarEvent(
+        dateTimeRange: DateTimeRange(start: start, end: end),
+        multiDayRule: const MultiDayRule.calendarDays(),
+      );
+    }
+
+    test('a short event crossing midnight is multi-day', () {
+      final crossing = event(DateTime.utc(2024, 1, 15, 23), DateTime.utc(2024, 1, 16, 1));
+      expect(crossing.spansMultipleDays(location: utcLocation), isTrue);
     });
 
-    test('a long event within a single calendar day should not be multi-day', () {
-      // A 10-hour event entirely inside one day must remain a single-day event.
-      final event = eventUtc(DateTime.utc(2024, 1, 15, 8), DateTime.utc(2024, 1, 15, 18));
-      expect(event.isMultiDayEvent, isFalse);
+    test('a long event inside one calendar day is not multi-day', () {
+      final within = event(DateTime.utc(2024, 1, 15, 8), DateTime.utc(2024, 1, 15, 18));
+      expect(within.spansMultipleDays(location: utcLocation), isFalse);
     });
-    },
-    skip: 'Desired behaviour: reclassify isMultiDayEvent to be location/calendar-day-aware. '
-        'Un-skip when spansMultipleDays lands with MultiDayRule.calendarDays().',
-  );
+
+    test('a full day stays multi-day so it remains in the header', () {
+      final fullDay = event(DateTime.utc(2024, 1, 15), DateTime.utc(2024, 1, 16));
+      expect(fullDay.spansMultipleDays(location: utcLocation), isTrue);
+    });
+  });
+
+  group('MultiDayRule.always', () {
+    test('classifies a two-minute event as multi-day', () {
+      final event = CalendarEvent(
+        dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 1, 15, 9), end: DateTime.utc(2024, 1, 15, 9, 2)),
+        multiDayRule: const MultiDayRule.always(),
+      );
+      expect(event.spansMultipleDays(location: utcLocation), isTrue);
+    });
+  });
+
+  group('choosing a rule', () {
+    test('per event, via the constructor', () {
+      final crossing = DateTimeRange(start: DateTime.utc(2024, 1, 15, 23), end: DateTime.utc(2024, 1, 16, 1));
+      expect(CalendarEvent(dateTimeRange: crossing).spansMultipleDays(location: utcLocation), isFalse);
+      expect(
+        CalendarEvent(dateTimeRange: crossing, multiDayRule: const MultiDayRule.calendarDays())
+            .spansMultipleDays(location: utcLocation),
+        isTrue,
+      );
+    });
+
+    test('per app, via a subclass that fixes the rule', () {
+      final event = _CalendarDayEvent(
+        dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 1, 15, 23), end: DateTime.utc(2024, 1, 16, 1)),
+      );
+      expect(event.spansMultipleDays(location: utcLocation), isTrue);
+    });
+
+    test('fully custom, by overriding spansMultipleDays', () {
+      final fullDay = DateTimeRange(start: DateTime.utc(2024, 1, 15), end: DateTime.utc(2024, 1, 16));
+      expect(CalendarEvent(dateTimeRange: fullDay).spansMultipleDays(location: utcLocation), isTrue);
+      expect(_StrictMultiDayEvent(dateTimeRange: fullDay).spansMultipleDays(location: utcLocation), isFalse);
+    });
+
+    test('copyWith carries the rule', () {
+      final event = CalendarEvent(
+        dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 1, 15), end: DateTime.utc(2024, 1, 16)),
+        multiDayRule: const MultiDayRule.always(),
+      );
+      expect(event.copyWith().multiDayRule, const MultiDayRule.always());
+      expect(
+        event.copyWith(multiDayRule: const MultiDayRule.calendarDays()).multiDayRule,
+        const MultiDayRule.calendarDays(),
+      );
+    });
+
+    test('the rule participates in layoutEquals, since it decides the lane', () {
+      final range = DateTimeRange(start: DateTime.utc(2024, 1, 15, 23), end: DateTime.utc(2024, 1, 16, 1));
+      final a = CalendarEvent(id: 'same', dateTimeRange: range);
+      final b = CalendarEvent(id: 'same', dateTimeRange: range, multiDayRule: const MultiDayRule.calendarDays());
+      expect(a.layoutEquals(b), isFalse);
+      expect(a, isNot(equals(b)));
+    });
+  });
+
+  group('MultiDayRule equality', () {
+    test('the same rule compares equal', () {
+      expect(const MultiDayRule.calendarDays(), const MultiDayRule.calendarDays());
+      expect(const MultiDayRule.always(), const MultiDayRule.always());
+      expect(
+        const MultiDayRule.minimumDuration(Duration(hours: 24)),
+        const MultiDayRule.minimumDuration(Duration(hours: 24)),
+      );
+    });
+
+    test('different rules do not', () {
+      expect(const MultiDayRule.calendarDays(), isNot(const MultiDayRule.always()));
+      expect(
+        const MultiDayRule.minimumDuration(Duration(hours: 24)),
+        isNot(const MultiDayRule.minimumDuration(Duration(hours: 12))),
+      );
+    });
+  });
+}
+
+/// Fixes the rule for a whole app in one place, the way a real subclass would.
+class _CalendarDayEvent extends CalendarEvent {
+  _CalendarDayEvent({required super.dateTimeRange}) : super(multiDayRule: const MultiDayRule.calendarDays());
+}
+
+/// Replaces the rule entirely with a strict "more than one calendar day".
+class _StrictMultiDayEvent extends CalendarEvent {
+  _StrictMultiDayEvent({required super.dateTimeRange});
+
+  @override
+  bool spansMultipleDays({required Location? location}) => datesSpanned(location: location).length > 1;
 }

--- a/test/models/calendar_interaction_test.dart
+++ b/test/models/calendar_interaction_test.dart
@@ -85,7 +85,6 @@ void main() {
         allowResizing: true,
         allowRescheduling: true,
         allowEventCreation: true,
-        throttleMilliseconds: 16,
         inputMode: InputMode.precise,
         allowHorizontalImpreciseResize: false,
         createEventGesture: CreateEventGesture.tap,
@@ -94,13 +93,11 @@ void main() {
 
       final copy = original.copyWith(
         allowResizing: false,
-        throttleMilliseconds: 32,
         inputMode: InputMode.imprecise,
         modifyEventGesture: CreateEventGesture.longPress,
       );
 
       expect(copy.allowResizing, isFalse);
-      expect(copy.throttleMilliseconds, equals(32));
       expect(copy.inputMode, equals(InputMode.imprecise));
       expect(copy.modifyEventGesture, equals(CreateEventGesture.longPress));
       // Untouched fields are preserved.
@@ -113,13 +110,11 @@ void main() {
     test('copyWith with no arguments preserves every field', () {
       final original = CalendarInteraction(
         allowResizing: false,
-        throttleMilliseconds: 99,
         inputMode: InputMode.imprecise,
         createEventGesture: CreateEventGesture.longPress,
       );
       final copy = original.copyWith();
       expect(copy.allowResizing, equals(original.allowResizing));
-      expect(copy.throttleMilliseconds, equals(original.throttleMilliseconds));
       expect(copy.inputMode, equals(original.inputMode));
       expect(copy.createEventGesture, equals(original.createEventGesture));
     });
@@ -132,7 +127,6 @@ void main() {
           allowResizing: true,
           allowRescheduling: true,
           allowEventCreation: true,
-          throttleMilliseconds: 16,
           inputMode: InputMode.precise,
           allowHorizontalImpreciseResize: false,
           createEventGesture: CreateEventGesture.tap,
@@ -148,7 +142,6 @@ void main() {
       'allowResizing': (i) => i.copyWith(allowResizing: false),
       'allowRescheduling': (i) => i.copyWith(allowRescheduling: false),
       'allowEventCreation': (i) => i.copyWith(allowEventCreation: false),
-      'throttleMilliseconds': (i) => i.copyWith(throttleMilliseconds: 999),
       'inputMode': (i) => i.copyWith(inputMode: InputMode.imprecise),
       'allowHorizontalImpreciseResize': (i) => i.copyWith(allowHorizontalImpreciseResize: true),
       'createEventGesture': (i) => i.copyWith(createEventGesture: CreateEventGesture.longPress),

--- a/test/widgets/drag_move_coalescing_test.dart
+++ b/test/widgets/drag_move_coalescing_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/day_tile.dart' show DayEventTile;
+
+import '../utilities.dart';
+
+/// Pointer moves arrive faster than the display refreshes, so [DragTargetUtilities.onMove]
+/// keeps only the newest and processes it once per frame.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+  late String eventId;
+
+  final start = DateTime(2025, 3, 24);
+  final viewConfiguration = MultiDayViewConfiguration.singleDay(
+    initialTimeOfDay: const TimeOfDay(hour: 5, minute: 0),
+    initialHeightPerMinute: 1,
+    displayRange: DateTimeRange(start: start, end: DateTime(2025, 3, 31)),
+    initialDateTime: start,
+  );
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+    eventId = eventsController.addEvent(
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(start: start.copyWith(hour: 6), end: start.copyWith(hour: 8)),
+      ),
+    );
+  });
+
+  Future<void> pumpCalendar(WidgetTester tester) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: viewConfiguration,
+        callbacks: CalendarCallbacks(
+          onEventChanged: (event, updatedEvent) => eventsController.updateEvent(
+            event: event,
+            updatedEvent: updatedEvent,
+          ),
+        ),
+        body: CalendarBody(
+          interaction: CalendarInteraction(
+            inputMode: InputMode.precise,
+            createEventGesture: CreateEventGesture.tap,
+            modifyEventGesture: CreateEventGesture.tap,
+          ),
+          multiDayTileComponents: TileComponents(
+            tileBuilder: (event, tileRange) => Container(key: ValueKey(event.id), color: Colors.red),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Starts a reschedule drag and returns the gesture, past the point where the
+  /// draggable has been picked up.
+  Future<TestGesture> beginDrag(WidgetTester tester) async {
+    final tile = find.byKey(DayEventTile.tileKey(eventId));
+    expect(tile, findsOneWidget);
+
+    final gesture = await tester.startGesture(tester.getCenter(tile));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0, 40));
+    await tester.pumpAndSettle();
+    return gesture;
+  }
+
+  testWidgets('moves within one frame coalesce into a single update', (tester) async {
+    await pumpCalendar(tester);
+    final gesture = await beginDrag(tester);
+
+    var updates = 0;
+    calendarController.selectedEvent.addListener(() => updates++);
+
+    // Three moves with no frame between them.
+    await gesture.moveBy(const Offset(0, 20));
+    await gesture.moveBy(const Offset(0, 20));
+    await gesture.moveBy(const Offset(0, 20));
+    expect(updates, 0, reason: 'nothing is processed until the frame ends');
+
+    await tester.pump();
+    expect(updates, 1, reason: 'the three moves collapse into one update');
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('the update uses the newest move, not the first', (tester) async {
+    await pumpCalendar(tester);
+    final gesture = await beginDrag(tester);
+
+    final afterFirstMove = calendarController.selectedEvent.value!.start;
+
+    await gesture.moveBy(const Offset(0, 30));
+    await gesture.moveBy(const Offset(0, 30));
+    await tester.pump();
+
+    final coalesced = calendarController.selectedEvent.value!.start;
+    final movedBy = coalesced.difference(afterFirstMove);
+
+    // 60 logical pixels at 1 minute per pixel. Had the first move won, this
+    // would be half as much.
+    expect(movedBy.inMinutes, greaterThan(45), reason: 'the last move should win, not the first');
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('a move queued at the moment of the drop does not survive it', (tester) async {
+    await pumpCalendar(tester);
+    final gesture = await beginDrag(tester);
+
+    // Queue a move and drop before the frame that would process it.
+    await gesture.moveBy(const Offset(0, 20));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(
+      calendarController.selectedEvent.value,
+      isNull,
+      reason: 'a pending move must not reselect the event after the drop deselected it',
+    );
+    expect(find.byKey(DayEventTile.tileKey(eventId)), findsOneWidget, reason: 'the preview must not be left behind');
+  });
+}

--- a/test/widgets/multi_day_drag_over_body_test.dart
+++ b/test/widgets/multi_day_drag_over_body_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/multi_day_tile.dart' show MultiDayEventTile;
+
+import '../utilities.dart';
+
+/// A multi-day event is laid out in the header, but a drag can wander down over
+/// the body. The header's drop target should keep following the cursor's day.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+  late String eventId;
+
+  final start = DateTime(2025, 1, 6); // A Monday.
+
+  final interaction = CalendarInteraction(
+    inputMode: InputMode.precise,
+    createEventGesture: CreateEventGesture.tap,
+    modifyEventGesture: CreateEventGesture.tap,
+  );
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+    // A two-day event starting on the Tuesday.
+    eventId = eventsController.addEvent(
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(
+          start: start.add(const Duration(days: 1, hours: 9)),
+          end: start.add(const Duration(days: 3, hours: 9)),
+        ),
+      ),
+    );
+  });
+
+  Future<void> pumpWeek(WidgetTester tester, {CalendarCallbacks? callbacks}) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        callbacks: callbacks,
+        viewConfiguration: MultiDayViewConfiguration.week(
+          displayRange: year2025DisplayRange,
+          initialTimeOfDay: const TimeOfDay(hour: 0, minute: 0),
+          initialDateTime: start,
+        ),
+        header: CalendarHeader(interaction: interaction),
+        body: CalendarBody(interaction: interaction),
+      ),
+    );
+  }
+
+  testWidgets('dragging a multi-day tile down into the body still moves the header preview', (tester) async {
+    await pumpWeek(tester);
+
+    final tile = find.byKey(MultiDayEventTile.tileKey(eventId));
+    expect(tile, findsOneWidget, reason: 'the multi-day tile should render in the header');
+
+    final originalStart = eventsController.byId(eventId)!.start;
+    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+
+    // Pick the tile up, then move well below the header, into the body.
+    final gesture = await tester.startGesture(tester.getCenter(tile));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0, 200));
+    await tester.pumpAndSettle();
+
+    // Now move sideways by two day columns while still over the body.
+    await gesture.moveBy(Offset(dayWidth * 2, 0));
+    await tester.pumpAndSettle();
+
+    final preview = calendarController.selectedEvent.value;
+    expect(preview, isNotNull, reason: 'the body should keep previewing a multi-day drag');
+    expect(
+      preview!.start.day,
+      isNot(equals(originalStart.day)),
+      reason: 'the preview should follow the cursor across day columns while over the body',
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('the time of day and duration survive a drag across the body', (tester) async {
+    await pumpWeek(tester);
+
+    final original = eventsController.byId(eventId)!;
+    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byKey(MultiDayEventTile.tileKey(eventId))));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(Offset(dayWidth, 250));
+    await tester.pumpAndSettle();
+
+    final preview = calendarController.selectedEvent.value!;
+    expect(
+      preview.start.day,
+      isNot(equals(original.start.day)),
+      reason: 'the date must actually have moved, or the rest of this test proves nothing',
+    );
+    expect(preview.duration, equals(original.duration), reason: 'a vertical drag must not resize a multi-day event');
+    expect(
+      preview.start.difference(preview.start.copyWith(hour: 0, minute: 0)),
+      equals(original.start.difference(original.start.copyWith(hour: 0, minute: 0))),
+      reason: 'the time of day should be preserved, only the date changes',
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('dropping over the body commits the new date', (tester) async {
+    CalendarEvent? changed;
+    await pumpWeek(tester, callbacks: CalendarCallbacks(onEventChanged: (_, updated) => changed = updated));
+
+    final originalStart = eventsController.byId(eventId)!.start;
+    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byKey(MultiDayEventTile.tileKey(eventId))));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(Offset(dayWidth, 220));
+    await tester.pumpAndSettle();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(changed, isNotNull, reason: 'releasing over the body should commit, not snap back');
+    expect(changed!.start.day, isNot(equals(originalStart.day)));
+  });
+}


### PR DESCRIPTION
**Stacked on #368 → #367 → #366. Merge those first, in order.** Based on #368 because it touches the same two files.

Dragging a multi-day event downwards froze its drop target in the header until the cursor came back up. It now keeps following the cursor's day column, and releasing over the body commits.

### Why this was almost free

Two pieces were already in place:

- The header's drop target is a `ValueListenableBuilder` on `controller.selectedEvent` (`multi_day_events_widget.dart:302`), so it follows whatever writes to that notifier. It does not care which drag target did.
- Flutter calls `onMove` on **every** entered drag target, including ones whose `onWillAcceptWithDetails` returned false — `_DragAvatar.updateDrag` adds each target to `_enteredTargets` before `didEnter` decides, then reports moves to all of them. So the body's `onMove` was already firing for multi-day events.

One line stood in the way, in `vertical_drag_target.dart`:

```dart
if (event.isMultiDayEvent) return null;
```

Returning null made `_processMove` bail before `controller.updateEvent`, so nothing ever notified.

### The change

A multi-day event is laid out in the header, so dragging it across the body can only change which date it starts on. That is exactly what the header already computes, so it moves to `DragTargetUtilities.rescheduleToDate` and both targets call it, rather than growing two versions that can drift apart.

The static accept guard now takes multi-day reschedules as well, so releasing over the body commits the date the header has been previewing instead of snapping back. Its time-of-day range check stays skipped for these, since a multi-day event is not laid out against it.

### Behaviour worth knowing

- **Only the date changes.** Time of day and duration are preserved, so a vertical drag cannot resize a multi-day event.
- **The start snaps to the cursor's date.** Grab a Tue–Thu event anywhere and drop on Friday, and it becomes Fri–Sun. That is the header's existing behaviour, matched deliberately rather than changed here. Preserving the grab offset would be a separate change affecting both targets.
- **No preview in the body by default.** `day_events_widget.dart` clears its own preview for multi-day events unless `showMultiDayEvents` is set, so the preview appears in the header alone, which is the point. With `showMultiDayEvents: true` it appears in both.

### Checks

`flutter analyze` clean. **1,511 passing**, up from 1,508 on #368.

`test/widgets/multi_day_drag_over_body_test.dart` covers the preview following the cursor across day columns, time of day and duration surviving the drag, and the drop committing. All three fail without the change — verified by reverting it. The middle one originally passed either way, since a null return leaves the preview untouched, so it now asserts the date actually moved first.
