### PR TITLE
feat: name the missing initializeDateFormatting call when locale data is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Removing an event no longer throws when its date index was never populated for that location. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - Tapping the trailing edge of an event tile resolves to the last visible day instead of one day past it. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - The two drag-target guards that decide whether an event may be dropped in the header or the body now use the calendar's location. They ignored it, so they could disagree with the rest of the calendar near midnight and across daylight saving changes. [#367](https://github.com/werner-scholtz/kalender/pull/367)
+- A calendar using a locale whose intl data was never loaded now reports which locale failed, the `initializeDateFormatting()` call to add and the library it is imported from. It previously surfaced intl's `LocaleDataException` from inside a build, which read as a fault in kalender rather than missing setup.
 - `TileComponents.overlayTileBuilder` is used again by the tiles in the multi-day overflow overlay. It has been ignored since 0.14.0, so the overlay rendered `tileBuilder` instead. [#381](https://github.com/werner-scholtz/kalender/pull/381)
 - The vertical layout delegate returns layout data for every event, even when two events share a hash code. A collision used to drop one of them and fail a layout assertion. Not reachable through `DefaultEventsController`, which never produces colliding events. [#370](https://github.com/werner-scholtz/kalender/pull/370)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Removing an event no longer throws when its date index was never populated for that location. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - Tapping the trailing edge of an event tile resolves to the last visible day instead of one day past it. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - The two drag-target guards that decide whether an event may be dropped in the header or the body now use the calendar's location. They ignored it, so they could disagree with the rest of the calendar near midnight and across daylight saving changes. [#367](https://github.com/werner-scholtz/kalender/pull/367)
-- A calendar whose locale has no intl data loaded now names the locale, the `initializeDateFormatting()` call to add and the library it comes from. It previously threw intl's `LocaleDataException` from inside a build.
+- A calendar whose locale has no intl data loaded now names the locale, the `initializeDateFormatting()` call to add and the library it comes from. It previously threw intl's `LocaleDataException` from inside a build. [#382](https://github.com/werner-scholtz/kalender/pull/382)
 - `TileComponents.overlayTileBuilder` is used again by the tiles in the multi-day overflow overlay. It has been ignored since 0.14.0, so the overlay rendered `tileBuilder` instead. [#381](https://github.com/werner-scholtz/kalender/pull/381)
 - The vertical layout delegate returns layout data for every event, even when two events share a hash code. A collision used to drop one of them and fail a layout assertion. Not reachable through `DefaultEventsController`, which never produces colliding events. [#370](https://github.com/werner-scholtz/kalender/pull/370)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Removing an event no longer throws when its date index was never populated for that location. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - Tapping the trailing edge of an event tile resolves to the last visible day instead of one day past it. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - The two drag-target guards that decide whether an event may be dropped in the header or the body now use the calendar's location. They ignored it, so they could disagree with the rest of the calendar near midnight and across daylight saving changes. [#367](https://github.com/werner-scholtz/kalender/pull/367)
-- A calendar using a locale whose intl data was never loaded now reports which locale failed, the `initializeDateFormatting()` call to add and the library it is imported from. It previously surfaced intl's `LocaleDataException` from inside a build, which read as a fault in kalender rather than missing setup.
+- A calendar whose locale has no intl data loaded now names the locale, the `initializeDateFormatting()` call to add and the library it comes from. It previously threw intl's `LocaleDataException` from inside a build.
 - `TileComponents.overlayTileBuilder` is used again by the tiles in the multi-day overflow overlay. It has been ignored since 0.14.0, so the overlay rendered `tileBuilder` instead. [#381](https://github.com/werner-scholtz/kalender/pull/381)
 - The vertical layout delegate returns layout data for every event, even when two events share a hash code. A collision used to drop one of them and fail a layout assertion. Not reachable through `DefaultEventsController`, which never produces colliding events. [#370](https://github.com/werner-scholtz/kalender/pull/370)
 

--- a/doc/events.md
+++ b/doc/events.md
@@ -127,7 +127,7 @@ CalendarEvent(
 event.spansMultipleDays(location: location, defaultRule: viewConfiguration.multiDayRule)
 ```
 
-The event's own `multiDayRule` takes precedence when set, otherwise `defaultRule` applies. Pass the calendar's location so that rules measuring calendar days, such as `MultiDayRule.calendarDays`, place midnight in the right timezone.
+The event's own `multiDayRule` takes precedence when set. Otherwise `defaultRule` applies. Pass the calendar's location so that rules measuring calendar days, such as `MultiDayRule.calendarDays`, place midnight in the right timezone.
 
 ---
 

--- a/doc/events.md
+++ b/doc/events.md
@@ -121,11 +121,13 @@ CalendarEvent(
 
 `CalendarEvent.multiDayRule` is null unless you set it, and null means the calendar's rule applies. It is carried through `copyWith` automatically, so a subclass override needs no extra parameter.
 
-To ask the question yourself, use `spansMultipleDays`:
+`spansMultipleDays` returns whether an event counts as multi-day, applying the same rules the calendar does:
 
 ```dart
 event.spansMultipleDays(location: location, defaultRule: viewConfiguration.multiDayRule)
 ```
+
+The event's own `multiDayRule` takes precedence when set, otherwise `defaultRule` applies. Pass the calendar's location so that rules measuring calendar days, such as `MultiDayRule.calendarDays`, place midnight in the right timezone.
 
 ---
 

--- a/doc/timezones-and-locales.md
+++ b/doc/timezones-and-locales.md
@@ -7,11 +7,15 @@ This is part of the [kalender](../README.md) documentation.
 Kalender uses the [intl](https://pub.dev/packages/intl) package to localize day and month names. Call `initializeDateFormatting()` before `runApp`:
 
 ```dart
+import 'package:intl/date_symbol_data_local.dart';
+
 void main() async {
   await initializeDateFormatting();
   runApp(const MyApp());
 }
 ```
+
+The function comes from `date_symbol_data_local.dart`, not from `intl.dart`. intl compiles in the `en_US` data only, so every other locale needs this call, including `en`. Skipping it throws an error naming the locale that failed and the call to add.
 
 `CalendarView` has a `locale` property that controls day/month name formatting.
 

--- a/doc/timezones-and-locales.md
+++ b/doc/timezones-and-locales.md
@@ -15,7 +15,7 @@ void main() async {
 }
 ```
 
-The function comes from `date_symbol_data_local.dart`, not from `intl.dart`. intl compiles in the `en_US` data only, so every other locale needs this call, including `en`. Skipping it throws an error naming the locale that failed and the call to add.
+The function comes from `date_symbol_data_local.dart`, not from `intl.dart`. The intl package compiles in the `en_US` data only, so every other locale needs this call, including `en`. Without it, kalender throws an error naming the locale that failed and the call to add.
 
 `CalendarView` has a `locale` property that controls day/month name formatting.
 

--- a/lib/src/extensions/date_time.dart
+++ b/lib/src/extensions/date_time.dart
@@ -1,11 +1,50 @@
+import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 
+/// Formats [date] and replaces intl's uninitialized locale data error with one
+/// that names the setup step and the library it comes from.
+///
+/// The format is built inside the guard because intl resolves its locale data
+/// lazily, so either the construction or the format call can fail.
+String _formatLocalized(DateFormat Function() format, DateTime date, dynamic locale) {
+  try {
+    return format().format(date);
+  } catch (error) {
+    if (!error.toString().contains('Locale data has not been initialized')) rethrow;
+    throw FlutterError.fromParts([
+      ErrorSummary('Locale data for ${locale == null ? 'the default locale' : '"$locale"'} has not been loaded.'),
+      ErrorDescription(
+        'kalender formats day and month names with the intl package, which needs its locale data loaded first.',
+      ),
+      ErrorHint(
+        'Call initializeDateFormatting() before runApp:\n'
+        "  import 'package:intl/date_symbol_data_local.dart';\n"
+        '\n'
+        '  void main() async {\n'
+        '    await initializeDateFormatting();\n'
+        '    runApp(const MyApp());\n'
+        '  }',
+      ),
+      ErrorHint(
+        'intl compiles in en_US only, so every other locale needs this call, including "en".',
+      ),
+    ]);
+  }
+}
+
 /// Useful extensions for working with [DateTime] objects.
+///
+/// The localized names require intl's locale data. See [DateTimeExtensions.dayNameLocalized].
 extension DateTimeExtensions on DateTime {
   /// Gets the day name in a specific locale.
   ///
   /// The [locale] parameter allows you to specify the desired locale.
   /// If not provided, it uses the system locale.
+  ///
+  /// Requires `initializeDateFormatting()` from
+  /// `package:intl/date_symbol_data_local.dart` to have been awaited, unless
+  /// [locale] is null or `en_US`. Throws a [FlutterError] naming the missing
+  /// call otherwise.
   ///
   /// Example:
   /// ```dart
@@ -14,7 +53,7 @@ extension DateTimeExtensions on DateTime {
   /// print(date.dayNameLocalized('fr')); // Output: "lundi"
   /// print(date.dayNameLocalized('es')); // Output: "lunes"
   /// ```
-  String dayNameLocalized([dynamic locale]) => DateFormat.EEEE(locale).format(this);
+  String dayNameLocalized([dynamic locale]) => _formatLocalized(() => DateFormat.EEEE(locale), this, locale);
 
   /// Gets the abbreviated day name in a specific locale.
   ///
@@ -24,7 +63,7 @@ extension DateTimeExtensions on DateTime {
   /// print(date.dayNameShortLocalized('en')); // Output: "Mon"
   /// print(date.dayNameShortLocalized('fr')); // Output: "lun"
   /// ```
-  String dayNameShortLocalized([dynamic locale]) => DateFormat.E(locale).format(this);
+  String dayNameShortLocalized([dynamic locale]) => _formatLocalized(() => DateFormat.E(locale), this, locale);
 
   /// Gets the month name in a specific locale.
   ///
@@ -35,7 +74,7 @@ extension DateTimeExtensions on DateTime {
   /// print(date.monthNameLocalized('fr')); // Output: "janvier"
   /// print(date.monthNameLocalized('es')); // Output: "enero"
   /// ```
-  String monthNameLocalized([dynamic locale]) => DateFormat.MMMM(locale).format(this);
+  String monthNameLocalized([dynamic locale]) => _formatLocalized(() => DateFormat.MMMM(locale), this, locale);
 
   /// Gets the abbreviated month name in a specific locale.
   ///
@@ -45,5 +84,5 @@ extension DateTimeExtensions on DateTime {
   /// print(date.monthNameShortLocalized('en')); // Output: "Jan"
   /// print(date.monthNameShortLocalized('fr')); // Output: "janv."
   /// ```
-  String monthNameShortLocalized([dynamic locale]) => DateFormat.MMM(locale).format(this);
+  String monthNameShortLocalized([dynamic locale]) => _formatLocalized(() => DateFormat.MMM(locale), this, locale);
 }

--- a/lib/src/extensions/date_time.dart
+++ b/lib/src/extensions/date_time.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 
-/// Formats [date] and replaces intl's uninitialized locale data error with one
-/// that names the setup step and the library it comes from.
+/// Formats [date] and replaces intl's uninitialized locale data error with one that names the setup step and the
+/// library it comes from.
 ///
-/// The format is built inside the guard because intl resolves its locale data
-/// lazily, so either the construction or the format call can fail.
+/// The format is built inside the guard because intl resolves its locale data lazily, so either the construction or
+/// the format call can fail.
 String _formatLocalized(DateFormat Function() format, DateTime date, dynamic locale) {
   try {
     return format().format(date);
@@ -41,10 +41,8 @@ extension DateTimeExtensions on DateTime {
   /// The [locale] parameter allows you to specify the desired locale.
   /// If not provided, it uses the system locale.
   ///
-  /// Requires `initializeDateFormatting()` from
-  /// `package:intl/date_symbol_data_local.dart` to have been awaited, unless
-  /// [locale] is null or `en_US`. Throws a [FlutterError] naming the missing
-  /// call otherwise.
+  /// Requires `initializeDateFormatting()` from `package:intl/date_symbol_data_local.dart` to have been awaited,
+  /// unless [locale] is null or `en_US`. Throws a [FlutterError] naming the missing call otherwise.
   ///
   /// Example:
   /// ```dart

--- a/test/extensions/uninitialized_locale_test.dart
+++ b/test/extensions/uninitialized_locale_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender_extensions.dart';
+
+/// This file must never call `initializeDateFormatting`. Locale data is global
+/// to the isolate, so loading it here would make every assertion below pass for
+/// the wrong reason.
+void main() {
+  final date = DateTime(2026, 7, 29);
+
+  group('uninitialized locale data', () {
+    test('reports the missing setup call instead of intl\'s bare exception', () {
+      FlutterError? thrown;
+      try {
+        date.dayNameLocalized('de');
+      } on FlutterError catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown, isNotNull, reason: 'an uninitialized locale should throw');
+      final message = thrown.toString();
+      expect(message, contains('initializeDateFormatting()'));
+      expect(message, contains('package:intl/date_symbol_data_local.dart'));
+      expect(message, contains('"de"'));
+    });
+
+    test('covers every localized name builder', () {
+      expect(() => date.dayNameLocalized('fr'), throwsA(isA<FlutterError>()));
+      expect(() => date.dayNameShortLocalized('fr'), throwsA(isA<FlutterError>()));
+      expect(() => date.monthNameLocalized('fr'), throwsA(isA<FlutterError>()));
+      expect(() => date.monthNameShortLocalized('fr'), throwsA(isA<FlutterError>()));
+    });
+
+    test('"en" needs the call even though "en_US" does not', () {
+      // intl compiles in en_US only, so the bare language tag is not covered.
+      expect(() => date.dayNameLocalized('en'), throwsA(isA<FlutterError>()));
+      expect(date.dayNameLocalized('en_US'), 'Wednesday');
+    });
+
+    test('the default locale still works without any setup', () {
+      expect(date.dayNameLocalized(), 'Wednesday');
+      expect(date.monthNameLocalized(), 'July');
+    });
+  });
+}


### PR DESCRIPTION
A calendar whose locale has no intl data loaded threw intl's `LocaleDataException` from inside a build, with a stack trace pointing at kalender's `dayNameLocalized`. It reads as a fault in the package rather than missing application setup.

The four localized name extensions now catch that failure and throw a `FlutterError` naming the locale that failed, the call to add, and the library it comes from. That last part is the piece intl leaves out: `initializeDateFormatting` lives in `package:intl/date_symbol_data_local.dart`, not in `package:intl/intl.dart`, which is not guessable from its message. Anything else the format throws is rethrown untouched.

Only some locales are affected. A calendar that sets no locale works, because intl falls back to its compiled-in `en_US` data. So do `en_US` and `en-US`. Plain `en` does not, and neither does any other locale.

The locale doc page was missing the `date_symbol_data_local.dart` import as well, so following it verbatim gave an undefined function. The second commit is a style pass over the added wording.