### PR TITLE
refactor: tighten the MultiDayRule surface before it freezes

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -83,13 +83,15 @@ CalendarEvent(
 
 `CalendarEvent.multiDayRule` is null unless you set it, and null means "use the calendar's rule". It takes part in `layoutEquals`, so two events differing only in their rule are not equal. A subclass overriding `layoutEquals` needs no change, since `super`'s comparison already covers it. Neither does your `copyWith` override: `multiDayRule` is deliberately not a parameter on it, because adding one to `CalendarEvent.copyWith` would make every subclass override invalid. The rule is carried through automatically.
 
-For a rule none of these express, override `spansMultipleDays`. Note its signature:
+For a rule none of these express, override `spansMultipleDays` rather than implementing `MultiDayRule`. Note its signature:
 
 ```dart
   @override
 - bool spansMultipleDays({required Location? location}) => ...;
 + bool spansMultipleDays({required Location? location, required MultiDayRule defaultRule}) => ...;
 ```
+
+If you do implement `MultiDayRule`, its one method is `isMultiDay(event, location:)`. The concrete rules behind the two factories are private, so `MultiDayRule` and those factories are the whole surface.
 
 ### `eventsFromDateTimeRange` takes the rule
 

--- a/lib/src/models/calendar_events/calendar_event.dart
+++ b/lib/src/models/calendar_events/calendar_event.dart
@@ -103,7 +103,7 @@ class CalendarEvent {
   ///
   /// Override for a rule no [MultiDayRule] expresses.
   bool spansMultipleDays({required Location? location, required MultiDayRule defaultRule}) {
-    return (multiDayRule ?? defaultRule).test(this, location: location);
+    return (multiDayRule ?? defaultRule).isMultiDay(this, location: location);
   }
 
   /// Whether this event spans more than one day.

--- a/lib/src/models/calendar_events/multi_day_rule.dart
+++ b/lib/src/models/calendar_events/multi_day_rule.dart
@@ -7,60 +7,63 @@ const defaultMultiDayRule = MultiDayRule.minimumDuration(Duration(hours: 24));
 /// Decides whether an event belongs in the multi-day header lane rather than
 /// the day timeline.
 ///
-/// Set it per event, or fix it for a whole app by passing it from a subclass:
+/// Set it once on the view configuration:
 ///
 /// ```dart
-/// class Event extends CalendarEvent {
-///   Event({required super.dateTimeRange})
-///       : super(multiDayRule: const MultiDayRule.calendarDays());
-/// }
+/// MultiDayViewConfiguration.week(
+///   multiDayRule: const MultiDayRule.calendarDays(),
+/// )
 /// ```
 ///
-/// This is a class rather than a function so that it has value equality.
-/// Configurations holding a rule are compared with `==` to decide whether the
-/// calendar needs to rebuild, and a function field would defeat that.
+/// A single event can disagree with the rest through
+/// [CalendarEvent.multiDayRule]. For a rule none of these express, override
+/// [CalendarEvent.spansMultipleDays] rather than implementing this class.
+///
+/// This is a class rather than a function so that it has value equality. View
+/// configurations are compared with `==` to decide whether the calendar needs
+/// to rebuild, and a function field would defeat that.
 abstract class MultiDayRule {
   const MultiDayRule();
 
-  /// Multi-day when the event lasts at least [minimum].
+  /// Multi-day when the event lasts at least [minimum]. The default, at 24 hours.
   ///
-  /// The default, with a [minimum] of 24 hours.
-  const factory MultiDayRule.minimumDuration(Duration minimum) = MinimumDurationRule;
+  /// Measures elapsed time rather than wall-clock time, and so ignores the
+  /// location it is given. An event that reads as 24 hours on the clock is 23
+  /// or 25 hours of elapsed time across a daylight saving change, and qualifies
+  /// or not accordingly. Use [MultiDayRule.calendarDays] when the day
+  /// boundaries are what matter.
+  const factory MultiDayRule.minimumDuration(Duration minimum) = _MinimumDurationRule;
 
   /// Multi-day when the event covers part of more than one calendar day.
   ///
   /// Unlike [MultiDayRule.minimumDuration] this depends on where the day
   /// boundaries fall, so a short event crossing midnight counts.
-  const factory MultiDayRule.calendarDays() = CalendarDaysRule;
+  const factory MultiDayRule.calendarDays() = _CalendarDaysRule;
 
   /// Whether [event] is multi-day, with calendar days measured in [location].
-  bool test(CalendarEvent event, {required Location? location});
+  bool isMultiDay(CalendarEvent event, {required Location? location});
 }
 
-/// Multi-day when the event lasts at least [minimum]. Ignores [Location],
-/// since duration does not depend on where the day boundaries fall.
-class MinimumDurationRule extends MultiDayRule {
-  const MinimumDurationRule(this.minimum);
+class _MinimumDurationRule extends MultiDayRule {
+  const _MinimumDurationRule(this.minimum);
 
-  /// The shortest duration that counts as multi-day.
   final Duration minimum;
 
   @override
-  bool test(CalendarEvent event, {required Location? location}) => event.duration >= minimum;
+  bool isMultiDay(CalendarEvent event, {required Location? location}) => event.duration >= minimum;
 
   @override
-  bool operator ==(Object other) => other is MinimumDurationRule && other.minimum == minimum;
+  bool operator ==(Object other) => other is _MinimumDurationRule && other.minimum == minimum;
 
   @override
   int get hashCode => minimum.hashCode;
 }
 
-/// Multi-day when the event covers part of more than one calendar day.
-class CalendarDaysRule extends MultiDayRule {
-  const CalendarDaysRule();
+class _CalendarDaysRule extends MultiDayRule {
+  const _CalendarDaysRule();
 
   @override
-  bool test(CalendarEvent event, {required Location? location}) {
+  bool isMultiDay(CalendarEvent event, {required Location? location}) {
     final range = event.internalRange(location: location);
     if (range.dates().length > 1) return true;
 
@@ -72,8 +75,8 @@ class CalendarDaysRule extends MultiDayRule {
   }
 
   @override
-  bool operator ==(Object other) => other is CalendarDaysRule;
+  bool operator ==(Object other) => other is _CalendarDaysRule;
 
   @override
-  int get hashCode => (CalendarDaysRule).hashCode;
+  int get hashCode => (_CalendarDaysRule).hashCode;
 }


### PR DESCRIPTION
The three points raised in review of #367 and #371. All cheap now, expensive after the 1.0.0 freeze. Independent of #374 and #375.

### The concrete rules are private

```dart
- const factory MultiDayRule.minimumDuration(Duration minimum) = MinimumDurationRule;
+ const factory MultiDayRule.minimumDuration(Duration minimum) = _MinimumDurationRule;
```

Const factory redirects work fine with private classes, so `MultiDayRule` and its two factories are now the entire public surface instead of three names. This diverges from `PageIndexCalculator`, which exposes its subclasses — but that was consistency with an existing choice, not a reason to freeze two more types nobody constructs directly.

Worth noting **no test referenced either class by name**. They all go through the factories, which is exactly why this is safe.

### `test()` became `isMultiDay()`

```dart
- bool test(CalendarEvent event, {required Location? location});
+ bool isMultiDay(CalendarEvent event, {required Location? location});
```

It is the single method a consumer implements to write a custom rule, and `test()` reads like testing infrastructure.

### `minimumDuration` documents that it ignores the location

It measures elapsed time, so an event reading 24 hours on the clock is 23 or 25 hours across a daylight saving change and qualifies or not accordingly. That is deliberate — it is what preserves pre-0.24.0 behaviour — but the required `location` parameter implied otherwise and nothing said so.

### Also fixed

The class doc still described setting the rule per event and fixing it for an app from a subclass's `super` call. #371 replaced that with the view configuration, so the example was actively misleading.

### Checks

`flutter analyze` clean. **1,511 passing**, unchanged. All seven examples clean.

Confirmed from outside the package that the factories still construct and compare, since that is what privatising the classes could have broken:

```dart
const a = MultiDayRule.minimumDuration(Duration(hours: 12));
const b = MultiDayRule.calendarDays();
// analyzed inside examples/example — no issues
```
