### PR TITLE
fix: keep multiDayRule when a subclass copies an event

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -138,7 +138,30 @@ CalendarEvent(
 )
 ```
 
-`CalendarEvent.multiDayRule` is null unless you set it, and null means "use the calendar's rule". It takes part in `layoutEquals`, so two events differing only in their rule are not equal. A subclass overriding `layoutEquals` needs no change, since `super`'s comparison already covers it. Neither does your `copyWith` override: `multiDayRule` is deliberately not a parameter on it, because adding one to `CalendarEvent.copyWith` would make every subclass override invalid. The rule is carried through automatically.
+`CalendarEvent.multiDayRule` is null unless you set it, and null means "use the calendar's rule". It takes part in `layoutEquals`, so two events differing only in their rule are not equal. A subclass overriding `layoutEquals` needs no change, since `super`'s comparison already covers it.
+
+`copyWith` takes no `multiDayRule` parameter, because adding one to `CalendarEvent.copyWith` would make every subclass override invalid. A subclass has to forward it:
+
+```dart
+  Event({
+    super.id,
+    required super.dateTimeRange,
+    required this.title,
++   super.multiDayRule,
+  });
+
+  @override
+  Event copyWith({DateTimeRange? dateTimeRange, String? title}) {
+    return Event(
+      id: id,
+      dateTimeRange: dateTimeRange ?? this.dateTimeRange,
++     multiDayRule: multiDayRule,
+      title: title ?? this.title,
+    );
+  }
+```
+
+Without it, every drag or resize produces a copy without the rule.
 
 For a rule none of these express, override `spansMultipleDays` rather than implementing `MultiDayRule`. Its signature is:
 

--- a/doc/events.md
+++ b/doc/events.md
@@ -19,6 +19,7 @@ class Event extends CalendarEvent {
     this.description,
     this.color,
     super.interaction,
+    super.multiDayRule,
   });
 
   @override
@@ -33,6 +34,8 @@ class Event extends CalendarEvent {
       id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       interaction: interaction ?? this.interaction,
+      // copyWith has no multiDayRule parameter. Forward it so copies keep the rule.
+      multiDayRule: multiDayRule,
       title: title ?? this.title,
       description: description ?? this.description,
       color: color ?? this.color,
@@ -119,7 +122,7 @@ CalendarEvent(
 )
 ```
 
-`CalendarEvent.multiDayRule` is null unless you set it, and null means the calendar's rule applies. It is carried through `copyWith` automatically, so a subclass override needs no extra parameter.
+`CalendarEvent.multiDayRule` is null unless you set it, and null means the calendar's rule applies. `copyWith` has no `multiDayRule` parameter. A subclass forwards the rule instead: accept `super.multiDayRule` in the constructor and pass `multiDayRule: multiDayRule` when `copyWith` rebuilds, as the [Custom Events](#custom-events) example does. Without that, every drag or resize produces a copy without the rule.
 
 `spansMultipleDays` returns whether an event counts as multi-day, applying the same rules the calendar does:
 

--- a/examples/advanced_example/lib/main.dart
+++ b/examples/advanced_example/lib/main.dart
@@ -19,6 +19,7 @@ class Event extends CalendarEvent {
     required this.title,
     required this.person,
     super.interaction,
+    super.multiDayRule,
   });
 
   factory Event.fromDetail(CalendarEvent calendarEvent, TapDetail detail) {
@@ -47,6 +48,7 @@ class Event extends CalendarEvent {
       id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       interaction: interaction ?? this.interaction,
+      multiDayRule: multiDayRule,
       title: title ?? this.title,
       person: person ?? this.person,
     );

--- a/examples/example/lib/main.dart
+++ b/examples/example/lib/main.dart
@@ -42,6 +42,7 @@ class Event extends CalendarEvent {
     required this.title,
     this.color,
     super.interaction,
+    super.multiDayRule,
   });
 
   final String title;
@@ -58,6 +59,7 @@ class Event extends CalendarEvent {
       id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       interaction: interaction ?? this.interaction,
+      multiDayRule: multiDayRule,
       title: title ?? this.title,
       color: color ?? this.color,
     );

--- a/examples/ics/lib/ics_event.dart
+++ b/examples/ics/lib/ics_event.dart
@@ -13,6 +13,7 @@ class IcsEvent extends CalendarEvent {
     required this.color,
     this.description,
     super.interaction,
+    super.multiDayRule,
   });
 
   final String uid;
@@ -33,6 +34,7 @@ class IcsEvent extends CalendarEvent {
       id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       interaction: interaction ?? this.interaction,
+      multiDayRule: multiDayRule,
       uid: uid ?? this.uid,
       title: title ?? this.title,
       description: description ?? this.description,

--- a/examples/recurrence/lib/recurring_event.dart
+++ b/examples/recurrence/lib/recurring_event.dart
@@ -10,6 +10,7 @@ class RecurringCalendarEvent extends CalendarEvent {
     required this.groupId,
     required super.dateTimeRange,
     super.interaction,
+    super.multiDayRule,
   });
 
   /// Copy the [CalendarEvent] with the new values.
@@ -23,6 +24,7 @@ class RecurringCalendarEvent extends CalendarEvent {
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       groupId: groupId,
       interaction: interaction ?? this.interaction,
+      multiDayRule: multiDayRule,
     );
   }
 

--- a/examples/testing/lib/test_configuration.dart
+++ b/examples/testing/lib/test_configuration.dart
@@ -67,6 +67,7 @@ class Event extends CalendarEvent {
     this.description,
     this.color,
     super.interaction,
+    super.multiDayRule,
   });
 
   /// The title of the [Event].
@@ -90,6 +91,7 @@ class Event extends CalendarEvent {
       id: id,
       dateTimeRange: dateTimeRange ?? this.dateTimeRange,
       interaction: interaction ?? this.interaction,
+      multiDayRule: multiDayRule,
       title: title ?? this.title,
       description: description ?? this.description,
       color: color ?? this.color,

--- a/examples/web_demo/lib/models/event.dart
+++ b/examples/web_demo/lib/models/event.dart
@@ -13,6 +13,7 @@ class Event extends CalendarEvent {
     this.description,
     this.color,
     super.interaction,
+    super.multiDayRule,
   });
 
   /// The title of the [Event].
@@ -36,6 +37,7 @@ class Event extends CalendarEvent {
         id: id,
         dateTimeRange: dateTimeRange ?? this.dateTimeRange,
         interaction: interaction ?? this.interaction,
+        multiDayRule: multiDayRule,
         title: title ?? this.title,
         description: description ?? this.description,
         color: color ?? this.color,

--- a/test/models/calendar_event_test.dart
+++ b/test/models/calendar_event_test.dart
@@ -360,6 +360,22 @@ void main() {
       );
     });
 
+    test('a subclass keeps the rule when its copyWith forwards it', () {
+      // The pattern the Custom Events guide documents. Dropping `multiDayRule`
+      // from the rebuild loses the rule on the first drag or resize.
+      final event = _DataEvent(
+        dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 1, 15), end: DateTime.utc(2024, 1, 16)),
+        title: 'Night shift',
+        multiDayRule: const MultiDayRule.calendarDays(),
+      );
+
+      final moved = event.copyWith(
+        dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 2), end: DateTime.utc(2024, 2, 2)),
+      );
+      expect(moved.multiDayRule, const MultiDayRule.calendarDays());
+      expect(moved.title, 'Night shift');
+    });
+
     test('the rule participates in layoutEquals, since it decides the lane', () {
       final range = DateTimeRange(start: DateTime.utc(2024, 1, 15, 23), end: DateTime.utc(2024, 1, 16, 1));
       final a = CalendarEvent(id: 'same', dateTimeRange: range);
@@ -391,6 +407,28 @@ void main() {
 /// Fixes the rule for a whole app in one place, the way a real subclass would.
 class _CalendarDayEvent extends CalendarEvent {
   _CalendarDayEvent({required super.dateTimeRange}) : super(multiDayRule: const MultiDayRule.calendarDays());
+}
+
+/// Attaches data the way the Custom Events guide shows, forwarding the rule.
+class _DataEvent extends CalendarEvent {
+  _DataEvent({
+    super.id,
+    required super.dateTimeRange,
+    required this.title,
+    super.multiDayRule,
+  });
+
+  final String title;
+
+  @override
+  _DataEvent copyWith({DateTimeRange? dateTimeRange, EventInteraction? interaction, String? title}) {
+    return _DataEvent(
+      id: id,
+      dateTimeRange: dateTimeRange ?? this.dateTimeRange,
+      multiDayRule: multiDayRule,
+      title: title ?? this.title,
+    );
+  }
 }
 
 /// Replaces the rule entirely with a strict "more than one calendar day".


### PR DESCRIPTION
The Custom Events guide showed a `CalendarEvent` subclass whose constructor did not accept `multiDayRule` and whose `copyWith` rebuilt the event without it. The calendar copies an event on every modification, so anyone who followed the guide and set a per-event rule lost that rule on the first drag or resize. The guide also said the rule is "carried through `copyWith` automatically, so a subclass override needs no extra parameter", which is true of the base class only.

The documented example now accepts `super.multiDayRule` and forwards it in `copyWith`, and the surrounding sentence says what a subclass has to do. The migration guide carried the same claim and gets the same correction, with a diff showing both lines. The six `CalendarEvent` subclasses across the example apps had the identical gap and are fixed the same way.

A test builds a subclass exactly as the guide documents it and asserts that a moved copy keeps its rule. Removing the forwarding line makes it fail, which is how the bug was confirmed.

No library code changed, `CalendarEvent.copyWith` already forwards the rule correctly and keeps no parameter for it. No changelog entry: `MultiDayRule` is new in 0.24.0, so relative to 0.23.0 there is no wrong behaviour for an upgrader to read about, and the feature entry plus the migration guide are now correct.