### PR TITLE
chore: remove the string builders deprecated in 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Breaking Changes
 
+- The seven string builders deprecated in 0.23.0 are removed from the component style classes. Their replacements on the matching `*Components` classes are unchanged, and each takes a `BuildContext` so it can read the calendar's locale. See [MIGRATION.md](MIGRATION.md#v022x--v0230) for the mapping. [#372](https://github.com/werner-scholtz/kalender/pull/372)
+- `MonthDayHeaderStyle.textStyle` is removed. It never had any effect, since `MonthDayHeader` renders only a day number, styled by `numberTextStyle`. [#372](https://github.com/werner-scholtz/kalender/pull/372)
 - `EventsController.eventsFromDateTimeRange` takes a required `multiDayRule`, since it is what sorts events into the header and the body. Only affects code implementing `EventsController`; pass the view configuration's rule. [#371](https://github.com/werner-scholtz/kalender/pull/371)
 - `CalendarEvent.spansMultipleDays` takes a required `defaultRule` alongside `location`, supplied by the calendar from the view configuration. A subclass overriding it must widen its signature to match. [#371](https://github.com/werner-scholtz/kalender/pull/371)
 - `CalendarInteraction.throttleMilliseconds` is removed. Drag updates are now coalesced to one per frame, so they follow the display's refresh rate instead of a fixed 16ms window and are no longer capped at 60 per second on a faster screen. Nothing replaces it: delete the argument. [#368](https://github.com/werner-scholtz/kalender/pull/368)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,12 @@
 
 ## v0.23.x → v0.24.0
 
+### The deprecated string builders are gone
+
+The seven `String Function(...)` fields on the component style classes, deprecated in 0.23.0, are removed, along with `MonthDayHeaderStyle.textStyle`, which never had any effect.
+
+If you are coming from 0.22.x or earlier and still setting them, the replacement table is under [v0.22.x → v0.23.0](#string-builders-moved-off-the-style-classes) below. Nothing about the replacements changed in this release, so a project already on the `*Components` builders needs no action.
+
 ### `throttleMilliseconds` is gone
 
 ```dart

--- a/lib/src/widgets/components/day_header.dart
+++ b/lib/src/widgets/components/day_header.dart
@@ -30,28 +30,16 @@ class DayHeaderStyle {
   /// Use this function to customize the string used for the day number.
   ///
   /// By default, the [DateTime.day] is used to get the day number.
-  @Deprecated(
-    'Moved to MultiDayHeaderComponents.dayHeaderNumberStringBuilder, which also receives a BuildContext. '
-    'Will be removed in 0.24.0.',
-  )
-  final String Function(DateTime date)? numberStringBuilder;
 
   /// Use this function to customize the sting displayed under the day number.
   ///
   /// By default, the [DateTimeExtensions.dayNameShortLocalized] is used to get the short name of the day in the current locale.
-  @Deprecated(
-    'Moved to MultiDayHeaderComponents.dayHeaderStringBuilder, which also receives a BuildContext. '
-    'Will be removed in 0.24.0.',
-  )
-  final String Function(DateTime date)? stringBuilder;
 
   /// Creates a new [DayHeaderStyle].
   const DayHeaderStyle({
     this.textStyle,
     this.numberTextStyle,
     this.mainAxisAlignment,
-    this.numberStringBuilder,
-    this.stringBuilder,
   });
 
   /// Creates a copy of this style with the given fields replaced with the new values.
@@ -59,15 +47,11 @@ class DayHeaderStyle {
     TextStyle? textStyle,
     TextStyle? numberTextStyle,
     MainAxisAlignment? mainAxisAlignment,
-    String Function(DateTime date)? numberStringBuilder,
-    String Function(DateTime date)? stringBuilder,
   }) {
     return DayHeaderStyle(
       textStyle: textStyle ?? this.textStyle,
       numberTextStyle: numberTextStyle ?? this.numberTextStyle,
       mainAxisAlignment: mainAxisAlignment ?? this.mainAxisAlignment,
-      numberStringBuilder: numberStringBuilder ?? this.numberStringBuilder,
-      stringBuilder: stringBuilder ?? this.stringBuilder,
     );
   }
 
@@ -78,8 +62,6 @@ class DayHeaderStyle {
       textStyle: other.textStyle ?? textStyle,
       numberTextStyle: other.numberTextStyle ?? numberTextStyle,
       mainAxisAlignment: other.mainAxisAlignment ?? mainAxisAlignment,
-      numberStringBuilder: other.numberStringBuilder ?? numberStringBuilder,
-      stringBuilder: other.stringBuilder ?? stringBuilder,
     );
   }
 
@@ -90,8 +72,6 @@ class DayHeaderStyle {
       textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
       numberTextStyle: TextStyle.lerp(a?.numberTextStyle, b?.numberTextStyle, t),
       mainAxisAlignment: t < 0.5 ? a?.mainAxisAlignment : b?.mainAxisAlignment,
-      numberStringBuilder: t < 0.5 ? a?.numberStringBuilder : b?.numberStringBuilder,
-      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
     );
   }
 
@@ -102,13 +82,11 @@ class DayHeaderStyle {
     return other is DayHeaderStyle &&
         other.textStyle == textStyle &&
         other.numberTextStyle == numberTextStyle &&
-        other.mainAxisAlignment == mainAxisAlignment &&
-        other.numberStringBuilder == numberStringBuilder &&
-        other.stringBuilder == stringBuilder;
+        other.mainAxisAlignment == mainAxisAlignment;
   }
 
   @override
-  int get hashCode => Object.hash(textStyle, numberTextStyle, mainAxisAlignment, numberStringBuilder, stringBuilder);
+  int get hashCode => Object.hash(textStyle, numberTextStyle, mainAxisAlignment);
 }
 
 /// A widget that displays the name of the day and the day number of the week.
@@ -147,7 +125,6 @@ class DayHeader extends StatelessWidget {
 
     final numberText = Text(
       components.dayHeaderNumberStringBuilder?.call(context, displayDate) ??
-          style.numberStringBuilder?.call(date) ??
           date.day.toString(),
       style: style.numberTextStyle,
     );
@@ -160,7 +137,6 @@ class DayHeader extends StatelessWidget {
 
     final dayName = Text(
       components.dayHeaderStringBuilder?.call(context, displayDate) ??
-          style.stringBuilder?.call(localDate) ??
           localDate.dayNameShortLocalized(context.locale),
       style: style.textStyle,
     );

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -17,8 +17,6 @@ typedef MonthDayHeaderBuilder = Widget Function(
 class MonthDayHeaderStyle {
   /// Creates a new [MonthDayHeaderStyle].
   const MonthDayHeaderStyle({
-    this.textStyle,
-    this.stringBuilder,
     this.numberTextStyle,
     this.buttonSize,
     this.margin,
@@ -26,15 +24,8 @@ class MonthDayHeaderStyle {
 
   /// Has never had any effect. [MonthDayHeader] displays only a day number,
   /// which is styled by [numberTextStyle], and no day name.
-  @Deprecated('Has no effect, MonthDayHeader displays no day name. Will be removed in 0.24.0.')
-  final TextStyle? textStyle;
 
   /// Use this function to customize the sting displayed by the [MonthDayHeader].
-  @Deprecated(
-    'Moved to MonthBodyComponents.monthDayHeaderStringBuilder, which also receives a BuildContext. '
-    'Will be removed in 0.24.0.',
-  )
-  final String Function(DateTime date)? stringBuilder;
 
   /// The [TextStyle] used by the [MonthDayHeader] widget to display the day number of the week.
   final TextStyle? numberTextStyle;
@@ -49,15 +40,11 @@ class MonthDayHeaderStyle {
 
   /// Creates a copy of this style with the given fields replaced with the new values.
   MonthDayHeaderStyle copyWith({
-    TextStyle? textStyle,
-    String Function(DateTime date)? stringBuilder,
     TextStyle? numberTextStyle,
     Size? buttonSize,
     EdgeInsets? margin,
   }) {
     return MonthDayHeaderStyle(
-      textStyle: textStyle ?? this.textStyle,
-      stringBuilder: stringBuilder ?? this.stringBuilder,
       numberTextStyle: numberTextStyle ?? this.numberTextStyle,
       buttonSize: buttonSize ?? this.buttonSize,
       margin: margin ?? this.margin,
@@ -68,8 +55,6 @@ class MonthDayHeaderStyle {
   MonthDayHeaderStyle merge(MonthDayHeaderStyle? other) {
     if (other == null) return this;
     return MonthDayHeaderStyle(
-      textStyle: other.textStyle ?? textStyle,
-      stringBuilder: other.stringBuilder ?? stringBuilder,
       numberTextStyle: other.numberTextStyle ?? numberTextStyle,
       buttonSize: other.buttonSize ?? buttonSize,
       margin: other.margin ?? margin,
@@ -80,8 +65,6 @@ class MonthDayHeaderStyle {
   static MonthDayHeaderStyle? lerp(MonthDayHeaderStyle? a, MonthDayHeaderStyle? b, double t) {
     if (identical(a, b)) return a;
     return MonthDayHeaderStyle(
-      textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
-      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
       numberTextStyle: TextStyle.lerp(a?.numberTextStyle, b?.numberTextStyle, t),
       buttonSize: Size.lerp(a?.buttonSize, b?.buttonSize, t),
       margin: EdgeInsets.lerp(a?.margin, b?.margin, t),
@@ -93,15 +76,13 @@ class MonthDayHeaderStyle {
     if (identical(this, other)) return true;
 
     return other is MonthDayHeaderStyle &&
-        other.textStyle == textStyle &&
-        other.stringBuilder == stringBuilder &&
         other.numberTextStyle == numberTextStyle &&
         other.buttonSize == buttonSize &&
         other.margin == margin;
   }
 
   @override
-  int get hashCode => Object.hash(textStyle, stringBuilder, numberTextStyle, buttonSize, margin);
+  int get hashCode => Object.hash(numberTextStyle, buttonSize, margin);
 }
 
 /// A widget that displays the day number.
@@ -131,7 +112,7 @@ class MonthDayHeader extends StatelessWidget {
     final stringBuilder = context.components.monthComponents.bodyComponents.monthDayHeaderStringBuilder;
     final displayDate = localDate.forLocation(location: context.location);
     final numberText =
-        stringBuilder?.call(context, displayDate) ?? style.stringBuilder?.call(displayDate) ?? date.day.toString();
+        stringBuilder?.call(context, displayDate) ?? date.day.toString();
 
     return Padding(
       padding: style.margin ?? EdgeInsets.zero,

--- a/lib/src/widgets/components/multi_day_overlay_portal_button.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal_button.dart
@@ -25,27 +25,18 @@ class MultiDayPortalOverlayButtonStyle {
   /// The text overflow behavior.
   final TextOverflow? textOverflow;
 
-  /// A function that builds a string based on the number of hidden rows.
-  @Deprecated(
-    'Moved to OverlayBuilders.multiDayPortalOverlayButtonStringBuilder, which also receives a BuildContext. '
-    'Will be removed in 0.24.0.',
-  )
-  final String Function(int numberOfHiddenRows)? stringBuilder;
-
-  const MultiDayPortalOverlayButtonStyle({this.textStyle, this.textPadding, this.stringBuilder, this.textOverflow});
+  const MultiDayPortalOverlayButtonStyle({this.textStyle, this.textPadding, this.textOverflow});
 
   /// Creates a copy of this style with the given fields replaced with the new values.
   MultiDayPortalOverlayButtonStyle copyWith({
     TextStyle? textStyle,
     EdgeInsetsGeometry? textPadding,
     TextOverflow? textOverflow,
-    String Function(int numberOfHiddenRows)? stringBuilder,
   }) {
     return MultiDayPortalOverlayButtonStyle(
       textStyle: textStyle ?? this.textStyle,
       textPadding: textPadding ?? this.textPadding,
       textOverflow: textOverflow ?? this.textOverflow,
-      stringBuilder: stringBuilder ?? this.stringBuilder,
     );
   }
 
@@ -56,7 +47,6 @@ class MultiDayPortalOverlayButtonStyle {
       textStyle: other.textStyle ?? textStyle,
       textPadding: other.textPadding ?? textPadding,
       textOverflow: other.textOverflow ?? textOverflow,
-      stringBuilder: other.stringBuilder ?? stringBuilder,
     );
   }
 
@@ -71,7 +61,6 @@ class MultiDayPortalOverlayButtonStyle {
       textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
       textPadding: EdgeInsetsGeometry.lerp(a?.textPadding, b?.textPadding, t),
       textOverflow: t < 0.5 ? a?.textOverflow : b?.textOverflow,
-      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
     );
   }
 
@@ -82,12 +71,11 @@ class MultiDayPortalOverlayButtonStyle {
     return other is MultiDayPortalOverlayButtonStyle &&
         other.textStyle == textStyle &&
         other.textPadding == textPadding &&
-        other.textOverflow == textOverflow &&
-        other.stringBuilder == stringBuilder;
+        other.textOverflow == textOverflow;
   }
 
   @override
-  int get hashCode => Object.hash(textStyle, textPadding, textOverflow, stringBuilder);
+  int get hashCode => Object.hash(textStyle, textPadding, textOverflow);
 }
 
 class MultiDayPortalOverlayButton extends StatelessWidget {
@@ -133,7 +121,6 @@ class MultiDayPortalOverlayButton extends StatelessWidget {
         padding: style.textPadding ?? const EdgeInsets.symmetric(horizontal: 4.0),
         child: Text(
           stringBuilder?.call(context, numberOfHiddenRows) ??
-              style.stringBuilder?.call(numberOfHiddenRows) ??
               defaultLabel(context, numberOfHiddenRows),
           style: style.textStyle,
           overflow: style.textOverflow,

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -20,7 +20,6 @@ class ScheduleDateStyle {
   /// Creates a new [ScheduleDateStyle].
   const ScheduleDateStyle({
     this.textStyle,
-    this.stringBuilder,
     this.numberTextStyle,
   });
 
@@ -28,11 +27,6 @@ class ScheduleDateStyle {
   final TextStyle? textStyle;
 
   /// Use this function to customize the sting displayed by the [ScheduleDate].
-  @Deprecated(
-    'Moved to ScheduleComponents.leadingDateStringBuilder, which also receives a BuildContext. '
-    'Will be removed in 0.24.0.',
-  )
-  final String Function(DateTime date)? stringBuilder;
 
   /// The [TextStyle] used by the [ScheduleDate] widget to display the day number of the week.
   final TextStyle? numberTextStyle;
@@ -40,12 +34,10 @@ class ScheduleDateStyle {
   /// Creates a copy of this style with the given fields replaced with the new values.
   ScheduleDateStyle copyWith({
     TextStyle? textStyle,
-    String Function(DateTime date)? stringBuilder,
     TextStyle? numberTextStyle,
   }) {
     return ScheduleDateStyle(
       textStyle: textStyle ?? this.textStyle,
-      stringBuilder: stringBuilder ?? this.stringBuilder,
       numberTextStyle: numberTextStyle ?? this.numberTextStyle,
     );
   }
@@ -55,7 +47,6 @@ class ScheduleDateStyle {
     if (other == null) return this;
     return ScheduleDateStyle(
       textStyle: other.textStyle ?? textStyle,
-      stringBuilder: other.stringBuilder ?? stringBuilder,
       numberTextStyle: other.numberTextStyle ?? numberTextStyle,
     );
   }
@@ -65,7 +56,6 @@ class ScheduleDateStyle {
     if (identical(a, b)) return a;
     return ScheduleDateStyle(
       textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
-      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
       numberTextStyle: TextStyle.lerp(a?.numberTextStyle, b?.numberTextStyle, t),
     );
   }
@@ -76,12 +66,11 @@ class ScheduleDateStyle {
 
     return other is ScheduleDateStyle &&
         other.textStyle == textStyle &&
-        other.stringBuilder == stringBuilder &&
         other.numberTextStyle == numberTextStyle;
   }
 
   @override
-  int get hashCode => Object.hash(textStyle, stringBuilder, numberTextStyle);
+  int get hashCode => Object.hash(textStyle, numberTextStyle);
 }
 
 /// A widget that displays the name of the day and the day number of the week.
@@ -108,7 +97,6 @@ class ScheduleDate extends StatelessWidget {
     final displayDate = date.forLocation(location: context.location);
     final text = Text(
       stringBuilder?.call(context, displayDate) ??
-          style.stringBuilder?.call(date) ??
           date.dayNameShortLocalized(context.locale),
       style: style.textStyle,
     );

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -59,14 +59,14 @@ double defaultTimelineWidth(BuildContext context, TimeOfDayRange timeOfDayRange,
   // segment is 5 minutes).
   const defaultMinutes = [59];
   const customMinutes = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
-  final hasCustomLabels = stringBuilder != null || style.stringBuilder != null;
+  final hasCustomLabels = stringBuilder != null;
   final minutes = hasCustomLabels ? customMinutes : defaultMinutes;
 
   var widest = 0.0;
   for (var hour = 0; hour < TimeOfDay.hoursPerDay; hour++) {
     for (final minute in minutes) {
       final time = TimeOfDay(hour: hour, minute: minute);
-      final text = stringBuilder?.call(context, time) ?? style.stringBuilder?.call(time) ?? time.format(context);
+      final text = stringBuilder?.call(context, time) ?? time.format(context);
       painter.text = TextSpan(text: text, style: textStyle);
       painter.layout();
       if (painter.width > widest) widest = painter.width;
@@ -101,11 +101,6 @@ class TimelineStyle {
   final double? width;
 
   /// The function that will be used to build the string.
-  @Deprecated(
-    'Moved to MultiDayBodyComponents.timelineStringBuilder, which also receives a BuildContext. '
-    'Will be removed in 0.24.0.',
-  )
-  final String Function(TimeOfDay timeOfDay)? stringBuilder;
 
   /// The decoration for the event start time.
   final Decoration? startDecoration;
@@ -118,7 +113,6 @@ class TimelineStyle {
     this.textDirection,
     this.textAlign,
     this.textOverflow,
-    this.stringBuilder,
     this.textPadding,
     this.width,
     this.startDecoration,
@@ -131,7 +125,6 @@ class TimelineStyle {
     TextDirection? textDirection,
     TextAlign? textAlign,
     TextOverflow? textOverflow,
-    String Function(TimeOfDay timeOfDay)? stringBuilder,
     EdgeInsets? textPadding,
     double? width,
     Decoration? startDecoration,
@@ -142,7 +135,6 @@ class TimelineStyle {
       textDirection: textDirection ?? this.textDirection,
       textAlign: textAlign ?? this.textAlign,
       textOverflow: textOverflow ?? this.textOverflow,
-      stringBuilder: stringBuilder ?? this.stringBuilder,
       textPadding: textPadding ?? this.textPadding,
       width: width ?? this.width,
       startDecoration: startDecoration ?? this.startDecoration,
@@ -158,7 +150,6 @@ class TimelineStyle {
       textDirection: other.textDirection ?? textDirection,
       textAlign: other.textAlign ?? textAlign,
       textOverflow: other.textOverflow ?? textOverflow,
-      stringBuilder: other.stringBuilder ?? stringBuilder,
       textPadding: other.textPadding ?? textPadding,
       width: other.width ?? width,
       startDecoration: other.startDecoration ?? startDecoration,
@@ -174,7 +165,6 @@ class TimelineStyle {
       textDirection: t < 0.5 ? a?.textDirection : b?.textDirection,
       textAlign: t < 0.5 ? a?.textAlign : b?.textAlign,
       textOverflow: t < 0.5 ? a?.textOverflow : b?.textOverflow,
-      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
       textPadding: EdgeInsets.lerp(a?.textPadding, b?.textPadding, t),
       width: lerpDouble(a?.width, b?.width, t),
       startDecoration: Decoration.lerp(a?.startDecoration, b?.startDecoration, t),
@@ -191,7 +181,6 @@ class TimelineStyle {
         other.textDirection == textDirection &&
         other.textAlign == textAlign &&
         other.textOverflow == textOverflow &&
-        other.stringBuilder == stringBuilder &&
         other.textPadding == textPadding &&
         other.width == width &&
         other.startDecoration == startDecoration &&
@@ -204,7 +193,6 @@ class TimelineStyle {
         textDirection,
         textAlign,
         textOverflow,
-        stringBuilder,
         textPadding,
         width,
         startDecoration,
@@ -224,9 +212,7 @@ mixin TimeLineUtils {
   /// The label shown for [time].
   String timelineString(BuildContext context, TimeOfDay time) {
     final stringBuilder = context.components.multiDayComponents.bodyComponents.timelineStringBuilder;
-    return stringBuilder?.call(context, time) ??
-        effectiveStyle(context).stringBuilder?.call(time) ??
-        time.format(context);
+    return stringBuilder?.call(context, time) ?? time.format(context);
   }
 
   /// The [TextStyle] that will be used for the text.

--- a/lib/src/widgets/components/week_day_header.dart
+++ b/lib/src/widgets/components/week_day_header.dart
@@ -17,18 +17,12 @@ class WeekDayHeaderStyle {
   const WeekDayHeaderStyle({
     this.textStyle,
     this.padding,
-    this.stringBuilder,
   });
 
   /// The [TextStyle] used by the [DateText] widget to display the day of the week.
   final TextStyle? textStyle;
 
   /// Use this function to customize the sting displayed by the [WeekDayHeader].
-  @Deprecated(
-    'Moved to MonthHeaderComponents.weekDayHeaderStringBuilder, which also receives a BuildContext. '
-    'Will be removed in 0.24.0.',
-  )
-  final String Function(DateTime date)? stringBuilder;
 
   /// The padding around the [WeekDayHeader] widget.
   final EdgeInsets? padding;
@@ -36,12 +30,10 @@ class WeekDayHeaderStyle {
   /// Creates a copy of this style with the given fields replaced with the new values.
   WeekDayHeaderStyle copyWith({
     TextStyle? textStyle,
-    String Function(DateTime date)? stringBuilder,
     EdgeInsets? padding,
   }) {
     return WeekDayHeaderStyle(
       textStyle: textStyle ?? this.textStyle,
-      stringBuilder: stringBuilder ?? this.stringBuilder,
       padding: padding ?? this.padding,
     );
   }
@@ -51,7 +43,6 @@ class WeekDayHeaderStyle {
     if (other == null) return this;
     return WeekDayHeaderStyle(
       textStyle: other.textStyle ?? textStyle,
-      stringBuilder: other.stringBuilder ?? stringBuilder,
       padding: other.padding ?? padding,
     );
   }
@@ -61,7 +52,6 @@ class WeekDayHeaderStyle {
     if (identical(a, b)) return a;
     return WeekDayHeaderStyle(
       textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
-      stringBuilder: t < 0.5 ? a?.stringBuilder : b?.stringBuilder,
       padding: EdgeInsets.lerp(a?.padding, b?.padding, t),
     );
   }
@@ -72,12 +62,11 @@ class WeekDayHeaderStyle {
 
     return other is WeekDayHeaderStyle &&
         other.textStyle == textStyle &&
-        other.stringBuilder == stringBuilder &&
         other.padding == padding;
   }
 
   @override
-  int get hashCode => Object.hash(textStyle, stringBuilder, padding);
+  int get hashCode => Object.hash(textStyle, padding);
 }
 
 /// A widget that displays the name of the day of the week.
@@ -99,7 +88,7 @@ class WeekDayHeader extends StatelessWidget {
     final padding = style.padding ?? const EdgeInsets.symmetric(vertical: 2);
     final stringBuilder = context.components.monthComponents.headerComponents.weekDayHeaderStringBuilder;
     final dateText =
-        stringBuilder?.call(context, date) ?? style.stringBuilder?.call(date) ?? date.dayNameLocalized(context.locale);
+        stringBuilder?.call(context, date) ?? date.dayNameLocalized(context.locale);
     return Padding(padding: padding, child: Center(child: Text(dateText, style: style.textStyle)));
   }
 }

--- a/test/models/component_styles_test.dart
+++ b/test/models/component_styles_test.dart
@@ -227,35 +227,32 @@ void main() {
   });
 
   group('MonthDayHeaderStyle', () {
-    const a = MonthDayHeaderStyle(textStyle: TextStyle(fontSize: 10), buttonSize: Size(20, 20));
-    const b = MonthDayHeaderStyle(textStyle: TextStyle(fontSize: 20), buttonSize: Size(40, 40));
+    const a = MonthDayHeaderStyle(numberTextStyle: TextStyle(fontSize: 10), buttonSize: Size(20, 20));
+    const b = MonthDayHeaderStyle(numberTextStyle: TextStyle(fontSize: 20), buttonSize: Size(40, 40));
 
     test('copyWith', () {
-      final copy = a.copyWith(numberTextStyle: const TextStyle(fontSize: 8), margin: const EdgeInsets.all(2));
-      expect(copy.numberTextStyle, const TextStyle(fontSize: 8));
+      final copy = a.copyWith(margin: const EdgeInsets.all(2));
       expect(copy.margin, const EdgeInsets.all(2));
-      expect(copy.textStyle, a.textStyle);
+      expect(copy.numberTextStyle, a.numberTextStyle);
       expect(copy.buttonSize, a.buttonSize);
     });
 
     test('merge', () {
-      final merged =
-          a.merge(const MonthDayHeaderStyle(numberTextStyle: TextStyle(fontSize: 9), buttonSize: Size(30, 30)));
-      expect(merged.numberTextStyle, const TextStyle(fontSize: 9));
+      final merged = a.merge(const MonthDayHeaderStyle(buttonSize: Size(30, 30)));
       expect(merged.buttonSize, const Size(30, 30));
-      expect(merged.textStyle, a.textStyle);
+      expect(merged.numberTextStyle, a.numberTextStyle);
       expect(a.merge(null), a);
     });
 
     test('lerp', () {
       final mid = MonthDayHeaderStyle.lerp(a, b, 0.5)!;
-      expect(mid.textStyle?.fontSize, 15);
+      expect(mid.numberTextStyle?.fontSize, 15);
       expect(mid.buttonSize, const Size(30, 30));
       expect(MonthDayHeaderStyle.lerp(null, null, 0.5), null);
     });
 
     test('equality', () {
-      expect(a, const MonthDayHeaderStyle(textStyle: TextStyle(fontSize: 10), buttonSize: Size(20, 20)));
+      expect(a, const MonthDayHeaderStyle(numberTextStyle: TextStyle(fontSize: 10), buttonSize: Size(20, 20)));
       expect(a == b, false);
     });
   });
@@ -476,12 +473,5 @@ void main() {
       );
       expect(a == b, false);
     });
-  });
-
-  test('stringBuilder fields keep function identity through copyWith and merge', () {
-    String builder(DateTime date) => 'x';
-    final style = const DayHeaderStyle().copyWith(stringBuilder: builder);
-    expect(style.stringBuilder, builder);
-    expect(const DayHeaderStyle().merge(style).stringBuilder, builder);
   });
 }

--- a/test/widgets/string_builders_test.dart
+++ b/test/widgets/string_builders_test.dart
@@ -78,44 +78,6 @@ void main() {
       expect(find.text('number'), findsWidgets);
     });
 
-    testWidgets('the deprecated style builders still apply when no components ones are set', (tester) async {
-      await pumpWeek(
-        tester,
-        CalendarComponents(
-          multiDayComponentStyles: MultiDayComponentStyles(
-            headerStyles: MultiDayHeaderComponentStyles(
-              dayHeaderStyle: DayHeaderStyle(
-                stringBuilder: (date) => 'old name',
-                numberStringBuilder: (date) => 'old number',
-              ),
-            ),
-          ),
-        ),
-      );
-
-      expect(find.text('old name'), findsWidgets);
-      expect(find.text('old number'), findsWidgets);
-    });
-
-    testWidgets('the components builder wins over the deprecated style one', (tester) async {
-      await pumpWeek(
-        tester,
-        CalendarComponents(
-          multiDayComponents: MultiDayComponents(
-            headerComponents: MultiDayHeaderComponents(dayHeaderStringBuilder: (context, date) => 'new'),
-          ),
-          multiDayComponentStyles: MultiDayComponentStyles(
-            headerStyles: MultiDayHeaderComponentStyles(
-              dayHeaderStyle: DayHeaderStyle(stringBuilder: (date) => 'old'),
-            ),
-          ),
-        ),
-      );
-
-      expect(find.text('new'), findsWidgets);
-      expect(find.text('old'), findsNothing);
-    });
-
     testWidgets('both builders receive the same date', (tester) async {
       final nameDates = <DateTime>[];
       final numberDates = <DateTime>[];
@@ -157,20 +119,6 @@ void main() {
       expect(find.text('wd'), findsWidgets);
     });
 
-    testWidgets('the deprecated style builder still applies', (tester) async {
-      await pumpMonth(
-        tester,
-        CalendarComponents(
-          monthComponentStyles: MonthComponentStyles(
-            headerStyles: MonthHeaderComponentStyles(
-              weekDayHeaderStyle: WeekDayHeaderStyle(stringBuilder: (date) => 'old wd'),
-            ),
-          ),
-        ),
-      );
-
-      expect(find.text('old wd'), findsWidgets);
-    });
   });
 
   group('MonthDayHeader', () {
@@ -270,33 +218,5 @@ void main() {
       expect(labels(tester), everyElement(matches(RegExp(r'^\+\d+$'))));
     });
 
-    testWidgets('the deprecated style builder still applies', (tester) async {
-      await pumpOverflowingWeek(
-        tester,
-        components: CalendarComponents(
-          overlayStyles: OverlayStyles(
-            multiDayPortalOverlayButtonStyle: MultiDayPortalOverlayButtonStyle(stringBuilder: (n) => 'old $n'),
-          ),
-        ),
-      );
-
-      expect(labels(tester), everyElement(startsWith('old ')));
-    });
-
-    testWidgets('the components builder wins over the deprecated style one', (tester) async {
-      await pumpOverflowingWeek(
-        tester,
-        components: CalendarComponents(
-          overlayBuilders: OverlayBuilders(
-            multiDayPortalOverlayButtonStringBuilder: (context, n) => 'new $n',
-          ),
-          overlayStyles: OverlayStyles(
-            multiDayPortalOverlayButtonStyle: MultiDayPortalOverlayButtonStyle(stringBuilder: (n) => 'old $n'),
-          ),
-        ),
-      );
-
-      expect(labels(tester), everyElement(startsWith('new ')));
-    });
   });
 }

--- a/test/widgets/timeline_alignment_test.dart
+++ b/test/widgets/timeline_alignment_test.dart
@@ -83,7 +83,7 @@ void main() {
   });
 
   testWidgets('custom stringBuilder shortening labels keeps columns aligned (#180)', (tester) async {
-    await pumpWeek(tester, components: withTimelineStyle(TimelineStyle(stringBuilder: (_) => 'X')));
+    await pumpWeek(tester, components: withTimelineStringBuilder((context, time) => 'X'));
 
     // The gutter shrank to fit the short label ...
     expect(gutterWidth(tester), lessThan(40), reason: 'Short labels should produce a narrow gutter');
@@ -136,22 +136,6 @@ void main() {
       textDirection: TextDirection.rtl,
     );
     expectAligned(tester);
-  });
-
-  testWidgets('the components string builder wins over the deprecated style one', (tester) async {
-    await pumpWeek(
-      tester,
-      components: CalendarComponents(
-        multiDayComponents: MultiDayComponents(
-          bodyComponents: MultiDayBodyComponents(timelineStringBuilder: (context, time) => 'components'),
-        ),
-        multiDayComponentStyles: MultiDayComponentStyles(
-          bodyStyles: MultiDayBodyComponentStyles(timelineStyle: TimelineStyle(stringBuilder: (_) => 'style')),
-        ),
-      ),
-    );
-
-    expect(labelAt(tester, 1), 'components');
   });
 
   // The calendar's own locale, which is not necessarily the app's, was not


### PR DESCRIPTION
First of the remaining 0.24.0 work. **This one is a promise, not a preference** — the 0.23.0 changelog says *"Both are removed in 0.24.0"*, and each member repeated it:

```dart
@Deprecated(
  'Moved to MultiDayHeaderComponents.dayHeaderStringBuilder, which also receives a BuildContext. '
  'Will be removed in 0.24.0.',
)
```

Shipping 0.24.0 with them still present would have meant re-dating every one of those notices to 0.25.0.

### What goes

Eight members across six style classes in `lib/src/widgets/components/`:

| Class | Member |
|---|---|
| `DayHeaderStyle` | `stringBuilder`, `numberStringBuilder` |
| `MonthDayHeaderStyle` | `stringBuilder`, `textStyle` |
| `TimelineStyle`, `ScheduleDateStyle`, `WeekDayHeaderStyle`, `MultiDayPortalOverlayButtonStyle` | `stringBuilder` |

Each appeared in about eight places — field, constructor parameter, `copyWith`, `merge`, `lerp`, `==`, `hashCode` — plus a resolution chain in its widget, where the middle term drops out:

```dart
  components.dayHeaderNumberStringBuilder?.call(context, displayDate) ??
-     style.numberStringBuilder?.call(date) ??
      date.day.toString()
```

`MonthDayHeaderStyle.textStyle` is the odd one: it never had any effect at all, since `MonthDayHeader` renders only a day number, styled by `numberTextStyle`.

### Two things that were not mechanical

`MultiDayPortalOverlayButtonStyle` declares its constructor on a single line rather than one parameter per line, so it needed doing by hand. And that same file has a **second** `stringBuilder` — a current, non-deprecated one on the `MultiDayPortalOverlayButton` widget — which had to survive.

### Tests

Seven removed, all of which existed only to pin the deprecated fallback: that a style builder still applied when no components one was set, and that the components one won when both were set. Neither question exists any more.

The alignment regression test for [#180](https://github.com/werner-scholtz/kalender/issues/180) is **kept**, moved onto the current builder. It is about a short label shrinking the timeline gutter and the header then failing to line up with the body — which has nothing to do with which field supplied the label.

`MonthDayHeaderStyle`'s style tests now vary `numberTextStyle`, the field that actually renders, instead of the one that never did.

### Checks

`flutter analyze` clean. **1,513 passing**, down exactly 7 from 1,520, matching the tests removed.

All seven examples analyze clean, run directly — they are the only consumer-shaped code in the repo, and the deprecated-use lint is not enabled here, so nothing else would have caught a leftover.

Every intra-document anchor in `MIGRATION.md` resolves; the first one I wrote did not, which is why it is worth checking.
