### PR TITLE
docs: resolve every dartdoc reference warning

### DIFF
--- a/lib/src/extensions/internal_date_time_range.dart
+++ b/lib/src/extensions/internal_date_time_range.dart
@@ -64,7 +64,7 @@ class InternalDateTimeRange extends DateTimeRange<InternalDateTime> {
   /// * If [date] is on the start day → `[start, endOfDay)`.
   /// * If [date] is on the end day → `[startOfDay, end)`.
   /// * If [date] is in between → the full day `[startOfDay, endOfDay)`.
-  /// * If start and end are the same day → returns [this].
+  /// * If start and end are the same day → returns the range unchanged.
   InternalDateTimeRange? dateTimeRangeOnDate(InternalDateTime date) {
     // Adjust the start and end times to the beginning and end of the day.
     final range = InternalDateTimeRange(start: start.startOfDay, end: end.endOfDay);

--- a/lib/src/layout_delegates/multi_day_event_layout.dart
+++ b/lib/src/layout_delegates/multi_day_event_layout.dart
@@ -283,7 +283,7 @@ class MultiDayLayoutFrame {
   /// ex. 1 Week (7 days).
   final InternalDateTimeRange dateTimeRange;
 
-  /// The sorted events for this frame that will be used to generate [MultiDayEventTile]s.
+  /// The sorted events for this frame that will be used to generate `MultiDayEventTile`s.
   final List<CalendarEvent> events;
 
   /// The layout information for each event in this frame.

--- a/lib/src/models/components/schedule_components.dart
+++ b/lib/src/models/components/schedule_components.dart
@@ -2,7 +2,7 @@ import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/widgets/components/schedule_date.dart';
 import 'package:kalender/src/widgets/components/schedule_tile_highlight.dart';
 
-/// A class containing custom widget builders for the [ScheduleBody`].
+/// A class containing custom widget builders for the `ScheduleBody`.
 class ScheduleComponents {
   /// A function that builds the day header widget.
   final ScheduleDateBuilder leadingDateBuilder;

--- a/lib/src/models/controllers/events_controller.dart
+++ b/lib/src/models/controllers/events_controller.dart
@@ -38,7 +38,7 @@ abstract class EventsController with ChangeNotifier {
   /// The events will be removed where [test] returns true.
   void removeWhere(bool Function(String key, CalendarEvent element) test);
 
-  /// Removes all [CalendarEvent]s from [_events].
+  /// Removes all [CalendarEvent]s from the controller.
   void clearEvents();
 
   /// Replaces all [CalendarEvent]s with [events] in a single update.

--- a/lib/src/models/view_configurations/view_configuration.dart
+++ b/lib/src/models/view_configurations/view_configuration.dart
@@ -98,8 +98,7 @@ abstract class ViewConfiguration {
 
   /// The [DateTimeRange] that the calendar can display.
   ///
-  /// This might be different depending on the location of the calendar view.
-  /// to get the exact range for a location, use: [PageIndexCalculator.displayRangeForLocation]
+  /// The exact range shown can differ by the calendar's location.
   DateTimeRange get dateTimeRange => pageIndexCalculator.dateTimeRange;
 }
 

--- a/lib/src/widgets/components/multi_day_overlay.dart
+++ b/lib/src/widgets/components/multi_day_overlay.dart
@@ -11,7 +11,7 @@ import 'package:kalender/src/widgets/internal_components/pass_through_pointer.da
 /// A function that returns a [MultiDayEventOverlayTile] for the multi-day overlay.
 ///
 /// The [event] is the event that is being displayed.
-/// The [dateTimeRange] is the range for which the event is displayed.
+/// The [internalRange] is the range for which the event is displayed.
 /// The [dismissOverlay] is a function that is called when the overlay needs to be dismissed.
 typedef MultiDayOverlayEventTileBuilder = MultiDayEventOverlayTile Function(
   CalendarEvent event,
@@ -28,7 +28,7 @@ typedef RenderBoxCallback = RenderBox Function();
 /// The [events] are all the events that should be displayed for the given [date].
 /// The [tileHeight] is the height of the tile.
 /// The [portalController] is the controller for the overlay portal.
-/// The [getMultiDayEventLayoutRenderBox] is the function that returns the [RenderBox] for the [MultiDayEventLayoutWidget].
+/// The [getMultiDayEventLayoutRenderBox] is the function that returns the [RenderBox] for the `MultiDayEventLayoutWidget`.
 /// The [getOverlayPortalRenderBox] is the function that returns the [RenderBox] for the [MultiDayOverlay].
 /// The [overlayTileBuilder] is the builder for the overlay event tile.
 /// The [style] is the style for the overlay.

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -38,7 +38,7 @@ typedef TimelineWidthBuilder = double Function(
 /// text padding. Measuring all labels (rather than a single sample) keeps the
 /// gutter correct regardless of the locale's time format, the hour's digit
 /// count, and any custom [MultiDayBodyComponents.timelineStringBuilder]. Honors
-/// the ambient [MediaQuery.textScaler] so it reserves enough room for scaled text.
+/// the ambient [MediaQueryData.textScaler] so it reserves enough room for scaled text.
 double defaultTimelineWidth(BuildContext context, TimeOfDayRange timeOfDayRange, TimelineStyle style) {
   if (style.width != null) return style.width!;
 

--- a/lib/src/widgets/components/week_day_header.dart
+++ b/lib/src/widgets/components/week_day_header.dart
@@ -19,10 +19,8 @@ class WeekDayHeaderStyle {
     this.padding,
   });
 
-  /// The [TextStyle] used by the [DateText] widget to display the day of the week.
+  /// The [TextStyle] used to display the day of the week.
   final TextStyle? textStyle;
-
-  /// Use this function to customize the sting displayed by the [WeekDayHeader].
 
   /// The padding around the [WeekDayHeader] widget.
   final EdgeInsets? padding;


### PR DESCRIPTION
Cleanup from the pre-release audit: `dart doc` reported ten unresolved doc references, it now reports zero. Comment-only, no behavior changes.

Three kinds of fix:

- **Out-of-scope types become code spans.** `ScheduleBody`, `MultiDayEventLayoutWidget`, and `MultiDayEventTile` all exist, but not in the import scope of the file referencing them, so the links could never resolve. (The `ScheduleBody` one also had a stray backtick inside the brackets.)
- **Stale references corrected.** A typedef doc still referenced `[dateTimeRange]` after the parameter was renamed `internalRange`. `[MediaQuery.textScaler]` is not a member, the property lives on `MediaQueryData`. `[this]` is not a referenceable element.
- **Dead pointers removed.** `PageIndexCalculator.displayRangeForLocation` no longer exists, so the sentence pointing at it is gone. The `DateText` widget was removed long ago. `EventsController`'s doc referenced a private `_events` the class does not have (which also silenced the twin warning inherited by `DefaultEventsController`). And `WeekDayHeaderStyle` carried an orphaned doc line left behind when the deprecated `stringBuilder` field was removed in #372.

Verified: `flutter analyze` clean, `dart doc` runs with zero warnings.

Independent of #377 and #378, no shared files.