### PR TITLE
chore: stop re-exporting the whole timezone package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Breaking Changes
 
+- kalender no longer re-exports the whole `timezone` package. `Location` and `TZDateTime` still come through, since they appear in kalender's own signatures. Everything else, including `getLocation` and `initializeTimeZones`, now needs `package:timezone` imported directly. [#375](https://github.com/werner-scholtz/kalender/pull/375)
 - The seven string builders deprecated in 0.23.0 are removed from the component style classes. Their replacements on the matching `*Components` classes are unchanged, and each takes a `BuildContext` so it can read the calendar's locale. See [MIGRATION.md](MIGRATION.md#v022x--v0230) for the mapping. [#372](https://github.com/werner-scholtz/kalender/pull/372)
 - `MonthDayHeaderStyle.textStyle` is removed. It never had any effect, since `MonthDayHeader` renders only a day number, styled by `numberTextStyle`. [#372](https://github.com/werner-scholtz/kalender/pull/372)
 - `EventsController.eventsFromDateTimeRange` takes a required `multiDayRule`, since it is what sorts events into the header and the body. Only affects code implementing `EventsController`; pass the view configuration's rule. [#371](https://github.com/werner-scholtz/kalender/pull/371)

--- a/examples/web_demo/lib/widgets/calendar/navigation_header.dart
+++ b/examples/web_demo/lib/widgets/calendar/navigation_header.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
+import 'package:timezone/timezone.dart';
 import 'package:web_demo/locations.dart';
 import 'package:web_demo/utils.dart';
 import 'package:web_demo/widgets/toolbar/chip_dropdown.dart';

--- a/lib/kalender_extensions.dart
+++ b/lib/kalender_extensions.dart
@@ -1,5 +1,9 @@
 library;
 
+// Only the two types that appear in kalender's own public signatures. Everything
+// else in the timezone package is that package's to export, not ours.
+export 'package:timezone/timezone.dart' show Location, TZDateTime;
+
 export 'src/extensions/date_time.dart';
 export 'src/extensions/internal_date_time.dart';
 export 'src/extensions/internal_date_time_range.dart';

--- a/lib/src/extensions/internal_date_time.dart
+++ b/lib/src/extensions/internal_date_time.dart
@@ -1,6 +1,5 @@
 import 'package:kalender/kalender.dart';
 
-export 'package:timezone/timezone.dart';
 
 /// A [DateTime] subclass that stores date/time components as-is via [DateTime.utc],
 /// bypassing implicit timezone conversions.

--- a/lib/src/extensions/internal_date_time_range.dart
+++ b/lib/src/extensions/internal_date_time_range.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 
-export 'package:timezone/timezone.dart';
 
 /// A [DateTimeRange] that uses [InternalDateTime] for timezone-safe display and layout.
 ///

--- a/lib/src/models/controllers/events_controller/default_event_store.dart
+++ b/lib/src/models/controllers/events_controller/default_event_store.dart
@@ -1,6 +1,7 @@
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/calendar_events/calendar_event.dart';
 import 'package:kalender/src/models/controllers/events_controller/event_store.dart';
+import 'package:timezone/timezone.dart';
 
 /// Maps timezone location names to their respective date-to-event-ID indexes.
 ///

--- a/test/configuration/default_initial_date_selection_strategies_test.dart
+++ b/test/configuration/default_initial_date_selection_strategies_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
 import 'package:timezone/data/latest_10y.dart';
+import 'package:timezone/timezone.dart';
 
 import '../utilities.dart';
 

--- a/test/extensions/internal_date_time_extension_test.dart
+++ b/test/extensions/internal_date_time_extension_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
 import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart';
 
 void main() {
   setUpAll(tz.initializeTimeZones);

--- a/test/models/calendar_event_test.dart
+++ b/test/models/calendar_event_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
 import 'package:timezone/data/latest_10y.dart';
+import 'package:timezone/timezone.dart';
 
 void main() {
   initializeTimeZones();

--- a/test/models/default_events_controller_test.dart
+++ b/test/models/default_events_controller_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
 import 'package:timezone/data/latest_10y.dart';
+import 'package:timezone/timezone.dart';
 
 import '../utilities.dart';
 

--- a/test/models/event_tile_utils_test.dart
+++ b/test/models/event_tile_utils_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
 import 'package:timezone/data/latest_10y.dart';
+import 'package:timezone/timezone.dart';
 
 import '../utilities.dart';
 

--- a/test/models/internal_date_time_range_test.dart
+++ b/test/models/internal_date_time_range_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart';
 
 void main() {
   setUpAll(tz.initializeTimeZones);

--- a/test/models/internal_date_time_test.dart
+++ b/test/models/internal_date_time_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart';
 
 void main() {
   setUpAll(tz.initializeTimeZones);

--- a/test/models/page_index_calculator_test.dart
+++ b/test/models/page_index_calculator_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/view_configurations/page_index_calculator.dart';
 import 'package:timezone/data/latest_10y.dart';
+import 'package:timezone/timezone.dart';
 
 final locationsToTest = [
   'Etc/UTC',

--- a/test/widgets/now_callback_is_today_test.dart
+++ b/test/widgets/now_callback_is_today_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
 import 'package:timezone/data/latest_10y.dart' as tz;
+import 'package:timezone/timezone.dart';
 
 import '../utilities.dart';
 

--- a/test/widgets/time_indicator_now_callback_test.dart
+++ b/test/widgets/time_indicator_now_callback_test.dart
@@ -4,6 +4,7 @@ import 'package:kalender/kalender.dart';
 import 'package:kalender/src/widgets/internal_components/positioned_time_indicator.dart';
 import 'package:kalender/src/widgets/internal_components/time_indicator_positioner.dart';
 import 'package:timezone/data/latest_10y.dart' as tz;
+import 'package:timezone/timezone.dart';
 
 import '../utilities.dart';
 

--- a/test/widgets/today_highlight_test.dart
+++ b/test/widgets/today_highlight_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
 import 'package:timezone/data/latest_10y.dart' as tz;
+import 'package:timezone/timezone.dart';
 
 import '../utilities.dart';
 


### PR DESCRIPTION
Roadmap item for 0.24.0. Independent of #374.

### What was leaking

`internal_date_time.dart` and `internal_date_time_range.dart` both carried a bare re-export, and both are themselves re-exported from `kalender_extensions.dart`:

```dart
export 'package:timezone/timezone.dart';
```

That put all of this into kalender's API reference, twice over: `TZDateTime`, `Location`, `TimeZone`, `TzInstant`, `LocationDatabase`, `TimeZoneInitException`, `LocationNotFoundException`, and the whole of the package's `env.dart` top level.

### What stays

Only the two that appear in kalender's own signatures, declared once:

```dart
export 'package:timezone/timezone.dart' show Location, TZDateTime;
```

Anything else is that package's to export. Most projects already depend on it, since initializing the database at startup needs `package:timezone/data/latest.dart` regardless — so in practice the missing piece is an import, not a dependency.

### One thing I got wrong while planning this

I expected the examples not to catch this, on the grounds that they already import `package:timezone` directly. **They caught it.** `web_demo` calls `getLocation` in `navigation_header.dart`, which imported kalender but not timezone, and it failed to compile:

```
error • The method 'getLocation' isn't defined for the type 'LocationMenu'
```

It already declared `timezone: any`, so the fix was the import alone. That is a fair sample of what this costs a consumer, and a reminder that the examples earn their place in the checklist even when reasoning says they will be quiet.

### Checks

`flutter analyze` clean. **1,513 passing**, unchanged. All seven examples analyze clean.

The 28 test-side and 3 package-side uses of `getLocation` gained an explicit `import 'package:timezone/timezone.dart';`, which is exactly the change a consumer makes.
