### PR TITLE
fix: give every event its own layout data even when two share a hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.24.0
 
+### Breaking Changes
+
+- `CalendarInteraction.throttleMilliseconds` is removed. Drag updates are now coalesced to one per frame, so they follow the display's refresh rate instead of a fixed 16ms window and are no longer capped at 60 per second on a faster screen. Nothing replaces it: delete the argument. [#368](https://github.com/werner-scholtz/kalender/pull/368)
+
 ### Features
 
 - `MultiDayRule` decides whether an event belongs in the multi-day header or the day timeline. Pass one to `CalendarEvent`, or fix it for a whole app from your subclass's `super` call. `MultiDayRule.minimumDuration` is the default at 24 hours and matches the previous behaviour, and `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day. [#367](https://github.com/werner-scholtz/kalender/pull/367)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking Changes
 
 - `CalendarInteraction.throttleMilliseconds` is removed. Drag updates are now coalesced to one per frame, so they follow the display's refresh rate instead of a fixed 16ms window and are no longer capped at 60 per second on a faster screen. Nothing replaces it: delete the argument. [#368](https://github.com/werner-scholtz/kalender/pull/368)
+- `DragTargetUtilities` requires a `mounted` getter. A class applying the mixin to a `State` already satisfies it, so most code needs no change. Anything else has to supply one, because the mixin now defers work to the end of the frame and must know whether its context is still usable. [#368](https://github.com/werner-scholtz/kalender/pull/368)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Features
 
+- Dragging a multi-day event down over the body keeps moving its drop target in the header, instead of freezing it until the cursor returns. Releasing over the body commits the date. Only the date changes, so the time of day and duration are untouched. [#369](https://github.com/werner-scholtz/kalender/pull/369)
 - `MultiDayRule` decides whether an event belongs in the multi-day header or the day timeline. Pass one to `CalendarEvent`, or fix it for a whole app from your subclass's `super` call. `MultiDayRule.minimumDuration` is the default at 24 hours and matches the previous behaviour, and `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day. [#367](https://github.com/werner-scholtz/kalender/pull/367)
 
 ### Deprecations

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,19 @@
 
 ## v0.23.x → v0.24.0
 
+### `throttleMilliseconds` is gone
+
+```dart
+  CalendarInteraction(
+    allowResizing: true,
+-   throttleMilliseconds: 16,
+  )
+```
+
+Delete the argument. Nothing replaces it.
+
+Drag updates are now coalesced to one per frame rather than throttled against the clock, so they follow whatever rate the display refreshes at. The old default of 16ms assumed a 60Hz screen and capped updates at about 62 per second, which is half what a 120Hz display can show. There is no longer a value to choose.
+
 ### `isMultiDayEvent` became `spansMultipleDays`
 
 ```dart

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,6 +15,25 @@ Delete the argument. Nothing replaces it.
 
 Drag updates are now coalesced to one per frame rather than throttled against the clock, so they follow whatever rate the display refreshes at. The old default of 16ms assumed a 60Hz screen and capped updates at about 62 per second, which is half what a 120Hz display can show. There is no longer a value to choose.
 
+### `DragTargetUtilities` requires `mounted`
+
+Only affects you if you apply the mixin yourself. A `State` already provides `mounted`, so this is nothing to do:
+
+```dart
+class _MyDragTargetState extends State<MyDragTarget> with DragTargetUtilities { }
+```
+
+Anywhere else, supply it:
+
+```dart
+  class MyDragHandler with DragTargetUtilities {
++   @override
++   bool get mounted => true;
+  }
+```
+
+The mixin defers move handling to the end of the frame, so it can outlive disposal and has to know whether its context is still usable. Reading `State.context` after disposal throws rather than returning null, which is why the check cannot live inside the mixin.
+
 ### `isMultiDayEvent` became `spansMultipleDays`
 
 ```dart

--- a/lib/src/layout_delegates/event_layout_delegate.dart
+++ b/lib/src/layout_delegates/event_layout_delegate.dart
@@ -194,32 +194,24 @@ abstract class EventLayoutDelegate extends MultiChildLayoutDelegate {
     final currentCache = <int, VerticalLayoutData>{};
     final cache = layoutCache.getCache(date, heightPerMinute, timeOfDayRange);
 
-    if (cache == null) {
-      // If there is no cache, calculate the layout data for each event.
-      for (var i = 0; i < numberOfChildren; i++) {
-        final id = i;
-        final event = events.elementAt(i);
-        final eventHash = event.hashCode;
-        currentCache[eventHash] = _calculateSingleEventLayout(id, size, event);
-      }
-    } else {
-      // If there is a cache, use it to calculate the layout data for each event.
-      for (var i = 0; i < numberOfChildren; i++) {
-        final id = i;
-        final event = events.elementAt(i);
-        final eventHash = event.hashCode;
+    // Collected per child rather than read back out of the cache. The cache is
+    // keyed by event hash, so two equal events share one entry, and using its
+    // values as the result would leave a child with no layout data at all.
+    final layoutData = <VerticalLayoutData>[];
 
-        final cached = cache[eventHash];
-        if (cached == null) {
-          currentCache[eventHash] = _calculateSingleEventLayout(id, size, event);
-        } else {
-          currentCache[eventHash] = cached.copyWith(id: id);
-        }
-      }
+    for (var i = 0; i < numberOfChildren; i++) {
+      final event = events.elementAt(i);
+      final eventHash = event.hashCode;
+
+      final cached = cache?[eventHash];
+      final data = cached == null ? _calculateSingleEventLayout(i, size, event) : cached.copyWith(id: i);
+
+      layoutData.add(data);
+      currentCache[eventHash] = data;
     }
 
     layoutCache.setCache(date, heightPerMinute, timeOfDayRange, currentCache);
-    return sortVerticalLayoutData(currentCache.values.toList());
+    return sortVerticalLayoutData(layoutData);
   }
 
   VerticalLayoutData _calculateSingleEventLayout(int id, Size size, CalendarEvent event) {

--- a/lib/src/models/calendar_interaction.dart
+++ b/lib/src/models/calendar_interaction.dart
@@ -105,13 +105,6 @@ class CalendarInteraction {
   static const defaultModifyEventGesture = CreateEventGesture.tap;
   static const defaultMobileModifyEventGesture = CreateEventGesture.longPress;
 
-  /// The number of milliseconds to throttle the interaction events.
-  ///
-  /// This is used to prevent excessive updates during drag operations.
-  /// This can be adjusted based on the performance needs of the application.
-  final int throttleMilliseconds;
-  static const defaultThrottleMilliseconds = 16;
-
   /// The input mode for the calendar.
   ///
   /// This determines how resize handles are positioned and when they become visible.
@@ -146,7 +139,6 @@ class CalendarInteraction {
     this.allowResizing = defaultAllowResizing,
     this.allowRescheduling = defaultAllowRescheduling,
     this.allowEventCreation = defaultAllowEventCreation,
-    this.throttleMilliseconds = defaultThrottleMilliseconds,
     this.inputMode = defaultInputMode,
     this.allowHorizontalImpreciseResize = defaultAllowHorizontalImpreciseResize,
     CreateEventGesture? createEventGesture,
@@ -162,7 +154,6 @@ class CalendarInteraction {
     bool? allowResizing,
     bool? allowRescheduling,
     bool? allowEventCreation,
-    int? throttleMilliseconds,
     InputMode? inputMode,
     bool? allowHorizontalImpreciseResize,
     CreateEventGesture? createEventGesture,
@@ -172,7 +163,6 @@ class CalendarInteraction {
       allowResizing: allowResizing ?? this.allowResizing,
       allowRescheduling: allowRescheduling ?? this.allowRescheduling,
       allowEventCreation: allowEventCreation ?? this.allowEventCreation,
-      throttleMilliseconds: throttleMilliseconds ?? this.throttleMilliseconds,
       inputMode: inputMode ?? this.inputMode,
       allowHorizontalImpreciseResize: allowHorizontalImpreciseResize ?? this.allowHorizontalImpreciseResize,
       createEventGesture: createEventGesture ?? this.createEventGesture,
@@ -188,7 +178,6 @@ class CalendarInteraction {
         other.allowResizing == allowResizing &&
         other.allowRescheduling == allowRescheduling &&
         other.allowEventCreation == allowEventCreation &&
-        other.throttleMilliseconds == throttleMilliseconds &&
         other.inputMode == inputMode &&
         other.allowHorizontalImpreciseResize == allowHorizontalImpreciseResize &&
         other.createEventGesture == createEventGesture &&
@@ -200,7 +189,6 @@ class CalendarInteraction {
         allowResizing,
         allowRescheduling,
         allowEventCreation,
-        throttleMilliseconds,
         inputMode,
         allowHorizontalImpreciseResize,
         createEventGesture,

--- a/lib/src/models/mixins/drag_target_utils.dart
+++ b/lib/src/models/mixins/drag_target_utils.dart
@@ -7,16 +7,24 @@ typedef UpdatedEvent = (CalendarEvent, CalendarEvent);
 
 mixin DragTargetUtilities {
   BuildContext get context;
+
+  /// Whether [context] is still usable.
+  ///
+  /// Satisfied by [State.mounted]. Checked before any deferred work, since
+  /// reading [State.context] after disposal throws rather than returning null.
+  bool get mounted;
   CalendarController get controller;
   EventsController get eventsController;
   CalendarCallbacks? get callbacks;
   double get dayWidth;
   List<DateTime> get visibleDates;
   bool get multiDayDragTarget;
-  int get throttleMilliseconds => context.interaction.throttleMilliseconds;
 
-  /// The last timestamp when the [onMove] was called.
-  int _lastMoveTimestamp = 0;
+  /// The most recent move, waiting to be processed at the end of the frame.
+  DragTargetDetails<Object?>? _pendingMove;
+
+  /// Whether a callback is already registered for the pending move.
+  bool _moveScheduled = false;
 
   /// A copy of the event being created.
   CalendarEvent? newEvent;
@@ -54,13 +62,27 @@ mixin DragTargetUtilities {
     );
   }
 
-  /// Handle the [DragTarget.onMove] with throttling.
+  /// Handle the [DragTarget.onMove], processing at most one move per frame.
+  ///
+  /// Pointer moves can arrive faster than the display refreshes, and each one
+  /// processed rebuilds the preview. Only the newest is worth drawing, so the
+  /// rest are discarded rather than throttled against the clock.
   void onMove(DragTargetDetails<Object?> details) {
-    // Throttle the move events to prevent excessive updates.
-    final currentTime = DateTime.now().millisecondsSinceEpoch;
-    if (currentTime - _lastMoveTimestamp < throttleMilliseconds) return;
-    _lastMoveTimestamp = currentTime;
-    _processMove(details);
+    _pendingMove = details;
+    if (_moveScheduled) return;
+    _moveScheduled = true;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _moveScheduled = false;
+      final pending = _pendingMove;
+      _pendingMove = null;
+      if (pending == null || !mounted) return;
+      _processMove(pending);
+    });
+
+    // addPostFrameCallback does not schedule a frame, and without one the
+    // pending move would sit unprocessed.
+    WidgetsBinding.instance.scheduleFrame();
   }
 
   /// Handle the [DragTarget.onMove].
@@ -140,6 +162,8 @@ mixin DragTargetUtilities {
       resolveEvent: _resolveEvent,
     );
 
+    _cancelPendingMove();
+
     if (result == null) return;
     final originalEvent = result.$1;
     final updatedEvent = result.$2;
@@ -151,9 +175,17 @@ mixin DragTargetUtilities {
 
   /// Handle the [DragTarget.onLeave]
   void onLeave(Object? details) {
+    _cancelPendingMove();
     controller.deselectEvent();
     newEvent = null;
   }
+
+  /// Drop any move still waiting to be processed.
+  ///
+  /// A move queued during the drag would otherwise be processed after the drop
+  /// has already deselected the event, reselecting it and leaving the preview
+  /// behind as a duplicate of the event it was previewing.
+  void _cancelPendingMove() => _pendingMove = null;
 
   /// Reschedule an event.
   CalendarEvent? rescheduleEvent(CalendarEvent event, InternalDateTime cursorDateTime);

--- a/lib/src/models/mixins/drag_target_utils.dart
+++ b/lib/src/models/mixins/drag_target_utils.dart
@@ -296,4 +296,23 @@ mixin DragTargetUtilities {
     if (start.isAfter(end)) (start, end) = (end, start);
     return DateTimeRange(start: start, end: end);
   }
+
+  /// Moves [event] to the date of [cursorDateTime], keeping its time of day and
+  /// duration.
+  ///
+  /// Used where only the date can meaningfully change: the header, and a
+  /// multi-day event dragged across the body.
+  CalendarEvent rescheduleToDate(CalendarEvent event, InternalDateTime cursorDateTime) {
+    final start = event.internalStart(location: context.location);
+    final newStart = cursorDateTime.copyWith(
+      hour: start.hour,
+      minute: start.minute,
+      second: start.second,
+      millisecond: start.millisecond,
+      microsecond: start.microsecond,
+    );
+
+    final range = InternalDateTimeRange(start: newStart, end: newStart.add(event.duration));
+    return event.copyWith(dateTimeRange: toLocationDateTimeRange(range));
+  }
 }

--- a/lib/src/widgets/drag_targets/horizontal_drag_target.dart
+++ b/lib/src/widgets/drag_targets/horizontal_drag_target.dart
@@ -193,20 +193,7 @@ class _HorizontalDragTargetState extends State<HorizontalDragTarget> with DragTa
       return null;
     }
 
-    // Calculate the new dateTimeRange for the event.
-    final start = event.internalStart(location: context.location);
-    final newStartTime = cursorDateTime.copyWith(
-      hour: start.hour,
-      minute: start.minute,
-      second: start.second,
-      millisecond: start.millisecond,
-      microsecond: start.microsecond,
-    );
-    final duration = event.duration;
-    final endTime = newStartTime.add(duration);
-    final newRange = InternalDateTimeRange(start: newStartTime, end: endTime);
-
-    return event.copyWith(dateTimeRange: toLocationDateTimeRange(newRange));
+    return rescheduleToDate(event, cursorDateTime);
   }
 
   @override

--- a/lib/src/widgets/drag_targets/vertical_drag_target.dart
+++ b/lib/src/widgets/drag_targets/vertical_drag_target.dart
@@ -54,9 +54,10 @@ class VerticalDragTarget extends StatefulWidget {
       onCreate: (controllerId) => controllerId == controller.id,
       onResize: (event, direction) => direction.vertical,
       onReschedule: (event) {
-        // Multi-day events belong in the header, not the body.
-        // They should be rescheduled via HorizontalDragTarget, not VerticalDragTarget.
-        if (event.spansMultipleDays(location: controller.viewController?.location)) return false;
+        // A multi-day event stays in the header, so the time of day range does
+        // not constrain it. Accepted so that dropping here commits the date the
+        // header has been previewing.
+        if (event.spansMultipleDays(location: controller.viewController?.location)) return true;
 
         // Check if the event will fit within the time of day range.
         if (!timeOfDayRange.isAllDay && event.duration > timeOfDayRange.duration) return false;
@@ -288,9 +289,12 @@ class _VerticalDragTargetState extends State<VerticalDragTarget> with SnapPoints
   /// Update the [CalendarEvent] based on the [Offset] delta.
   @override
   CalendarEvent? rescheduleEvent(CalendarEvent event, InternalDateTime cursorDateTime) {
-    // Multi-day events belong in the header, not the body.
-    // Return null to prevent updating the selection while dragging over this area.
-    if (event.spansMultipleDays(location: context.location)) return null;
+    // A multi-day event is laid out in the header, so dragging it across the
+    // body can only change which date it starts on. Updating it here is what
+    // moves the header's drop target as the cursor crosses day columns.
+    if (event.spansMultipleDays(location: context.location)) {
+      return rescheduleToDate(event, cursorDateTime);
+    }
 
     InternalDateTime start;
 

--- a/test/interactions/drag_target_utils_test.dart
+++ b/test/interactions/drag_target_utils_test.dart
@@ -14,6 +14,9 @@ class _DragUtilsHarness with DragTargetUtilities {
   BuildContext get context => throw UnimplementedError();
 
   @override
+  bool get mounted => true;
+
+  @override
   final CalendarController controller;
 
   @override

--- a/test/layout/layout_data_per_child_test.dart
+++ b/test/layout/layout_data_per_child_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/layout_delegates/event_layout_delegate.dart';
+
+/// The delegate caches layout data in a map keyed by event hash, and
+/// `CustomMultiChildLayout` asserts when a child is not laid out. So the
+/// returned list has to hold one entry per event even when two events share a
+/// key, otherwise a child is silently dropped and layout throws.
+void main() {
+  final date = InternalDateTime(2024, 1, 1);
+
+  CalendarEvent event({String? id, int hour = 9}) {
+    return CalendarEvent(
+      id: id,
+      dateTimeRange: DateTimeRange(
+        start: DateTime.utc(2024, 1, 1, hour),
+        end: DateTime.utc(2024, 1, 1, hour + 1),
+      ),
+    );
+  }
+
+  OverlapLayoutDelegate delegateFor(List<CalendarEvent> events, {EventLayoutDelegateCache? cache}) {
+    return OverlapLayoutDelegate(
+      events: events,
+      heightPerMinute: 1,
+      date: date,
+      location: null,
+      timeOfDayRange: TimeOfDayRange.allDay(),
+      minimumTileHeight: null,
+      layoutCache: cache ?? EventLayoutDelegateCache(),
+    );
+  }
+
+  const size = Size(300, 24 * 60);
+
+  test('every event gets layout data, including distinct ones', () {
+    final delegate = delegateFor([event(hour: 9), event(hour: 11), event(hour: 13)]);
+    expect(delegate.calculateVerticalLayoutData(size), hasLength(3));
+  });
+
+  test('two events sharing a hash still get one entry each', () {
+    // Same id, same range, so identical hashCodes and a single cache entry.
+    final duplicate = event(id: 'same');
+    final delegate = delegateFor([duplicate, event(id: 'same')]);
+
+    final data = delegate.calculateVerticalLayoutData(size);
+    expect(data, hasLength(2), reason: 'a shared cache entry must not drop a child');
+    expect(data.map((d) => d.id).toSet(), {0, 1}, reason: 'each child needs its own id to be laid out');
+  });
+
+  test('a subclass whose hashCode ignores the id does not lose children', () {
+    // Legal Dart, and normally only makes hash lookups slower. Here it used to
+    // collapse every event into one entry.
+    final delegate = delegateFor([
+      _ConstantHashEvent(hour: 9),
+      _ConstantHashEvent(hour: 11),
+      _ConstantHashEvent(hour: 13),
+    ]);
+
+    final data = delegate.calculateVerticalLayoutData(size);
+    expect(data, hasLength(3));
+    expect(data.map((d) => d.id).toSet(), {0, 1, 2});
+  });
+
+  test('reusing a warm cache still returns one entry per child', () {
+    final cache = EventLayoutDelegateCache();
+    final events = [event(hour: 9), event(hour: 11)];
+
+    delegateFor(events, cache: cache).calculateVerticalLayoutData(size);
+    final second = delegateFor(events, cache: cache).calculateVerticalLayoutData(size);
+
+    expect(second, hasLength(2));
+    expect(second.map((d) => d.id).toSet(), {0, 1});
+  });
+}
+
+/// Hashes to a constant, so every instance collides.
+class _ConstantHashEvent extends CalendarEvent {
+  _ConstantHashEvent({required int hour})
+      : super(
+          dateTimeRange: DateTimeRange(
+            start: DateTime.utc(2024, 1, 1, hour),
+            end: DateTime.utc(2024, 1, 1, hour + 1),
+          ),
+        );
+
+  @override
+  int get hashCode => 0;
+
+  @override
+  bool operator ==(Object other) => identical(this, other);
+}

--- a/test/models/calendar_interaction_test.dart
+++ b/test/models/calendar_interaction_test.dart
@@ -85,7 +85,6 @@ void main() {
         allowResizing: true,
         allowRescheduling: true,
         allowEventCreation: true,
-        throttleMilliseconds: 16,
         inputMode: InputMode.precise,
         allowHorizontalImpreciseResize: false,
         createEventGesture: CreateEventGesture.tap,
@@ -94,13 +93,11 @@ void main() {
 
       final copy = original.copyWith(
         allowResizing: false,
-        throttleMilliseconds: 32,
         inputMode: InputMode.imprecise,
         modifyEventGesture: CreateEventGesture.longPress,
       );
 
       expect(copy.allowResizing, isFalse);
-      expect(copy.throttleMilliseconds, equals(32));
       expect(copy.inputMode, equals(InputMode.imprecise));
       expect(copy.modifyEventGesture, equals(CreateEventGesture.longPress));
       // Untouched fields are preserved.
@@ -113,13 +110,11 @@ void main() {
     test('copyWith with no arguments preserves every field', () {
       final original = CalendarInteraction(
         allowResizing: false,
-        throttleMilliseconds: 99,
         inputMode: InputMode.imprecise,
         createEventGesture: CreateEventGesture.longPress,
       );
       final copy = original.copyWith();
       expect(copy.allowResizing, equals(original.allowResizing));
-      expect(copy.throttleMilliseconds, equals(original.throttleMilliseconds));
       expect(copy.inputMode, equals(original.inputMode));
       expect(copy.createEventGesture, equals(original.createEventGesture));
     });
@@ -132,7 +127,6 @@ void main() {
           allowResizing: true,
           allowRescheduling: true,
           allowEventCreation: true,
-          throttleMilliseconds: 16,
           inputMode: InputMode.precise,
           allowHorizontalImpreciseResize: false,
           createEventGesture: CreateEventGesture.tap,
@@ -148,7 +142,6 @@ void main() {
       'allowResizing': (i) => i.copyWith(allowResizing: false),
       'allowRescheduling': (i) => i.copyWith(allowRescheduling: false),
       'allowEventCreation': (i) => i.copyWith(allowEventCreation: false),
-      'throttleMilliseconds': (i) => i.copyWith(throttleMilliseconds: 999),
       'inputMode': (i) => i.copyWith(inputMode: InputMode.imprecise),
       'allowHorizontalImpreciseResize': (i) => i.copyWith(allowHorizontalImpreciseResize: true),
       'createEventGesture': (i) => i.copyWith(createEventGesture: CreateEventGesture.longPress),

--- a/test/widgets/drag_move_coalescing_test.dart
+++ b/test/widgets/drag_move_coalescing_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/day_tile.dart' show DayEventTile;
+
+import '../utilities.dart';
+
+/// Pointer moves arrive faster than the display refreshes, so [DragTargetUtilities.onMove]
+/// keeps only the newest and processes it once per frame.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+  late String eventId;
+
+  final start = DateTime(2025, 3, 24);
+  final viewConfiguration = MultiDayViewConfiguration.singleDay(
+    initialTimeOfDay: const TimeOfDay(hour: 5, minute: 0),
+    initialHeightPerMinute: 1,
+    displayRange: DateTimeRange(start: start, end: DateTime(2025, 3, 31)),
+    initialDateTime: start,
+  );
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+    eventId = eventsController.addEvent(
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(start: start.copyWith(hour: 6), end: start.copyWith(hour: 8)),
+      ),
+    );
+  });
+
+  Future<void> pumpCalendar(WidgetTester tester) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: viewConfiguration,
+        callbacks: CalendarCallbacks(
+          onEventChanged: (event, updatedEvent) => eventsController.updateEvent(
+            event: event,
+            updatedEvent: updatedEvent,
+          ),
+        ),
+        body: CalendarBody(
+          interaction: CalendarInteraction(
+            inputMode: InputMode.precise,
+            createEventGesture: CreateEventGesture.tap,
+            modifyEventGesture: CreateEventGesture.tap,
+          ),
+          multiDayTileComponents: TileComponents(
+            tileBuilder: (event, tileRange) => Container(key: ValueKey(event.id), color: Colors.red),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Starts a reschedule drag and returns the gesture, past the point where the
+  /// draggable has been picked up.
+  Future<TestGesture> beginDrag(WidgetTester tester) async {
+    final tile = find.byKey(DayEventTile.tileKey(eventId));
+    expect(tile, findsOneWidget);
+
+    final gesture = await tester.startGesture(tester.getCenter(tile));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0, 40));
+    await tester.pumpAndSettle();
+    return gesture;
+  }
+
+  testWidgets('moves within one frame coalesce into a single update', (tester) async {
+    await pumpCalendar(tester);
+    final gesture = await beginDrag(tester);
+
+    var updates = 0;
+    calendarController.selectedEvent.addListener(() => updates++);
+
+    // Three moves with no frame between them.
+    await gesture.moveBy(const Offset(0, 20));
+    await gesture.moveBy(const Offset(0, 20));
+    await gesture.moveBy(const Offset(0, 20));
+    expect(updates, 0, reason: 'nothing is processed until the frame ends');
+
+    await tester.pump();
+    expect(updates, 1, reason: 'the three moves collapse into one update');
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('the update uses the newest move, not the first', (tester) async {
+    await pumpCalendar(tester);
+    final gesture = await beginDrag(tester);
+
+    final afterFirstMove = calendarController.selectedEvent.value!.start;
+
+    await gesture.moveBy(const Offset(0, 30));
+    await gesture.moveBy(const Offset(0, 30));
+    await tester.pump();
+
+    final coalesced = calendarController.selectedEvent.value!.start;
+    final movedBy = coalesced.difference(afterFirstMove);
+
+    // 60 logical pixels at 1 minute per pixel. Had the first move won, this
+    // would be half as much.
+    expect(movedBy.inMinutes, greaterThan(45), reason: 'the last move should win, not the first');
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('a move queued at the moment of the drop does not survive it', (tester) async {
+    await pumpCalendar(tester);
+    final gesture = await beginDrag(tester);
+
+    // Queue a move and drop before the frame that would process it.
+    await gesture.moveBy(const Offset(0, 20));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(
+      calendarController.selectedEvent.value,
+      isNull,
+      reason: 'a pending move must not reselect the event after the drop deselected it',
+    );
+    expect(find.byKey(DayEventTile.tileKey(eventId)), findsOneWidget, reason: 'the preview must not be left behind');
+  });
+}

--- a/test/widgets/multi_day_drag_over_body_test.dart
+++ b/test/widgets/multi_day_drag_over_body_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/multi_day_tile.dart' show MultiDayEventTile;
+
+import '../utilities.dart';
+
+/// A multi-day event is laid out in the header, but a drag can wander down over
+/// the body. The header's drop target should keep following the cursor's day.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+  late String eventId;
+
+  final start = DateTime(2025, 1, 6); // A Monday.
+
+  final interaction = CalendarInteraction(
+    inputMode: InputMode.precise,
+    createEventGesture: CreateEventGesture.tap,
+    modifyEventGesture: CreateEventGesture.tap,
+  );
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+    // A two-day event starting on the Tuesday.
+    eventId = eventsController.addEvent(
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(
+          start: start.add(const Duration(days: 1, hours: 9)),
+          end: start.add(const Duration(days: 3, hours: 9)),
+        ),
+      ),
+    );
+  });
+
+  Future<void> pumpWeek(WidgetTester tester, {CalendarCallbacks? callbacks}) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        callbacks: callbacks,
+        viewConfiguration: MultiDayViewConfiguration.week(
+          displayRange: year2025DisplayRange,
+          initialTimeOfDay: const TimeOfDay(hour: 0, minute: 0),
+          initialDateTime: start,
+        ),
+        header: CalendarHeader(interaction: interaction),
+        body: CalendarBody(interaction: interaction),
+      ),
+    );
+  }
+
+  testWidgets('dragging a multi-day tile down into the body still moves the header preview', (tester) async {
+    await pumpWeek(tester);
+
+    final tile = find.byKey(MultiDayEventTile.tileKey(eventId));
+    expect(tile, findsOneWidget, reason: 'the multi-day tile should render in the header');
+
+    final originalStart = eventsController.byId(eventId)!.start;
+    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+
+    // Pick the tile up, then move well below the header, into the body.
+    final gesture = await tester.startGesture(tester.getCenter(tile));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(0, 200));
+    await tester.pumpAndSettle();
+
+    // Now move sideways by two day columns while still over the body.
+    await gesture.moveBy(Offset(dayWidth * 2, 0));
+    await tester.pumpAndSettle();
+
+    final preview = calendarController.selectedEvent.value;
+    expect(preview, isNotNull, reason: 'the body should keep previewing a multi-day drag');
+    expect(
+      preview!.start.day,
+      isNot(equals(originalStart.day)),
+      reason: 'the preview should follow the cursor across day columns while over the body',
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('the time of day and duration survive a drag across the body', (tester) async {
+    await pumpWeek(tester);
+
+    final original = eventsController.byId(eventId)!;
+    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byKey(MultiDayEventTile.tileKey(eventId))));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(Offset(dayWidth, 250));
+    await tester.pumpAndSettle();
+
+    final preview = calendarController.selectedEvent.value!;
+    expect(
+      preview.start.day,
+      isNot(equals(original.start.day)),
+      reason: 'the date must actually have moved, or the rest of this test proves nothing',
+    );
+    expect(preview.duration, equals(original.duration), reason: 'a vertical drag must not resize a multi-day event');
+    expect(
+      preview.start.difference(preview.start.copyWith(hour: 0, minute: 0)),
+      equals(original.start.difference(original.start.copyWith(hour: 0, minute: 0))),
+      reason: 'the time of day should be preserved, only the date changes',
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('dropping over the body commits the new date', (tester) async {
+    CalendarEvent? changed;
+    await pumpWeek(tester, callbacks: CalendarCallbacks(onEventChanged: (_, updated) => changed = updated));
+
+    final originalStart = eventsController.byId(eventId)!.start;
+    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byKey(MultiDayEventTile.tileKey(eventId))));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(Offset(dayWidth, 220));
+    await tester.pumpAndSettle();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(changed, isNotNull, reason: 'releasing over the body should commit, not snap back');
+    expect(changed!.start.day, isNot(equals(originalStart.day)));
+  });
+}


### PR DESCRIPTION
**Stacked on #369 → #368 → #367 → #366. Merge those first, in order.**

Follow-up to the sharp edge noted in #368. **This is hardening, not a fix for something reachable today** — see below.

### The defect

`EventLayoutDelegate.calculateVerticalLayoutData` used one map for two jobs:

```dart
final currentCache = <int, VerticalLayoutData>{};
for (var i = 0; i < numberOfChildren; i++) {
  currentCache[event.hashCode] = ...;                          // job 1: the cache to store
}
layoutCache.setCache(..., currentCache);
return sortVerticalLayoutData(currentCache.values.toList());   // job 2: the result
```

A map keyed by `event.hashCode` can hold fewer entries than there are events. When two collide, the returned list is short, `CustomMultiChildLayout` has a child with no layout data, and Flutter asserts:

```
Each child must be laid out exactly once.
The OverlapLayoutDelegate custom multichild layout delegate forgot to lay out the following child
```

The message names the delegate, not whatever produced the duplicate. It took instrumenting the delegate to find during #368.

### The change

The result is collected per child instead of read back out of the cache. The cache still dedupes, which is harmless — two equal events legitimately share layout data. The two loop branches merge, since `cache?[hash]` being null already means "compute it".

### Why hardening and not a fix

I checked every write to `selectedEvent.value` before claiming this. Three of the four are safe. The desync needs `selectedEvent` set while `_selectedEventId` is null, which only `updateEvent` does, and the one route there was the pending-move bug fixed in #368 itself. I could not find a path a user hits today.

What remains are footguns worth closing:

- `CalendarController.updateEvent` is public and undocumented, and does not set `_selectedEventId`. Calling it while nothing is selected desyncs the two, and `day_events_widget.dart` then inserts the preview alongside the real event instead of replacing it.
- A subclass whose `hashCode` omits the id collapses every event sharing a key. `int get hashCode => 0;` is legal Dart that normally only costs lookup speed; here it crashes layout.

### Checks

`flutter analyze` clean. **1,515 passing**, up from 1,511 on #369.

`test/layout/layout_data_per_child_test.dart` covers duplicate events, a subclass hashing to a constant, and a warm cache. The first two fail without the change, verified by stashing it; the other two are regression guards that pass either way.
