### PR TITLE
docs: repair the 0.24.0 migration guide and close two changelog gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Features
 
 - Dragging a multi-day event down over the body keeps moving its drop target in the header, instead of freezing it until the cursor returns. Releasing over the body commits the date. Only the date changes, so the time of day and duration are untouched. [#369](https://github.com/werner-scholtz/kalender/pull/369)
-- `MultiDayRule` decides which events belong in the multi-day header rather than the day timeline. Set it once on the view configuration. `MultiDayRule.minimumDuration` is the default at 24 hours and matches the previous behaviour, and `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day. A single event can opt out with `CalendarEvent.multiDayRule`, which is otherwise null. [#367](https://github.com/werner-scholtz/kalender/pull/367) [#371](https://github.com/werner-scholtz/kalender/pull/371)
+- `MultiDayRule` decides which events belong in the multi-day header rather than the day timeline. Set it once on the view configuration. `MultiDayRule.minimumDuration` is the default at 24 hours and matches the previous behaviour, and `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day. A single event can opt out with `CalendarEvent.multiDayRule`, which is otherwise null. [#367](https://github.com/werner-scholtz/kalender/pull/367) [#371](https://github.com/werner-scholtz/kalender/pull/371) [#376](https://github.com/werner-scholtz/kalender/pull/376)
 
 ### Deprecations
 
@@ -28,6 +28,7 @@
 - Removing an event no longer throws when its date index was never populated for that location. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - Tapping the trailing edge of an event tile resolves to the last visible day instead of one day past it. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - The two drag-target guards that decide whether an event may be dropped in the header or the body now use the calendar's location. They ignored it, so they could disagree with the rest of the calendar near midnight and across daylight saving changes. [#367](https://github.com/werner-scholtz/kalender/pull/367)
+- The vertical layout delegate returns layout data for every event, even when two events share a hash code. A collision used to drop one of them and fail a layout assertion. Not reachable through `DefaultEventsController`, which never produces colliding events. [#370](https://github.com/werner-scholtz/kalender/pull/370)
 
 ## 0.23.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,25 @@ The seven `String Function(...)` fields on the component style classes, deprecat
 
 If you are coming from 0.22.x or earlier and still setting them, the replacement table is under [v0.22.x → v0.23.0](#string-builders-moved-off-the-style-classes) below. Nothing about the replacements changed in this release, so a project already on the `*Components` builders needs no action.
 
+### The timezone package is no longer re-exported
+
+```dart
++ import 'package:timezone/timezone.dart';
+```
+
+kalender still exports `Location` and `TZDateTime`, since both appear in its own signatures. Everything else from the timezone package, most commonly `getLocation` and `initializeTimeZones`, now needs the direct import above. Add the package to your pubspec if it is not there yet:
+
+```bash
+flutter pub add timezone
+```
+
+If you only ever pass a `Location` into the calendar, nothing changes.
+
+### Three removals that outlived their deprecation window
+
+- `CalendarCallbacks.onMultiDayTapped`: deprecated in 0.13.0 and never called since then, so deleting the argument changes nothing.
+- `DateTimeExtensions.monthNameEnglish` and `dayNameEnglish`: use `monthNameLocalized('en')` and `dayNameLocalized('en')`.
+
 ### `throttleMilliseconds` is gone
 
 ```dart
@@ -44,10 +63,10 @@ The mixin defers move handling to the end of the frame, so it can outlive dispos
 
 ```dart
 - if (event.isMultiDayEvent) { ... }
-+ if (event.spansMultipleDays(location: context.location, defaultRule: context.multiDayRule)) { ... }
++ if (event.spansMultipleDays(location: location, defaultRule: viewConfiguration.multiDayRule)) { ... }
 ```
 
-`context.multiDayRule` resolves the current view's rule, so inside a calendar it is the shortest way to supply it.
+Pass the calendar's `location` and the rule from your view configuration. If you never set one, that rule is `defaultMultiDayRule`.
 
 The old getter still works and is removed in 0.25.0. It answers as if the calendar were in UTC, because a getter cannot take a location, and as if no rule were set on the view.
 
@@ -83,12 +102,11 @@ CalendarEvent(
 
 `CalendarEvent.multiDayRule` is null unless you set it, and null means "use the calendar's rule". It takes part in `layoutEquals`, so two events differing only in their rule are not equal. A subclass overriding `layoutEquals` needs no change, since `super`'s comparison already covers it. Neither does your `copyWith` override: `multiDayRule` is deliberately not a parameter on it, because adding one to `CalendarEvent.copyWith` would make every subclass override invalid. The rule is carried through automatically.
 
-For a rule none of these express, override `spansMultipleDays` rather than implementing `MultiDayRule`. Note its signature:
+For a rule none of these express, override `spansMultipleDays` rather than implementing `MultiDayRule`. Its signature is:
 
 ```dart
-  @override
-- bool spansMultipleDays({required Location? location}) => ...;
-+ bool spansMultipleDays({required Location? location, required MultiDayRule defaultRule}) => ...;
+@override
+bool spansMultipleDays({required Location? location, required MultiDayRule defaultRule}) => ...;
 ```
 
 If you do implement `MultiDayRule`, its one method is `isMultiDay(event, location:)`. The concrete rules behind the two factories are private, so `MultiDayRule` and those factories are the whole surface.


### PR DESCRIPTION
Findings from the pre-release audit of the 0.24.0 documentation. All three are in files that ship the release story, so they gate the tag.

## MIGRATION.md

- **The headline migration snippet could not compile.** It told upgraders to call `event.spansMultipleDays(location: context.location, defaultRule: context.multiDayRule)`, but both getters live on the `ProviderContext` extension, which kalender does not export. The snippet now passes the calendar's `location` and the view configuration's rule explicitly. Exporting the extension instead was considered and rejected: widening the public surface days before a release is the wrong trade, and #376 just went the other direction.
- **The override example diffed against a signature that never shipped.** A 0.23.x reader migrates from `isMultiDayEvent`, not from an intermediate `spansMultipleDays({location})` that only existed between #367 and #371 inside unreleased 0.24.0. It now shows the final signature plainly.
- **Two breaking changes had changelog entries but no migration section**: the narrowed timezone re-export (`getLocation` and `initializeTimeZones` now need a direct `package:timezone` import) and the three removals that outlived their deprecation window (`onMultiDayTapped`, `monthNameEnglish`, `dayNameEnglish`). Both get short sections.

## CHANGELOG.md

- The 0.24.0 Fixes section gains the missing entry for #370, the layout-delegate hash-collision hardening. Worded to be honest about reach: not triggerable through `DefaultEventsController`.
- The MultiDayRule feature entry now also cites #376, which set the rule's final public shape.

## Verification

- All relative links and anchors in MIGRATION.md and CHANGELOG.md resolve, including the two new section headings.
- The corrected snippet compiles against the public API, verified during the audit with `dart analyze` from consumer-shaped code.

Independent of #377, only these two files change.