### PR TITLE
ci: pin the repository links to the release tag before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,5 +56,19 @@ jobs:
       - name: Test
         run: flutter test
 
+      # pub.dev renders README.md, CHANGELOG.md and example/README.md from the
+      # archive and resolves their links against the moving main branch. Rewrite
+      # them to the tag so a published version keeps linking to its own docs.
+      # The commit exists only in this runner and is never pushed. It keeps the
+      # git state clean so the dry run below stays warning-free and strict.
+      - name: Pin repository links to the tag
+        run: |
+          dart run tool/pin_release_links.dart "$GITHUB_REF_NAME"
+          git -c user.name=github-actions -c user.email=github-actions@github.com \
+            commit --all --message "Pin repository links to $GITHUB_REF_NAME" --quiet
+
+      - name: Dry-run publish
+        run: flutter pub publish --dry-run
+
       - name: Publish
         run: flutter pub publish --force

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,9 @@ Publishing is triggered by a tag, not by a merge. Bump `version` in `pubspec.yam
 git tag v0.23.0 && git push origin v0.23.0
 ```
 
-`publish.yml` refuses the tag unless it points at a commit on main and `pubspec.yaml` matches it, then analyzes, tests and publishes. A published version is permanent: it can be retracted within seven days, but the number can never be reused.
+`publish.yml` refuses the tag unless it points at a commit on main and `pubspec.yaml` matches it, then analyzes, tests, pins the repository links to the tag and publishes. A published version is permanent: it can be retracted within seven days, but the number can never be reused.
+
+The published archive is not byte-identical to the tag. Before packaging, the workflow runs `dart run tool/pin_release_links.dart <tag>`, which rewrites README.md, example/README.md and CHANGELOG.md so the pub.dev pages link to the tag's documentation instead of main. The rewrite is committed only inside the runner to keep the publish validator's clean-git check meaningful and is never pushed, so the repository keeps its relative links. To preview the published pages locally, run the script with any release tag, inspect with `git diff`, then restore with `git checkout -- README.md example/README.md CHANGELOG.md`.
 
 The same tag rebuilds the [live demo](https://werner-scholtz.github.io/kalender/), so it always shows the published package rather than whatever is on main. To rebuild it from main instead, push a commit whose message contains `web demo`.
 

--- a/test/tool/pin_release_links_test.dart
+++ b/test/tool/pin_release_links_test.dart
@@ -45,9 +45,10 @@ void main() {
     test('the banner image is re-pinned from main to the tag', () {
       expect(
         pinBranchUrls(
-            '<img src="https://raw.githubusercontent.com/werner-scholtz/kalender/main/readme_assets/banner.png">',
-            repo,
-            tag),
+          '<img src="https://raw.githubusercontent.com/werner-scholtz/kalender/main/readme_assets/banner.png">',
+          repo,
+          tag,
+        ),
         '<img src="https://raw.githubusercontent.com/werner-scholtz/kalender/$tag/readme_assets/banner.png">',
       );
     });

--- a/test/tool/pin_release_links_test.dart
+++ b/test/tool/pin_release_links_test.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/pin_release_links.dart'
+    show leftoverProblems, pinBranchUrls, pinChangelog, pinRelativeLinks, repositoryUrl;
+
+const repo = 'https://github.com/werner-scholtz/kalender';
+const tag = 'v9.9.9';
+
+void main() {
+  group('repositoryUrl', () {
+    test('strips the trailing .git from the repository field', () {
+      expect(repositoryUrl('name: kalender\nrepository: $repo.git\n'), repo);
+    });
+  });
+
+  group('pinRelativeLinks', () {
+    test('relative links become blob links on the tag and keep their anchors', () {
+      expect(
+        pinRelativeLinks('[views](doc/views.md#views) and [license](LICENSE)', repo, tag),
+        '[views]($repo/blob/$tag/doc/views.md#views) and [license]($repo/blob/$tag/LICENSE)',
+      );
+    });
+
+    test('relative images become raw links on the tag', () {
+      expect(
+        pinRelativeLinks('![banner](readme_assets/banner.png)', repo, tag),
+        '![banner](https://raw.githubusercontent.com/werner-scholtz/kalender/$tag/readme_assets/banner.png)',
+      );
+    });
+
+    test('anchor-only table of contents links are left alone', () {
+      const toc = '- [Features](#features)';
+      expect(pinRelativeLinks(toc, repo, tag), toc);
+    });
+
+    test('absolute links are left alone', () {
+      const absolute = '[demo](https://werner-scholtz.github.io/kalender/)';
+      expect(pinRelativeLinks(absolute, repo, tag), absolute);
+    });
+  });
+
+  group('pinBranchUrls', () {
+    test('the banner image is re-pinned from main to the tag', () {
+      expect(
+        pinBranchUrls(
+            '<img src="https://raw.githubusercontent.com/werner-scholtz/kalender/main/readme_assets/banner.png">',
+            repo,
+            tag),
+        '<img src="https://raw.githubusercontent.com/werner-scholtz/kalender/$tag/readme_assets/banner.png">',
+      );
+    });
+
+    test('tree/main example links are re-pinned to the tag', () {
+      expect(
+        pinBranchUrls('[example]($repo/tree/main/examples/web_demo)', repo, tag),
+        '[example]($repo/tree/$tag/examples/web_demo)',
+      );
+    });
+  });
+
+  group('pinChangelog', () {
+    test('rewrites only the relative MIGRATION.md links', () {
+      const line = 'See [MIGRATION.md](MIGRATION.md#v023x--v0240) for the mapping. [#372]($repo/pull/372)';
+      final result = pinChangelog(line, repo, tag);
+      expect(result, contains(']($repo/blob/$tag/MIGRATION.md#v023x--v0240)'));
+      expect(result, contains('[#372]($repo/pull/372)'));
+    });
+
+    test('historical blob/main and release branch links are untouched', () {
+      const historical = '[a]($repo/blob/main/lib/src/calendar_view.dart) [b]($repo/blob/main-0.4.2/CHANGELOG.md)';
+      expect(pinChangelog(historical, repo, tag), historical);
+    });
+  });
+
+  group('leftoverProblems', () {
+    test('reports a leftover relative link with its line number', () {
+      final problems = leftoverProblems('README.md', 'fine\n[stray](doc/views.md)', repo, allowMainRefs: false);
+      expect(problems, hasLength(1));
+      expect(problems.single, startsWith('README.md:2:'));
+    });
+
+    test('reports a main branch reference unless allowed', () {
+      const content = '[a]($repo/blob/main/doc/views.md)';
+      expect(leftoverProblems('README.md', content, repo, allowMainRefs: false), hasLength(1));
+      expect(leftoverProblems('CHANGELOG.md', content, repo, allowMainRefs: true), isEmpty);
+    });
+  });
+
+  group('repository files', () {
+    test('the real README, example README and CHANGELOG rewrite cleanly', () {
+      final repoUrl = repositoryUrl(File('pubspec.yaml').readAsStringSync());
+
+      final readme = pinRelativeLinks(pinBranchUrls(File('README.md').readAsStringSync(), repoUrl, tag), repoUrl, tag);
+      expect(leftoverProblems('README.md', readme, repoUrl, allowMainRefs: false), isEmpty);
+
+      final example = pinBranchUrls(File('example/README.md').readAsStringSync(), repoUrl, tag);
+      expect(leftoverProblems('example/README.md', example, repoUrl, allowMainRefs: false), isEmpty);
+
+      final changelog = pinChangelog(File('CHANGELOG.md').readAsStringSync(), repoUrl, tag);
+      expect(leftoverProblems('CHANGELOG.md', changelog, repoUrl, allowMainRefs: true), isEmpty);
+    });
+  });
+}

--- a/tool/pin_release_links.dart
+++ b/tool/pin_release_links.dart
@@ -1,0 +1,103 @@
+// Rewrites the repository links in README.md, example/README.md and CHANGELOG.md
+// to point at a release tag instead of the main branch.
+//
+// pub.dev renders these files from the published archive and resolves their
+// repository links against the default branch, so the page of an old version
+// links to newer documentation. The publish workflow runs this script before
+// packaging so every published version keeps linking to its own documentation.
+// The rewrite only touches the working tree, nothing is committed.
+//
+// Usage: dart run tool/pin_release_links.dart v0.24.0
+//
+// Restore with: git checkout -- README.md example/README.md CHANGELOG.md
+
+import 'dart:io';
+
+/// A relative markdown image, capturing the alt text, path and anchor.
+final relativeImage = RegExp(r'!\[([^\]]*)\]\((?!https?://|#)([^)#\s]+)(#[^)]*)?\)');
+
+/// A relative markdown link, capturing the path and anchor.
+final relativeLink = RegExp(r'\]\((?!https?://|#)([^)#\s]+)(#[^)]*)?\)');
+
+/// The repository URL from [pubspec], without a trailing `.git`.
+String repositoryUrl(String pubspec) {
+  final match = RegExp(r'^repository:\s*(.+?)(?:\.git)?\s*$', multiLine: true).firstMatch(pubspec);
+  if (match == null) throw const FormatException('pubspec.yaml has no repository field');
+  return match.group(1)!;
+}
+
+/// Rewrites relative links to `blob/<tag>` URLs and relative images to raw
+/// URLs on the tag, matching how pub.dev resolves each kind.
+String pinRelativeLinks(String content, String repoUrl, String tag) {
+  final rawBase = repoUrl.replaceFirst('https://github.com/', 'https://raw.githubusercontent.com/');
+  return content
+      .replaceAllMapped(relativeImage, (m) => '![${m[1]}]($rawBase/$tag/${m[2]}${m[3] ?? ''})')
+      .replaceAllMapped(relativeLink, (m) => ']($repoUrl/blob/$tag/${m[1]}${m[2] ?? ''})');
+}
+
+/// Rewrites absolute URLs that reference the main branch to the tag.
+String pinBranchUrls(String content, String repoUrl, String tag) {
+  final rawBase = repoUrl.replaceFirst('https://github.com/', 'https://raw.githubusercontent.com/');
+  return content
+      .replaceAll('$rawBase/main/', '$rawBase/$tag/')
+      .replaceAll('$repoUrl/tree/main/', '$repoUrl/tree/$tag/')
+      .replaceAll('$repoUrl/blob/main/', '$repoUrl/blob/$tag/');
+}
+
+/// Rewrites only the relative MIGRATION.md links. The changelog's historical
+/// entries reference the main branch on purpose, so they must stay untouched.
+String pinChangelog(String content, String repoUrl, String tag) {
+  return content.replaceAllMapped(
+    RegExp(r'\]\(MIGRATION\.md(#[^)]*)?\)'),
+    (m) => ']($repoUrl/blob/$tag/MIGRATION.md${m[1] ?? ''})',
+  );
+}
+
+/// Lines in [content] that still carry a relative link, or a main branch
+/// reference unless [allowMainRefs] is set.
+List<String> leftoverProblems(String path, String content, String repoUrl, {required bool allowMainRefs}) {
+  final rawBase = repoUrl.replaceFirst('https://github.com/', 'https://raw.githubusercontent.com/');
+  final mainRefs = ['$repoUrl/blob/main/', '$repoUrl/tree/main/', '$rawBase/main/'];
+  final problems = <String>[];
+  final lines = content.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    if (relativeImage.hasMatch(line) || relativeLink.hasMatch(line)) {
+      problems.add('$path:${i + 1}: a relative link survived the rewrite: $line');
+    }
+    if (!allowMainRefs && mainRefs.any(line.contains)) {
+      problems.add('$path:${i + 1}: a link still references the main branch: $line');
+    }
+  }
+  return problems;
+}
+
+void main(List<String> args) {
+  if (args.length != 1 || !RegExp(r'^v\d+\.\d+\.\d+').hasMatch(args.first)) {
+    stderr.writeln('Usage: dart run tool/pin_release_links.dart <tag>');
+    stderr.writeln('The tag must look like v1.2.3, a pre-release suffix is allowed.');
+    exit(64);
+  }
+  final tag = args.first;
+  final repoUrl = repositoryUrl(File('pubspec.yaml').readAsStringSync());
+
+  final rewrites = <String, String Function(String)>{
+    'README.md': (content) => pinRelativeLinks(pinBranchUrls(content, repoUrl, tag), repoUrl, tag),
+    'example/README.md': (content) => pinBranchUrls(content, repoUrl, tag),
+    'CHANGELOG.md': (content) => pinChangelog(content, repoUrl, tag),
+  };
+
+  final problems = <String>[];
+  for (final entry in rewrites.entries) {
+    final file = File(entry.key);
+    final rewritten = entry.value(file.readAsStringSync());
+    file.writeAsStringSync(rewritten);
+    problems.addAll(leftoverProblems(entry.key, rewritten, repoUrl, allowMainRefs: entry.key == 'CHANGELOG.md'));
+    stdout.writeln('Pinned ${entry.key} to $tag');
+  }
+
+  if (problems.isNotEmpty) {
+    problems.forEach(stderr.writeln);
+    exit(1);
+  }
+}


### PR DESCRIPTION
pub.dev renders README.md, CHANGELOG.md and example/README.md from the published archive but resolves their repository links against the default branch. The page of an old version therefore links to whatever the documentation looks like on main today, which matters now that the guides live in `doc/` and change between releases.

The publish workflow now runs `tool/pin_release_links.dart <tag>` before packaging. It rewrites the relative links in README.md to `blob/<tag>` URLs, re-pins the banner image and the example directory links from `main` to the tag, and rewrites the changelog's relative MIGRATION.md links. The changelog's historical `blob/main` links describe old code and stay untouched. After rewriting, the script verifies nothing relative or main-pinned is left in the rendered files and fails the release otherwise.

Two guards keep this from ever breaking a release silently. The script's tests include one that runs the rewrite against the real repository files, so a documentation link it cannot pin fails ordinary CI the day it is added. And the workflow gains a `pub publish --dry-run` step after the rewrite, which is strict about warnings. The rewrite is committed only inside the runner to keep the git state clean for that check, and is never pushed, so the repository and its tags keep relative links.

Rehearsed locally with `v0.23.0`: 21 rewrites in README.md, 6 in example/README.md, 3 in CHANGELOG.md, and the dry run passes with 0 warnings. AGENTS.md documents that the published archive is no longer byte-identical to the tag.