### PR TITLE
docs: write down the rule for deprecating and removing public API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,48 @@ Mixins `DayEventTileUtils` and `MultiDayEventTileUtils` provide helper methods f
 
 ## Versioning & Migration
 
-This is a pre-1.0 package — breaking changes can occur in minor versions. Each breaking release includes a migration guide in [MIGRATION.md](MIGRATION.md).
+This is a pre-1.0 package, so the minor version is the breaking slot. Breaking changes are batched into as few releases as possible rather than dribbled out.
+
+### Breaking changes and deprecations
+
+These are rules, not preferences.
+
+**Deprecate only when the old member still gives a correct answer.** A deprecated member that compiles but silently does nothing is worse than a compile error, because the build stays green while the behaviour is gone. `CalendarInteraction.throttleMilliseconds` was removed outright in 0.24.0 for exactly this reason: nothing was left behind it. `CalendarEvent.isMultiDayEvent` was deprecated instead, because it still returns a usable answer.
+
+**The window is one minor release.** Deprecated in 0.23.0 means removed in 0.24.0. Do not extend it, and do not remove early.
+
+**Every `@Deprecated` message names the replacement and the removal version.** Both, every time:
+
+```dart
+@Deprecated('Use spansMultipleDays, which takes a location. Will be removed in 0.25.0.')
+```
+
+A message without a version has no deadline and will sit there for years. Three currently do.
+
+**Some changes cannot be deprecated at all.** There is no window available for any of these, so they go straight into a breaking batch with a migration entry:
+
+- Turning a getter into a method of the same name. Dart rejects declaring both (`duplicate_definition`), so the getter has to vanish the moment the method appears.
+- Adding a named parameter to a method that subclasses override, including optional ones. An override must accept every named parameter its supertype declares, so `copyWith` and `eventsFromDateTimeRange` break every implementer either way.
+- Adding a member to a public mixin or abstract class, such as `DragTargetUtilities.mounted`.
+
+**Record it in both places.** A deprecation gets a `### Deprecations` entry in the changelog naming the removal version. A breaking change gets a `### Breaking Changes` entry plus a section in [MIGRATION.md](MIGRATION.md) showing the before and after.
+
+**If the version is not tagged yet, amend the existing entries rather than appending.** Someone upgrading should read what the release does, not the history of how it got there.
+
+### Verifying a removal
+
+`flutter analyze` at the root will not catch a break for two separate reasons, and both have bitten:
+
+- `deprecated_member_use_from_same_package` is not enabled, so in-package uses of a deprecated member never warn.
+- `analysis_options.yaml` excludes `examples/**`, so the only consumer-shaped code in the repo is invisible to it.
+
+So always run the examples directly:
+
+```bash
+for d in examples/*/; do (cd "$d" && flutter analyze); done
+```
+
+This is what caught a `copyWith` change in 0.24.0 that broke all seven while the package analyze stayed clean.
 
 ### Releasing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ flutter test
 dart tool/test_timezones_linux.dart
 ```
 
+- Removing or renaming anything public? The rules for deprecating it, how long it stays, and what to write in the changelog and migration guide are in [AGENTS.md](AGENTS.md#breaking-changes-and-deprecations). They also cover the changes that cannot be deprecated at all.
+
 ## Reporting issues
 
 If you find a bug or have a feature request, open an issue on [GitHub](https://github.com/werner-scholtz/kalender/issues). Include as much detail as you can, Flutter version, platform, a minimal reproduction if possible.


### PR DESCRIPTION
Docs only. Independent of #372 — that PR is the first thing this rule governs, but neither needs the other.

### The gap

`Versioning & Migration` in `AGENTS.md` covered releasing in detail — tags, pre-releases, patching an old version — but said this much about breaking changes:

> This is a pre-1.0 package — breaking changes can occur in minor versions. Each breaking release includes a migration guide in MIGRATION.md.

Nothing about when to deprecate rather than remove, how long a deprecation lasts, or what the message has to contain. The result is visible in the package: the three oldest `@Deprecated` messages name a replacement but **no removal version**, so they have no deadline and have simply sat there.

```dart
@Deprecated('Use onTappedWithDetail or onLongPressedWithDetail instead.')
@Deprecated('Use monthName or monthNameLocalized or monthNameShortLocalized instead.')
@Deprecated('Use dayName or dayNameLocalized or dayNameShortLocalized instead.')
```

### The rule

Written from what 0.23.0 and 0.24.0 actually did, not invented:

- **Deprecate only when the old member still gives a correct answer.** One that compiles but silently does nothing is worse than a compile error. `throttleMilliseconds` was removed outright for this reason; `isMultiDayEvent` earned a window because it still answers usefully.
- **The window is one minor release.** Deprecated in 0.23.0 means removed in 0.24.0.
- **Every message names the replacement and the removal version.** Both, every time.
- **Some changes cannot be deprecated at all**, so they go straight into a breaking batch: a getter becoming a method of the same name (`duplicate_definition`), a named parameter added to anything subclasses override (optional ones break implementers too), and a member added to a public mixin or abstract class.
- **Record it in the changelog and in MIGRATION.md.** If the version is not tagged yet, amend the existing entries rather than appending, so an upgrader reads what the release does rather than how it got there.

### The verification note is the expensive one

The root `flutter analyze` misses consumer-facing breaks for two independent reasons, and both have bitten during 0.24.0:

- `deprecated_member_use_from_same_package` is not enabled, so in-package uses of a deprecated member never warn.
- `analysis_options.yaml` excludes `examples/**`, so the only consumer-shaped code in the repo is invisible to it.

Hence the standing instruction to run each example directly. That is what caught a `copyWith` change breaking all seven examples with `invalid_override` while the package analyze stayed green.

`CONTRIBUTING.md` gains one line pointing here, since a human contributor would look there first.

### Not included

The three version-less deprecations above are left alone. Giving them a removal version is a commitment to actually remove them, which is a call for the maintainer rather than something to slip into a docs PR.
