### PR TITLE
docs: fix the zoom snippet, point class links at the API docs

### DIFF
--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -270,7 +270,7 @@ KalenderThemeData(
 
 Pass a `CalendarComponents` object to `CalendarView` to override default widget builders or just pass style objects to tweak colors, text styles, and padding without defining your own widgets. Styles passed here apply to that one `CalendarView` and win over the [theme](#theming).
 
-Style classes: [`MultiDayComponentStyles`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/models/components/multi_day_styles.dart), [`MonthComponentStyles`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/models/components/month_styles.dart), [`ScheduleComponentStyles`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/models/components/schedule_styles.dart).
+Style classes: [`MultiDayComponentStyles`](https://pub.dev/documentation/kalender/latest/kalender/MultiDayComponentStyles-class.html), [`MonthComponentStyles`](https://pub.dev/documentation/kalender/latest/kalender/MonthComponentStyles-class.html), [`ScheduleComponentStyles`](https://pub.dev/documentation/kalender/latest/kalender/ScheduleComponentStyles-class.html).
 
 <details>
   <summary>MultiDayComponents</summary>

--- a/doc/events.md
+++ b/doc/events.md
@@ -138,7 +138,7 @@ The event's own `multiDayRule` takes precedence when set. Otherwise `defaultRule
 
 ### Vertical layout (Day / MultiDay body)
 
-The package uses [`CustomMultiChildLayout`](https://api.flutter.dev/flutter/widgets/CustomMultiChildLayout-class.html) with an [`EventLayoutDelegate`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/layout_delegates/event_layout_delegate.dart) to position tiles.
+The package uses [`CustomMultiChildLayout`](https://api.flutter.dev/flutter/widgets/CustomMultiChildLayout-class.html) with an [`EventLayoutDelegate`](https://pub.dev/documentation/kalender/latest/kalender/EventLayoutDelegate-class.html) to position tiles.
 
 Built-in strategies (pass via `MultiDayBodyConfiguration.eventLayoutStrategy`):
 

--- a/doc/views.md
+++ b/doc/views.md
@@ -70,7 +70,7 @@ Presents events in a chronological scrollable list.
 
 ### EventsController
 
-[`EventsController`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/models/controllers/events_controller.dart) manages and exposes events to the calendar. Typically one instance per app. Use [`DefaultEventsController`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/models/controllers/events_controller/default_events_controller.dart) unless you need a custom storage layer.
+[`EventsController`](https://pub.dev/documentation/kalender/latest/kalender/EventsController-class.html) manages and exposes events to the calendar. Typically one instance per app. Use [`DefaultEventsController`](https://pub.dev/documentation/kalender/latest/kalender/DefaultEventsController-class.html) unless you need a custom storage layer.
 
 | Method                               | Description                                                                                                                    |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
@@ -88,7 +88,7 @@ Presents events in a chronological scrollable list.
 
 ### CalendarController
 
-[`CalendarController`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/models/controllers/calendar_controller.dart) drives a single `CalendarView` widget.
+[`CalendarController`](https://pub.dev/documentation/kalender/latest/kalender/CalendarController-class.html) drives a single `CalendarView` widget.
 
 **State notifiers:**
 
@@ -106,7 +106,7 @@ Presents events in a chronological scrollable list.
 - `animateToDate(date)` / `animateToDateTime(dateTime)`
 - `animateToEvent(event)`
 
-> Internally the controller delegates to a [`ViewController`](https://github.com/werner-scholtz/kalender/blob/main/lib/src/models/controllers/view_controller.dart) (`MultiDayViewController`, `MonthViewController`, or `ScheduleViewController`) depending on the active `ViewConfiguration`.
+> Internally the controller delegates to a [`ViewController`](https://pub.dev/documentation/kalender/latest/kalender/ViewController-class.html) (`MultiDayViewController`, `MonthViewController`, or `ScheduleViewController`) depending on the active `ViewConfiguration`.
 
 ---
 
@@ -313,9 +313,12 @@ Each view has its own configuration class with sensible defaults. Expand the ref
 
 Zoom the calendar in and out by changing the `heightPerMinute` value on the `MultiDayViewController`. The [`web_demo`](https://github.com/werner-scholtz/kalender/tree/main/examples/web_demo) example shows a full implementation with [`ZoomDetector`](https://github.com/werner-scholtz/kalender/blob/main/examples/web_demo/lib/widgets/calendar/zoom.dart).
 
-Here's a minimal example of wiring up zoom with Ctrl+scroll on desktop:
+Here's a minimal example of wiring up zoom with Ctrl+scroll on desktop. `PointerScrollEvent` and `HardwareKeyboard` are not exported by `material.dart`, so both imports are needed:
 
 ```dart
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+
 class ZoomableCalendar extends StatelessWidget {
   final CalendarController calendarController;
   final Widget child;

--- a/examples/examples_needed.md
+++ b/examples/examples_needed.md
@@ -1,3 +1,0 @@
-# Ideas for examples that are needed
-
-<!-- // TODO: gather some ideas -->

--- a/test/tool/pin_release_links_test.dart
+++ b/test/tool/pin_release_links_test.dart
@@ -3,7 +3,15 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../tool/pin_release_links.dart'
-    show leftoverProblems, pinBranchUrls, pinChangelog, pinRelativeLinks, repositoryUrl;
+    show
+        docFiles,
+        leftoverProblems,
+        packageName,
+        pinBranchUrls,
+        pinChangelog,
+        pinPubDevDocs,
+        pinRelativeLinks,
+        repositoryUrl;
 
 const repo = 'https://github.com/werner-scholtz/kalender';
 const tag = 'v9.9.9';
@@ -61,6 +69,35 @@ void main() {
     });
   });
 
+  group('packageName', () {
+    test('reads the name field', () {
+      expect(packageName('name: kalender\nversion: 0.24.0\n'), 'kalender');
+    });
+  });
+
+  group('pinPubDevDocs', () {
+    test('latest becomes the released version, without the leading v', () {
+      expect(
+        pinPubDevDocs(
+          'https://pub.dev/documentation/kalender/latest/kalender/EventsController-class.html',
+          'kalender',
+          tag,
+        ),
+        'https://pub.dev/documentation/kalender/9.9.9/kalender/EventsController-class.html',
+      );
+    });
+
+    test("another package's latest is left alone, this tag says nothing about its versions", () {
+      const other = 'https://pub.dev/documentation/timezone/latest/timezone/Location-class.html';
+      expect(pinPubDevDocs(other, 'kalender', tag), other);
+    });
+
+    test('a pub.dev package page is left alone', () {
+      const packagePage = 'https://pub.dev/packages/intl';
+      expect(pinPubDevDocs(packagePage, 'kalender', tag), packagePage);
+    });
+  });
+
   group('pinChangelog', () {
     test('rewrites only the relative MIGRATION.md links', () {
       const line = 'See [MIGRATION.md](MIGRATION.md#v023x--v0240) for the mapping. [#372]($repo/pull/372)';
@@ -77,30 +114,95 @@ void main() {
 
   group('leftoverProblems', () {
     test('reports a leftover relative link with its line number', () {
-      final problems = leftoverProblems('README.md', 'fine\n[stray](doc/views.md)', repo, allowMainRefs: false);
+      final problems = leftoverProblems('README.md', 'fine\n[stray](doc/views.md)', repo, allowUnpinnedLinks: false);
       expect(problems, hasLength(1));
       expect(problems.single, startsWith('README.md:2:'));
     });
 
     test('reports a main branch reference unless allowed', () {
       const content = '[a]($repo/blob/main/doc/views.md)';
-      expect(leftoverProblems('README.md', content, repo, allowMainRefs: false), hasLength(1));
-      expect(leftoverProblems('CHANGELOG.md', content, repo, allowMainRefs: true), isEmpty);
+      expect(leftoverProblems('README.md', content, repo, allowUnpinnedLinks: false), hasLength(1));
+      expect(leftoverProblems('CHANGELOG.md', content, repo, allowUnpinnedLinks: true), isEmpty);
+    });
+
+    test('a relative link is allowed when the file keeps them', () {
+      const content = 'see [views](views.md#views)\nand the [index](../README.md)';
+      expect(leftoverProblems('doc/events.md', content, repo, allowUnpinnedLinks: false), hasLength(2));
+      expect(
+        leftoverProblems('doc/events.md', content, repo, allowUnpinnedLinks: false, allowRelativeLinks: true),
+        isEmpty,
+      );
+    });
+
+    test('a main branch reference is still reported when relative links are allowed', () {
+      const content = '[strategy]($repo/blob/main/examples/advanced_example/lib/layout_strategy.dart)';
+      final problems =
+          leftoverProblems('doc/layout.md', content, repo, allowUnpinnedLinks: false, allowRelativeLinks: true);
+      expect(problems, hasLength(1));
+      expect(problems.single, startsWith('doc/layout.md:1:'));
+    });
+  });
+
+  group('docFiles', () {
+    test('lists only markdown, sorted', () {
+      final directory = Directory.systemTemp.createTempSync('doc_files_test');
+      addTearDown(() => directory.deleteSync(recursive: true));
+      File('${directory.path}/views.md').writeAsStringSync('');
+      File('${directory.path}/appearance.md').writeAsStringSync('');
+      File('${directory.path}/notes.txt').writeAsStringSync('');
+
+      expect(
+        docFiles(directory).map((path) => path.split(Platform.pathSeparator).last),
+        ['appearance.md', 'views.md'],
+      );
+    });
+
+    test('an absent directory yields nothing', () {
+      expect(docFiles(Directory('doc_that_does_not_exist')), isEmpty);
+    });
+
+    test('finds the real guides', () {
+      expect(docFiles(), isNotEmpty);
     });
   });
 
   group('repository files', () {
+    final pubspec = File('pubspec.yaml').readAsStringSync();
+    final repoUrl = repositoryUrl(pubspec);
+    final package = packageName(pubspec);
+
+    String pinAll(String content) => pinPubDevDocs(pinBranchUrls(content, repoUrl, tag), package, tag);
+
     test('the real README, example README and CHANGELOG rewrite cleanly', () {
-      final repoUrl = repositoryUrl(File('pubspec.yaml').readAsStringSync());
+      final readme = pinRelativeLinks(pinAll(File('README.md').readAsStringSync()), repoUrl, tag);
+      expect(leftoverProblems('README.md', readme, repoUrl, allowUnpinnedLinks: false, package: package), isEmpty);
 
-      final readme = pinRelativeLinks(pinBranchUrls(File('README.md').readAsStringSync(), repoUrl, tag), repoUrl, tag);
-      expect(leftoverProblems('README.md', readme, repoUrl, allowMainRefs: false), isEmpty);
-
-      final example = pinBranchUrls(File('example/README.md').readAsStringSync(), repoUrl, tag);
-      expect(leftoverProblems('example/README.md', example, repoUrl, allowMainRefs: false), isEmpty);
+      final example = pinAll(File('example/README.md').readAsStringSync());
+      expect(
+        leftoverProblems('example/README.md', example, repoUrl, allowUnpinnedLinks: false, package: package),
+        isEmpty,
+      );
 
       final changelog = pinChangelog(File('CHANGELOG.md').readAsStringSync(), repoUrl, tag);
-      expect(leftoverProblems('CHANGELOG.md', changelog, repoUrl, allowMainRefs: true), isEmpty);
+      expect(leftoverProblems('CHANGELOG.md', changelog, repoUrl, allowUnpinnedLinks: true, package: package), isEmpty);
+    });
+
+    test('the real guides rewrite cleanly and keep their relative links', () {
+      for (final path in docFiles()) {
+        final rewritten = pinAll(File(path).readAsStringSync());
+        expect(
+          leftoverProblems(
+            path,
+            rewritten,
+            repoUrl,
+            allowUnpinnedLinks: false,
+            allowRelativeLinks: true,
+            package: package,
+          ),
+          isEmpty,
+          reason: '$path still has an unpinned link after the rewrite',
+        );
+      }
     });
   });
 }

--- a/tool/pin_release_links.dart
+++ b/tool/pin_release_links.dart
@@ -1,5 +1,5 @@
-// Rewrites the repository links in README.md, example/README.md and CHANGELOG.md
-// to point at a release tag instead of the main branch.
+// Rewrites the repository links in README.md, example/README.md, CHANGELOG.md and
+// doc/*.md to point at a release tag instead of the main branch.
 //
 // pub.dev renders these files from the published archive and resolves their
 // repository links against the default branch, so the page of an old version
@@ -7,9 +7,14 @@
 // packaging so every published version keeps linking to its own documentation.
 // The rewrite only touches the working tree, nothing is committed.
 //
+// The guides under doc/ are only ever read on GitHub, where a relative link
+// already resolves against whatever ref is being browsed. They therefore get the
+// branch rewrite but not the relative rewrite, which prepends a root-relative
+// prefix and would break `../README.md` and sibling links like `views.md`.
+//
 // Usage: dart run tool/pin_release_links.dart v0.24.0
 //
-// Restore with: git checkout -- README.md example/README.md CHANGELOG.md
+// Restore with: git checkout -- README.md example/README.md CHANGELOG.md doc/
 
 import 'dart:io';
 
@@ -26,6 +31,13 @@ String repositoryUrl(String pubspec) {
   return match.group(1)!;
 }
 
+/// The package name from [pubspec].
+String packageName(String pubspec) {
+  final match = RegExp(r'^name:\s*(\S+)\s*$', multiLine: true).firstMatch(pubspec);
+  if (match == null) throw const FormatException('pubspec.yaml has no name field');
+  return match.group(1)!;
+}
+
 /// Rewrites relative links to `blob/<tag>` URLs and relative images to raw
 /// URLs on the tag, matching how pub.dev resolves each kind.
 String pinRelativeLinks(String content, String repoUrl, String tag) {
@@ -33,6 +45,19 @@ String pinRelativeLinks(String content, String repoUrl, String tag) {
   return content
       .replaceAllMapped(relativeImage, (m) => '![${m[1]}]($rawBase/$tag/${m[2]}${m[3] ?? ''})')
       .replaceAllMapped(relativeLink, (m) => ']($repoUrl/blob/$tag/${m[1]}${m[2] ?? ''})');
+}
+
+/// A pub.dev API documentation link for [package] on the `latest` version.
+RegExp pubDevLatest(String package) => RegExp('https://pub\\.dev/documentation/$package/latest/');
+
+/// Rewrites this package's pub.dev API documentation links from `latest` to the
+/// released version, so an old release links to the API it actually shipped.
+///
+/// Only [package] is rewritten. Another package's `latest` is correct as it
+/// stands, because this tag says nothing about that package's versions.
+String pinPubDevDocs(String content, String package, String tag) {
+  final version = tag.startsWith('v') ? tag.substring(1) : tag;
+  return content.replaceAll(pubDevLatest(package), 'https://pub.dev/documentation/$package/$version/');
 }
 
 /// Rewrites absolute URLs that reference the main branch to the tag.
@@ -53,23 +78,46 @@ String pinChangelog(String content, String repoUrl, String tag) {
   );
 }
 
-/// Lines in [content] that still carry a relative link, or a main branch
-/// reference unless [allowMainRefs] is set.
-List<String> leftoverProblems(String path, String content, String repoUrl, {required bool allowMainRefs}) {
+/// Lines in [content] that still carry a relative link, or a link that floats to
+/// the newest documentation rather than this release's.
+///
+/// Set [allowUnpinnedLinks] for files that keep such links on purpose, such as
+/// the changelog's historical entries. Set [allowRelativeLinks] for files whose
+/// relative links are deliberately kept, such as the guides under doc/.
+List<String> leftoverProblems(
+  String path,
+  String content,
+  String repoUrl, {
+  required bool allowUnpinnedLinks,
+  bool allowRelativeLinks = false,
+  String package = 'kalender',
+}) {
   final rawBase = repoUrl.replaceFirst('https://github.com/', 'https://raw.githubusercontent.com/');
   final mainRefs = ['$repoUrl/blob/main/', '$repoUrl/tree/main/', '$rawBase/main/'];
+  final latestDocs = pubDevLatest(package);
   final problems = <String>[];
   final lines = content.split('\n');
   for (var i = 0; i < lines.length; i++) {
     final line = lines[i];
-    if (relativeImage.hasMatch(line) || relativeLink.hasMatch(line)) {
+    if (!allowRelativeLinks && (relativeImage.hasMatch(line) || relativeLink.hasMatch(line))) {
       problems.add('$path:${i + 1}: a relative link survived the rewrite: $line');
     }
-    if (!allowMainRefs && mainRefs.any(line.contains)) {
+    if (!allowUnpinnedLinks && mainRefs.any(line.contains)) {
       problems.add('$path:${i + 1}: a link still references the main branch: $line');
+    }
+    if (!allowUnpinnedLinks && latestDocs.hasMatch(line)) {
+      problems.add('$path:${i + 1}: a link still references the latest API docs: $line');
     }
   }
   return problems;
+}
+
+/// The guide files under doc/, sorted so a run is deterministic.
+List<String> docFiles([Directory? directory]) {
+  final dir = directory ?? Directory('doc');
+  if (!dir.existsSync()) return const [];
+  return dir.listSync().whereType<File>().map((file) => file.path).where((path) => path.endsWith('.md')).toList()
+    ..sort();
 }
 
 void main(List<String> args) {
@@ -79,21 +127,46 @@ void main(List<String> args) {
     exit(64);
   }
   final tag = args.first;
-  final repoUrl = repositoryUrl(File('pubspec.yaml').readAsStringSync());
+  final pubspec = File('pubspec.yaml').readAsStringSync();
+  final repoUrl = repositoryUrl(pubspec);
+  final package = packageName(pubspec);
 
-  final rewrites = <String, String Function(String)>{
-    'README.md': (content) => pinRelativeLinks(pinBranchUrls(content, repoUrl, tag), repoUrl, tag),
-    'example/README.md': (content) => pinBranchUrls(content, repoUrl, tag),
-    'CHANGELOG.md': (content) => pinChangelog(content, repoUrl, tag),
-  };
+  /// Everything except the changelog, whose historical entries are pinned separately.
+  String pinAll(String content) => pinPubDevDocs(pinBranchUrls(content, repoUrl, tag), package, tag);
+
+  final rewrites = <({String path, String Function(String) rewrite, bool allowUnpinnedLinks, bool allowRelativeLinks})>[
+    (
+      path: 'README.md',
+      rewrite: (content) => pinRelativeLinks(pinAll(content), repoUrl, tag),
+      allowUnpinnedLinks: false,
+      allowRelativeLinks: false,
+    ),
+    (path: 'example/README.md', rewrite: pinAll, allowUnpinnedLinks: false, allowRelativeLinks: false),
+    (
+      path: 'CHANGELOG.md',
+      rewrite: (content) => pinChangelog(content, repoUrl, tag),
+      allowUnpinnedLinks: true,
+      allowRelativeLinks: false,
+    ),
+    for (final doc in docFiles()) (path: doc, rewrite: pinAll, allowUnpinnedLinks: false, allowRelativeLinks: true),
+  ];
 
   final problems = <String>[];
-  for (final entry in rewrites.entries) {
-    final file = File(entry.key);
-    final rewritten = entry.value(file.readAsStringSync());
+  for (final entry in rewrites) {
+    final file = File(entry.path);
+    final rewritten = entry.rewrite(file.readAsStringSync());
     file.writeAsStringSync(rewritten);
-    problems.addAll(leftoverProblems(entry.key, rewritten, repoUrl, allowMainRefs: entry.key == 'CHANGELOG.md'));
-    stdout.writeln('Pinned ${entry.key} to $tag');
+    problems.addAll(
+      leftoverProblems(
+        entry.path,
+        rewritten,
+        repoUrl,
+        allowUnpinnedLinks: entry.allowUnpinnedLinks,
+        allowRelativeLinks: entry.allowRelativeLinks,
+        package: package,
+      ),
+    );
+    stdout.writeln('Pinned ${entry.path} to $tag');
   }
 
   if (problems.isNotEmpty) {


### PR DESCRIPTION
## Description

Three unrelated documentation fixes that stand on their own, plus one deletion.

**The zoom example did not compile.** `PointerScrollEvent` and `HardwareKeyboard` are not exported by `material.dart`, so the snippet in the views guide was missing two imports. Both are now shown, with a line saying why.

**Eight links naming a class pointed into `lib/src`,** the private implementation directory, rather than the generated API reference. They now point at pub.dev. All eight were checked to return 200.

**`pin_release_links.dart` only covered README.md, example/README.md and CHANGELOG.md,** so the guides under `doc/` kept linking to `main` no matter which tag was being browsed. It now covers `doc/*.md`, and pins this package's pub.dev documentation links from `latest` to the released version so an old release links to the API it shipped.

The guides deliberately get the branch rewrite but not the relative rewrite. Their relative links already resolve against whatever ref is being browsed, and the relative rewrite prepends a root-relative prefix that would break `../README.md` and sibling links like `views.md`. `leftoverProblems` takes `allowRelativeLinks` to match, and `allowMainRefs` is renamed to `allowUnpinnedLinks` now that it covers both branch refs and floating documentation links.

Also removes `examples/examples_needed.md`, a two-line placeholder with a TODO.

## Testing
- [x] Unit Tests Added/Updated
- [ ] Widget Tests Added/Updated (if applicable)

`test/tool/pin_release_links_test.dart` gains cases for `packageName`, `pinPubDevDocs`, `docFiles`, the new `allowRelativeLinks` flag, and a check that every real guide rewrites cleanly.

The zoom snippet was extracted verbatim from the guide and analyzed against the package to confirm it now builds.

## Checklist
- [x] I have run `flutter analyze` and fixed any issues
- [x] I have run `dart format .`

## Additional Notes

First of four stacked documentation PRs. The others build on this one and are best reviewed in order.