### PR TITLE
ci: compile the snippets in the README and the guides

### DIFF
--- a/.github/workflows/flutter_analyze_and_test.yml
+++ b/.github/workflows/flutter_analyze_and_test.yml
@@ -35,6 +35,24 @@ jobs:
         shell: bash
         working-directory: ./
 
+  doc-snippets: # The code in the README and the guides, which flutter analyze cannot see
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: subosito/flutter-action@v2
+
+      - name: Install dependencies
+        run: flutter pub get
+        shell: bash
+        working-directory: ./
+
+      # Generates the snippets into examples/doc_snippets and analyzes them, so
+      # it cannot join the analyze_examples.yml matrix, which only runs analyze.
+      - name: Compile the documentation snippets
+        run: dart run tool/analyze_doc_snippets.dart
+        shell: bash
+        working-directory: ./
+
   test: # Separate job for tests with matrix
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ build/
 /ios/
 
 /examples/**/pubspec.lock
+
+# Written by tool/analyze_doc_snippets.dart on every run.
+/examples/doc_snippets/lib/generated/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,3 +270,26 @@ Key breaking changes to be aware of:
 A guide links to a class with its pub.dev API page, not a `lib/src` blob URL.
 `pin_release_links.dart` rewrites both, so a published version keeps linking to
 the documentation it shipped with.
+
+### Snippets in the documentation
+
+Every fenced dart block in `README.md`, `example/README.md` and `doc/*.md` is
+compiled by `tool/analyze_doc_snippets.dart`, which CI runs. Each block needs a
+directive comment above it saying how, and a block without one fails the run:
+
+```markdown
+<!-- snippet: file -->          top-level declarations
+<!-- snippet: statements -->    wrapped in an async function body
+<!-- snippet: expression -->    wrapped in a variable initializer
+<!-- snippet: continues -->     appended to the block above
+<!-- snippet: skip: reason -->  not compiled, reason required
+```
+
+A snippet may assume only `material.dart` and `kalender.dart`. Anything else has
+to be imported in the block itself, so a snippet a reader copies whole actually
+compiles. That rule exists because a wider implied header hid the missing
+`gestures.dart` and `services.dart` in the zoom example for as long as it was
+there. Placeholder identifiers such as the `Event` subclass come from
+`examples/doc_snippets/lib/preamble.dart`, which is analyzed too.
+
+Diagnostics are reported against the markdown line, not the generated file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,14 @@ flutter test
 dart tool/test_timezones_linux.dart
 ```
 
+- Adding or changing a code sample in the README or the guides? Every fenced dart block carries a directive comment saying how it is compiled, and CI compiles them all:
+
+```bash
+dart run tool/analyze_doc_snippets.dart
+```
+
+A block without a directive fails the run, so a new snippet cannot go in unchecked. `tool/analyze_doc_snippets.dart` documents the directives at the top.
+
 - Removing or renaming anything public? The rules for deprecating it, how long it stays, and what to write in the changelog and migration guide are in [AGENTS.md](AGENTS.md#breaking-changes-and-deprecations). They also cover the changes that cannot be deprecated at all.
 
 ## Reporting issues

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ flutter pub add intl
 
 The minimal setup, using only the base `CalendarEvent` class with no custom fields:
 
+<!-- snippet: file -->
 ```dart
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -16,6 +16,7 @@ For schedule views, use `ScheduleTileComponents` instead (passed via `CalendarBo
 
 For most apps a plain `tileBuilder` is all you need:
 
+<!-- snippet: expression -->
 ```dart
 CalendarBody(
   multiDayTileComponents: TileComponents(
@@ -41,6 +42,7 @@ Every aspect of an event tile's appearance and drag behavior can be overridden.
 <details>
   <summary>TileComponents reference</summary>
 
+  <!-- snippet: expression -->
   ```dart
   TileComponents(
     // Required: the stationary event tile.
@@ -83,6 +85,7 @@ Schedule view tiles have a different set of builders since they are laid out in 
 <details>
   <summary>ScheduleTileComponents reference</summary>
 
+  <!-- snippet: expression -->
   ```dart
   ScheduleTileComponents(
     // Required: the stationary event tile.
@@ -112,6 +115,7 @@ For tiles that need to know the exact tapped time or find nearby events, use the
 <details>
   <summary>DayEventTileUtils (day / multi-day body tiles)</summary>
 
+  <!-- snippet: file -->
   ```dart
   class CustomDayEventTile extends StatelessWidget with DayEventTileUtils {
     @override
@@ -168,6 +172,7 @@ For tiles that need to know the exact tapped time or find nearby events, use the
 <details>
   <summary>MultiDayEventTileUtils (month view / multi-day header tiles)</summary>
 
+  <!-- snippet: file -->
   ```dart
   class CustomMultiDayEventTile extends StatelessWidget with MultiDayEventTileUtils {
     @override
@@ -227,6 +232,7 @@ Out of the box the calendar follows your app's Material 3 theme: line colors, te
 
 To change how every calendar in the app looks, register a `KalenderThemeData` on your theme. Any field you leave out keeps its Material 3 default.
 
+<!-- snippet: expression -->
 ```dart
 MaterialApp(
   theme: ThemeData(
@@ -253,6 +259,7 @@ Theme changes animate: because `KalenderThemeData` is a `ThemeExtension` with `l
 
 The overlay that opens from the `+3` button, which stands in for events that do not fit, is themed the same way. Its card and close button take Flutter's own `CardThemeData` and `ButtonStyle`, so anything you can do to a `Card` or an `IconButton` you can do here.
 
+<!-- snippet: expression -->
 ```dart
 KalenderThemeData(
   multiDayOverlayStyle: MultiDayOverlayStyle(
@@ -279,33 +286,32 @@ Style classes: [`MultiDayComponentStyles`](https://pub.dev/documentation/kalende
 <details>
   <summary>MultiDayComponents</summary>
 
+  <!-- snippet: expression -->
   ```dart
-  CalendarView(
-    components: CalendarComponents(
-      multiDayComponents: MultiDayComponents(
-        headerComponents: MultiDayHeaderComponents(
-          dayHeaderBuilder: (date, style) => CustomWidget(),
-          weekNumberBuilder: (visibleDateTimeRange, style) => CustomWidget(),
-          leftTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
-          rightTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
-          overlayBuilders: OverlayBuilders(
-            multiDayPortalOverlayButtonBuilder:
-                (portalController, numberOfHiddenRows, style) => SizedBox(),
-          ),
+  CalendarComponents(
+    multiDayComponents: MultiDayComponents(
+      headerComponents: MultiDayHeaderComponents(
+        dayHeaderBuilder: (date, style) => CustomWidget(),
+        weekNumberBuilder: (visibleDateTimeRange, style) => CustomWidget(),
+        leftTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
+        rightTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
+        overlayBuilders: OverlayBuilders(
+          multiDayPortalOverlayButtonBuilder:
+              (portalController, numberOfHiddenRows, style) => SizedBox(),
         ),
-        bodyComponents: MultiDayBodyComponents(
-          hourLines: (heightPerMinute, timeOfDayRange, style, timelineStyle) => CustomWidget(),
-          timeline: (heightPerMinute, timeOfDayRange, style, eventBeingDragged, visibleDateTimeRange) =>
-              CustomWidget(),
-          // Sizes the timeline gutter, for example to fit a custom timeline's labels.
-          timelineWidth: (context, timeOfDayRange, style) => 48,
-          daySeparator: (style) => CustomWidget(),
-          timeIndicator: (timeOfDayRange, heightPerMinute, style, location) => CustomWidget(),
-          leftTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
-          rightTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
-          topTriggerBuilder: (viewPortHeight) => SizedBox(height: viewPortHeight / 20),
-          bottomTriggerBuilder: (viewPortHeight) => SizedBox(height: viewPortHeight / 20),
-        ),
+      ),
+      bodyComponents: MultiDayBodyComponents(
+        hourLines: (heightPerMinute, timeOfDayRange, style, timelineStyle) => CustomWidget(),
+        timeline: (heightPerMinute, timeOfDayRange, style, eventBeingDragged, visibleDateTimeRange) =>
+            CustomWidget(),
+        // Sizes the timeline gutter, for example to fit a custom timeline's labels.
+        timelineWidth: (context, timeOfDayRange, style) => 48,
+        daySeparator: (style) => CustomWidget(),
+        timeIndicator: (timeOfDayRange, heightPerMinute, style, location) => CustomWidget(),
+        leftTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
+        rightTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
+        topTriggerBuilder: (viewPortHeight) => SizedBox(height: viewPortHeight / 20),
+        bottomTriggerBuilder: (viewPortHeight) => SizedBox(height: viewPortHeight / 20),
       ),
     ),
   )
@@ -315,26 +321,25 @@ Style classes: [`MultiDayComponentStyles`](https://pub.dev/documentation/kalende
 <details>
   <summary>MonthComponents</summary>
 
+  <!-- snippet: expression -->
   ```dart
-  CalendarView(
-    components: CalendarComponents(
-      monthComponents: MonthComponents(
-        headerComponents: MonthHeaderComponents(
-          weekDayHeaderBuilder: (date, style) => SizedBox(),
-        ),
-        bodyComponents: MonthBodyComponents(
-          monthDayHeaderBuilder: (date, style) => SizedBox(),
-          // Custom per-cell background, or use the ready-made
-          // MonthDayCell.shadeAdjacentMonths() to shade adjacent-month days.
-          monthDayCellBuilder: (details) => SizedBox(),
-          monthGridBuilder: (style, numberOfRows) => SizedBox(),
-          weekNumberBuilder: (visibleDateTimeRange, style) => SizedBox(),
-          leftTriggerBuilder: (pageWidth) => SizedBox(),
-          rightTriggerBuilder: (pageWidth) => SizedBox(),
-          overlayBuilders: OverlayBuilders(
-            multiDayPortalOverlayButtonBuilder:
-                (portalController, numberOfHiddenRows, style) => SizedBox(),
-          ),
+  CalendarComponents(
+    monthComponents: MonthComponents(
+      headerComponents: MonthHeaderComponents(
+        weekDayHeaderBuilder: (date, style) => SizedBox(),
+      ),
+      bodyComponents: MonthBodyComponents(
+        monthDayHeaderBuilder: (date, style) => SizedBox(),
+        // Custom per-cell background, or use the ready-made
+        // MonthDayCell.shadeAdjacentMonths() to shade adjacent-month days.
+        monthDayCellBuilder: (details) => SizedBox(),
+        monthGridBuilder: (style, numberOfRows) => SizedBox(),
+        weekNumberBuilder: (visibleDateTimeRange, style) => SizedBox(),
+        leftTriggerBuilder: (pageWidth) => SizedBox(),
+        rightTriggerBuilder: (pageWidth) => SizedBox(),
+        overlayBuilders: OverlayBuilders(
+          multiDayPortalOverlayButtonBuilder:
+              (portalController, numberOfHiddenRows, style) => SizedBox(),
         ),
       ),
     ),
@@ -345,23 +350,22 @@ Style classes: [`MultiDayComponentStyles`](https://pub.dev/documentation/kalende
 <details>
   <summary>ScheduleComponents</summary>
 
+  <!-- snippet: expression -->
   ```dart
-  CalendarView(
-    components: CalendarComponents(
-      scheduleComponents: ScheduleComponents(
-        // The date column shown beside the first row of each day.
-        leadingDateBuilder: (date, style) => Container(),
+  CalendarComponents(
+    scheduleComponents: ScheduleComponents(
+      // The date column shown beside the first row of each day.
+      leadingDateBuilder: (date, style) => Container(),
 
-        // Wraps a row to highlight it as the drop target during a drag.
-        scheduleTileHighlightBuilder: (date, dateTimeRange, style, child) =>
-            Container(child: child),
+      // Wraps a row to highlight it as the drop target during a drag.
+      scheduleTileHighlightBuilder: (date, dateTimeRange, style, child) =>
+          Container(child: child),
 
-        // Optional: builder for days with no events.
-        emptyItemBuilder: (tileRange) => Container(),
+      // Optional: builder for days with no events.
+      emptyItemBuilder: (tileRange) => Container(),
 
-        // Optional: builder for the month heading rows.
-        monthItemBuilder: (monthRange) => Container(),
-      ),
+      // Optional: builder for the month heading rows.
+      monthItemBuilder: (monthRange) => Container(),
     ),
   )
   ```

--- a/doc/controllers-and-callbacks.md
+++ b/doc/controllers-and-callbacks.md
@@ -55,7 +55,15 @@ The calendar draws no toolbar of its own. Switching views, moving between pages
 and showing the current month are all built in your app, using the navigation
 methods above and a `ViewConfiguration` held in state.
 
+<!-- snippet: file -->
 ```dart
+class CalendarScreen extends StatefulWidget {
+  const CalendarScreen({super.key});
+
+  @override
+  State<CalendarScreen> createState() => _CalendarScreenState();
+}
+
 class _CalendarScreenState extends State<CalendarScreen> {
   final eventsController = DefaultEventsController();
   final calendarController = CalendarController();
@@ -135,6 +143,7 @@ The [basic example](https://github.com/werner-scholtz/kalender/tree/main/example
 
 Pass a `CalendarCallbacks` to `CalendarView` to react to user interactions.
 
+<!-- snippet: expression -->
 ```dart
 CalendarCallbacks(
   // --- Event interactions ---

--- a/doc/events.md
+++ b/doc/events.md
@@ -10,6 +10,7 @@ on screen, see [Layout](layout.md). For what they look like, see
 
 Since v0.16.0, `CalendarEvent` is no longer generic. The idiomatic way to attach custom data (title, color, description, etc.) is to **extend** `CalendarEvent` directly.
 
+<!-- snippet: file -->
 ```dart
 class Event extends CalendarEvent {
   final String title;
@@ -70,6 +71,7 @@ class Event extends CalendarEvent {
 
 Use `eventsController.updateEvent()` to replace an existing event with an updated copy:
 
+<!-- snippet: statements -->
 ```dart
 final original = eventsController.byId(someId)! as Event;
 final updated = original.copyWith(title: 'Updated Title', color: Colors.red);
@@ -86,29 +88,35 @@ Only override `layoutEquals` when a custom property changes the *size or positio
 
 Cast the event to your subclass. A convenience getter keeps the cast to one place:
 
+<!-- snippet: expression -->
 ```dart
-tileBuilder: (event, tileRange) {
-  final myEvent = event as Event;
-  return Container(
-    color: myEvent.color ?? Colors.blue,
-    child: Text(myEvent.title),
-  );
-},
+TileComponents(
+  tileBuilder: (event, tileRange) {
+    final myEvent = event as Event;
+    return Container(
+      color: myEvent.color ?? Colors.blue,
+      child: Text(myEvent.title),
+    );
+  },
+)
 ```
 
 ### Returning your subclass on event creation
 
 Use `onEventCreate` to intercept the bare `CalendarEvent` created by a gesture and return a fully typed instance:
 
+Pass this as `CalendarView.callbacks`:
+
+<!-- snippet: expression -->
 ```dart
-callbacks: CalendarCallbacks(
+CalendarCallbacks(
   onEventCreate: (event) => Event(
     dateTimeRange: event.dateTimeRange,
     title: 'New Event',
     color: Colors.blue,
   ),
   onEventCreated: (event) => eventsController.addEvent(event),
-),
+)
 ```
 
 ---
@@ -119,6 +127,7 @@ A `MultiDayRule` decides whether an event renders in the multi-day header lane o
 
 A single event can override the calendar's rule:
 
+<!-- snippet: expression -->
 ```dart
 CalendarEvent(
   dateTimeRange: range,
@@ -130,6 +139,7 @@ CalendarEvent(
 
 `spansMultipleDays` returns whether an event counts as multi-day, applying the same rules the calendar does:
 
+<!-- snippet: expression -->
 ```dart
 event.spansMultipleDays(location: location, defaultRule: viewConfiguration.multiDayRule)
 ```

--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -16,6 +16,7 @@ different things in its header than in its body.
 - `interaction: CalendarInteraction`: toggling resize / reschedule / create.
 - `snapping: CalendarSnapping`: (body only, MultiDay) snap interval, snap-to-indicator, snap-to-events, custom snap strategy.
 
+<!-- snippet: expression -->
 ```dart
 CalendarBody(
   interaction: CalendarInteraction(
@@ -52,6 +53,7 @@ Zoom the calendar in and out by changing the `heightPerMinute` value on the `Mul
 
 Here's a minimal example of wiring up zoom with Ctrl+scroll on desktop. `PointerScrollEvent` and `HardwareKeyboard` are not exported by `material.dart`, so both imports are needed:
 
+<!-- snippet: file -->
 ```dart
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';

--- a/doc/layout.md
+++ b/doc/layout.md
@@ -24,6 +24,7 @@ To create a custom strategy, subclass `EventLayoutDelegate`. See [`CustomSideByS
 
 Here's a minimal skeleton:
 
+<!-- snippet: file -->
 ```dart
 class MyLayoutDelegate extends EventLayoutDelegate {
   MyLayoutDelegate({
@@ -62,6 +63,7 @@ class MyLayoutDelegate extends EventLayoutDelegate {
 
 Then create your strategy function:
 
+<!-- snippet: continues -->
 ```dart
 EventLayoutDelegate myLayoutStrategy(
   Iterable<CalendarEvent> events,
@@ -90,6 +92,7 @@ Events are placed in a grid of rows × columns (rows = concurrent events, column
 
 The default generator sorts events by duration then start date. Supply an `eventComparator` to change the order:
 
+<!-- snippet: expression -->
 ```dart
 CalendarBody(
   monthBodyConfiguration: MonthBodyConfiguration(

--- a/doc/timezones-and-locales.md
+++ b/doc/timezones-and-locales.md
@@ -6,6 +6,7 @@ This is part of the [kalender](README.md) documentation.
 
 Kalender uses the [intl](https://pub.dev/packages/intl) package to localize day and month names. Call `initializeDateFormatting()` before `runApp`:
 
+<!-- snippet: file -->
 ```dart
 import 'package:intl/date_symbol_data_local.dart';
 
@@ -19,10 +20,13 @@ The function comes from `date_symbol_data_local.dart`, not from `intl.dart`. The
 
 `CalendarView` has a `locale` property that controls day/month name formatting.
 
+<!-- snippet: expression -->
 ```dart
 CalendarView(
   locale: 'af_ZA',
-  // ...
+  eventsController: eventsController,
+  calendarController: calendarController,
+  viewConfiguration: viewConfiguration,
 )
 ```
 
@@ -31,6 +35,7 @@ that do not fit is labelled with a plus sign and the count, `+3`, with the numbe
 formatted for the calendar's locale, so it needs no translation. The week number's
 tooltip is the one string that still defaults to English:
 
+<!-- snippet: expression -->
 ```dart
 MaterialApp(
   theme: ThemeData(
@@ -53,9 +58,15 @@ matching `*Components` class. Each one receives the `BuildContext`, so it can re
 the calendar's own locale with `context.calendarLocale`, which is not necessarily
 the app's locale:
 
+<!-- snippet: expression -->
 ```dart
+import 'package:intl/intl.dart';
+
 CalendarView(
   locale: 'af_ZA',
+  eventsController: eventsController,
+  calendarController: calendarController,
+  viewConfiguration: viewConfiguration,
   components: CalendarComponents(
     multiDayComponents: MultiDayComponents(
       headerComponents: MultiDayHeaderComponents(
@@ -81,6 +92,7 @@ on `MonthHeaderComponents`, `leadingDateStringBuilder` on `ScheduleComponents`, 
 
 `CalendarView` accepts a `Location` from the [timezone](https://pub.dev/packages/timezone) package. The `CalendarEvent` constructor automatically converts `dateTimeRange` values to UTC, so events are always stored in UTC internally and converted to the given location for display.
 
+<!-- snippet: expression -->
 ```dart
 import 'package:timezone/timezone.dart' as tz;
 
@@ -94,7 +106,10 @@ CalendarView(
 
 Pre-initialize `DefaultEventsController` with the locations you expect to query for best performance:
 
+<!-- snippet: statements -->
 ```dart
+import 'package:timezone/timezone.dart' as tz;
+
 final eventsController = DefaultEventsController(
   locations: [
     tz.getLocation('America/New_York'),
@@ -115,7 +130,10 @@ When events come from an `.ics` file, a device calendar, or an API, map each sou
 - **UTC instant** (an `.ics` time ending in `Z`, or an epoch): pass it as-is.
 - **Zoned time** (an IANA `TZID`): build a `TZDateTime` in that zone so the instant is correct.
 
+  <!-- snippet: statements -->
   ```dart
+  import 'package:timezone/timezone.dart' as tz;
+
   final start = tz.TZDateTime(tz.getLocation('Europe/London'), 2025, 1, 6, 9);
   final event = CalendarEvent(
     dateTimeRange: DateTimeRange(start: start, end: start.add(const Duration(hours: 1))),
@@ -130,6 +148,7 @@ Then set `CalendarView(location:)` to the zone the calendar should display in. T
 
 By default, the time indicator position and "today" header highlighting are derived from the calendar's `Location`. If your app stores wall-clock times as UTC (e.g. an application where `location: UTC`) but still wants the indicator and today highlight to reflect the user's local time, pass a `NowCallback` on your view configuration:
 
+<!-- snippet: expression -->
 ```dart
 MultiDayViewConfiguration.week(
   nowCallback: () => DateTime.now(), // system local time

--- a/doc/timezones-and-locales.md
+++ b/doc/timezones-and-locales.md
@@ -86,6 +86,19 @@ The builders are `dayHeaderStringBuilder` and `dayHeaderNumberStringBuilder` on
 on `MonthHeaderComponents`, `leadingDateStringBuilder` on `ScheduleComponents`, and
 `multiDayPortalOverlayButtonStringBuilder` on `OverlayBuilders`.
 
+The times down the side of a multi-day view are the one case where the default
+does not come from the calendar's `locale`. They use Flutter's `TimeOfDay.format`,
+so they follow the device's 12-hour or 24-hour setting. Fix the format with
+`timelineStringBuilder`:
+
+<!-- snippet: expression -->
+```dart
+MultiDayBodyComponents(
+  timelineStringBuilder: (context, time) =>
+      '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}',
+)
+```
+
 ---
 
 ## Location

--- a/doc/views.md
+++ b/doc/views.md
@@ -22,6 +22,7 @@ All configurations accept:
 - `initialDateTime`: the date to show on first render. Defaults to `DateTime.now()`.
 - `multiDayRule`: what counts as a multi-day event and so renders in the multi-day header rather than the day timeline. Defaults to events lasting 24 hours or more (`MultiDayRule.minimumDuration`). `MultiDayRule.calendarDays()` instead counts anything that crosses midnight. A single event can override the rule, see [Multi-day events](events.md#multi-day-events).
 
+<!-- snippet: expression -->
 ```dart
 MultiDayViewConfiguration.week(
   displayRange: DateTimeRange(
@@ -48,6 +49,7 @@ These views also control where the day opens vertically and how tall an hour is:
 - `initialTimeOfDay`: the time at the top of the viewport on first render. Defaults to midnight, so set it to the hour your users actually start at or the calendar opens on empty overnight hours.
 - `initialHeightPerMinute`: the starting zoom, in logical pixels per minute. Defaults to `0.7`, giving a 42 pixel hour. Change it later through the controller, see [Zoom](interaction.md#zoom).
 
+<!-- snippet: expression -->
 ```dart
 MultiDayViewConfiguration.week(
   initialTimeOfDay: const TimeOfDay(hour: 7, minute: 0),
@@ -64,6 +66,7 @@ Shows an entire month at a glance, weeks as rows.
 
 Month view can be adjusted with `firstDayOfWeek` and `showWeekNumbers`:
 
+<!-- snippet: expression -->
 ```dart
 MonthViewConfiguration.singleMonth(
   initialDateTime: DateTime(2025, 1, 1),
@@ -101,6 +104,7 @@ Each view has its own configuration class with sensible defaults. Expand the ref
 <details>
   <summary>MultiDayHeaderConfiguration</summary>
 
+  <!-- snippet: expression -->
   ```dart
   CalendarHeader(
     multiDayHeaderConfiguration: MultiDayHeaderConfiguration(
@@ -119,6 +123,7 @@ Each view has its own configuration class with sensible defaults. Expand the ref
 <details>
   <summary>MultiDayBodyConfiguration</summary>
 
+  <!-- snippet: expression -->
   ```dart
   CalendarBody(
     multiDayBodyConfiguration: MultiDayBodyConfiguration(
@@ -139,6 +144,7 @@ Each view has its own configuration class with sensible defaults. Expand the ref
 <details>
   <summary>MonthBodyConfiguration</summary>
 
+  <!-- snippet: expression -->
   ```dart
   CalendarBody(
     monthBodyConfiguration: MonthBodyConfiguration(
@@ -154,6 +160,7 @@ Each view has its own configuration class with sensible defaults. Expand the ref
 <details>
   <summary>ScheduleBodyConfiguration</summary>
 
+  <!-- snippet: expression -->
   ```dart
   CalendarBody(
     scheduleBodyConfiguration: ScheduleBodyConfiguration(

--- a/example/README.md
+++ b/example/README.md
@@ -3,6 +3,7 @@
 A complete calendar, using only the base `CalendarEvent` class with no custom fields.
 Tapping an empty slot creates an event, and events can be dragged and resized.
 
+<!-- snippet: file -->
 ```dart
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ each answer one question.
 | [riverpod](riverpod) | Sharing the events controller, the calendar controller and the selected view through providers. |
 | [web_demo](web_demo) | The source behind the [live demo](https://werner-scholtz.github.io/kalender/). Every option through a runtime configuration panel, theming, locales, text direction, timezones, and a desktop split view over one shared event store. |
 | [testing](testing) | A performance harness rather than an app. Drives the calendar through navigation, scrolling, rescheduling and resizing at 10 and 50 events per day and records frame build times. Feeds the [benchmarks dashboard](https://werner-scholtz.github.io/kalender/dev/bench/). |
+| [doc_snippets](doc_snippets) | Not an app either. Holds the placeholder identifiers that `tool/analyze_doc_snippets.dart` compiles the documentation snippets against. |
 
 Run any of them from its own directory:
 

--- a/examples/doc_snippets/analysis_options.yaml
+++ b/examples/doc_snippets/analysis_options.yaml
@@ -1,0 +1,11 @@
+# The generated snippets are checked for whether they compile, not for style, so
+# no lint set is included. Analyzer errors and warnings are the signal.
+analyzer:
+  errors:
+    # Every snippet gets the same import header, so most of it is unused in most
+    # of them. That says nothing about whether the snippet compiles.
+    unnecessary_import: ignore
+    unused_element: ignore
+    unused_import: ignore
+    unused_local_variable: ignore
+    unused_shown_name: ignore

--- a/examples/doc_snippets/lib/preamble.dart
+++ b/examples/doc_snippets/lib/preamble.dart
@@ -1,0 +1,84 @@
+// Identifiers the guides use as placeholders, so a snippet can show the line
+// that matters without the scaffolding around it.
+//
+// This file is analyzed like any other, so the stubs stay honest: if a signature
+// in the package changes, the stub stops compiling here first.
+
+import 'package:flutter/material.dart';
+import 'package:kalender/kalender.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+/// The custom event subclass the guides build on, as defined in doc/events.md.
+class Event extends CalendarEvent {
+  Event({
+    super.id,
+    required super.dateTimeRange,
+    required this.title,
+    this.description,
+    this.color,
+    super.interaction,
+    super.multiDayRule,
+  });
+
+  final String title;
+  final String? description;
+  final Color? color;
+
+  @override
+  Event copyWith({
+    DateTimeRange? dateTimeRange,
+    EventInteraction? interaction,
+    String? title,
+    String? description,
+    Color? color,
+  }) {
+    return Event(
+      id: id,
+      dateTimeRange: dateTimeRange ?? this.dateTimeRange,
+      interaction: interaction ?? this.interaction,
+      multiDayRule: multiDayRule,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      color: color ?? this.color,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return super == other &&
+        other is Event &&
+        other.title == title &&
+        other.description == description &&
+        other.color == color;
+  }
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, title, description, color);
+}
+
+/// Stands in for a widget the reader supplies.
+Widget CustomWidget() => const SizedBox.shrink();
+
+/// Stands in for the reader's app widget, which several snippets pass to
+/// `runApp`. A snippet that declares its own shadows this one.
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+final eventsController = DefaultEventsController();
+final calendarController = CalendarController();
+final viewConfiguration = MultiDayViewConfiguration.week();
+
+final location = tz.getLocation('UTC');
+final range =
+    DateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2025, 1, 2));
+final event = CalendarEvent(dateTimeRange: range);
+const someId = 'an-event-id';
+
+/// Stands in for a positioner the reader writes, see doc/appearance.md.
+ResizeHandlePositioner get myResizeHandlePositioner =>
+    throw UnimplementedError();

--- a/examples/doc_snippets/pubspec.yaml
+++ b/examples/doc_snippets/pubspec.yaml
@@ -1,0 +1,15 @@
+name: doc_snippets
+description: Compiles the Dart snippets extracted from the README and the doc/ guides.
+publish_to: none
+version: 0.0.0
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  intl: '>=0.19.0 <0.23.0'
+  kalender:
+    path: ../..
+  timezone: '>=0.11.0 <0.12.0'

--- a/test/tool/analyze_doc_snippets_test.dart
+++ b/test/tool/analyze_doc_snippets_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/analyze_doc_snippets.dart'
+    show GeneratedUnit, SnippetError, SnippetKind, generateUnit, groupSnippets, mapDiagnostics, parseSnippets;
+
+/// Wraps [code] in a fenced dart block under [directive].
+String block(String directive, String code) => '# Title\n\nSome prose.\n\n$directive\n```dart\n$code\n```\n';
+
+void main() {
+  group('parseSnippets', () {
+    test('reads the directive and the code below it', () {
+      final snippets = parseSnippets(block('<!-- snippet: expression -->', 'CalendarBody()'), 'doc/a.md');
+      expect(snippets, hasLength(1));
+      expect(snippets.single.kind, SnippetKind.expression);
+      expect(snippets.single.code, 'CalendarBody()');
+      expect(snippets.single.path, 'doc/a.md');
+    });
+
+    test('the line points at the first code line, not the fence', () {
+      final snippets = parseSnippets(block('<!-- snippet: file -->', 'class A {}'), 'doc/a.md');
+      expect(snippets.single.line, 7);
+    });
+
+    test('a block with no directive is an error naming the file and line', () {
+      expect(
+        () => parseSnippets('# Title\n\n```dart\nclass A {}\n```\n', 'doc/a.md'),
+        throwsA(isA<SnippetError>().having((e) => e.message, 'message', contains('doc/a.md:3'))),
+      );
+    });
+
+    test('a skipped block must give a reason', () {
+      expect(
+        () => parseSnippets(block('<!-- snippet: skip -->', 'whatever'), 'doc/a.md'),
+        throwsA(isA<SnippetError>().having((e) => e.message, 'message', contains('must say why'))),
+      );
+      final skipped = parseSnippets(block('<!-- snippet: skip: pseudocode -->', 'whatever'), 'doc/a.md');
+      expect(skipped.single.kind, SnippetKind.skip);
+      expect(skipped.single.skipReason, 'pseudocode');
+    });
+
+    test('a continued block needs a compiled block above it', () {
+      expect(
+        () => parseSnippets(block('<!-- snippet: continues -->', 'class B {}'), 'doc/a.md'),
+        throwsA(isA<SnippetError>().having((e) => e.message, 'message', contains('needs a compiled block above it'))),
+      );
+    });
+
+    test('an indented block, as inside a details element, is dedented', () {
+      const markdown =
+          '<details>\n\n  <!-- snippet: expression -->\n  ```dart\n  CalendarBody(\n    x: 1,\n  )\n  ```\n';
+      final snippets = parseSnippets(markdown, 'doc/a.md');
+      expect(snippets.single.code, 'CalendarBody(\n  x: 1,\n)');
+    });
+
+    test('a blank line between the directive and the fence is allowed', () {
+      final snippets = parseSnippets('<!-- snippet: file -->\n\n```dart\nclass A {}\n```\n', 'doc/a.md');
+      expect(snippets.single.kind, SnippetKind.file);
+    });
+
+    test('a non-dart fence is ignored', () {
+      expect(parseSnippets('```bash\nflutter pub add kalender\n```\n', 'README.md'), isEmpty);
+    });
+  });
+
+  group('Snippet', () {
+    test('imports are lifted out of the body', () {
+      final snippet = parseSnippets(
+        block('<!-- snippet: file -->', "import 'package:flutter/gestures.dart';\n\nclass A {}"),
+        'doc/a.md',
+      ).single;
+      expect(snippet.imports, ["import 'package:flutter/gestures.dart';"]);
+      expect(snippet.body, 'class A {}');
+      expect(snippet.bodyOffset, 2);
+    });
+  });
+
+  group('groupSnippets', () {
+    test('a continued block joins the one above it, and skips are dropped', () {
+      const markdown = '<!-- snippet: file -->\n```dart\nclass A {}\n```\n'
+          '<!-- snippet: continues -->\n```dart\nclass B {}\n```\n'
+          '<!-- snippet: skip: prose -->\n```dart\nnot code\n```\n'
+          '<!-- snippet: file -->\n```dart\nclass C {}\n```\n';
+      final units = groupSnippets(parseSnippets(markdown, 'doc/a.md'));
+      expect(units, hasLength(2));
+      expect(units.first, hasLength(2));
+      expect(units.last, hasLength(1));
+    });
+  });
+
+  group('generateUnit', () {
+    GeneratedUnit unitFor(String directive, String code) =>
+        generateUnit(groupSnippets(parseSnippets(block(directive, code), 'doc/a.md')).single, 0);
+
+    test('an expression becomes a variable initializer', () {
+      final unit = unitFor('<!-- snippet: expression -->', 'CalendarBody()');
+      expect(unit.source, contains('final Object? _snippet0 =\nCalendarBody()\n;'));
+    });
+
+    test('statements become an async function body', () {
+      final unit = unitFor('<!-- snippet: statements -->', 'final a = 1;');
+      expect(unit.source, contains('Future<void> _snippet0() async {\nfinal a = 1;\n}'));
+    });
+
+    test('a file is used as it stands', () {
+      final unit = unitFor('<!-- snippet: file -->', 'class A {}');
+      expect(unit.source, contains('\nclass A {}\n'));
+      expect(unit.source, isNot(contains('_snippet0')));
+    });
+
+    test('every snippet may assume material and kalender, and nothing more', () {
+      final unit = unitFor('<!-- snippet: file -->', 'class A {}');
+      expect(unit.source, contains("import 'package:flutter/material.dart';"));
+      expect(unit.source, contains("import 'package:kalender/kalender.dart';"));
+      expect(unit.source, isNot(contains("import 'package:flutter/gestures.dart';")));
+      expect(unit.source, isNot(contains("import 'package:timezone/timezone.dart'")));
+    });
+
+    test("a snippet's own imports are added", () {
+      final unit = unitFor('<!-- snippet: file -->', "import 'package:flutter/gestures.dart';\n\nclass A {}");
+      expect(unit.source, contains("import 'package:flutter/gestures.dart';"));
+    });
+
+    test('each body line records the markdown line it came from', () {
+      final unit = unitFor('<!-- snippet: file -->', 'class A {\n  int x = 1;\n}');
+      final lines = unit.source.split('\n');
+      final classLine = lines.indexOf('class A {') + 1;
+      expect(unit.origins[classLine], (path: 'doc/a.md', line: 7));
+      expect(unit.origins[classLine + 1], (path: 'doc/a.md', line: 8));
+    });
+  });
+
+  group('mapDiagnostics', () {
+    test('a generated location becomes the markdown line a reader sees', () {
+      final unit = generateUnit(
+        groupSnippets(parseSnippets(block('<!-- snippet: file -->', 'class A {\n  int x = 1;\n}'), 'doc/a.md')).single,
+        0,
+      );
+      final generatedLine = unit.source.split('\n').indexOf('  int x = 1;') + 1;
+
+      final mapped = mapDiagnostics(
+        '  error • Something went wrong • lib/generated/snippet_0.dart:$generatedLine:7 • some_code',
+        {'snippet_0.dart': unit},
+      );
+
+      expect(mapped.single, contains('doc/a.md:8:7'));
+      expect(mapped.single, isNot(contains('snippet_0.dart')));
+    });
+
+    test('a diagnostic on the generated header is passed through unchanged', () {
+      final unit = generateUnit(
+        groupSnippets(parseSnippets(block('<!-- snippet: file -->', 'class A {}'), 'doc/a.md')).single,
+        0,
+      );
+      final mapped = mapDiagnostics(
+        '  error • Bad import • lib/generated/snippet_0.dart:3:1 • some_code',
+        {'snippet_0.dart': unit},
+      );
+      expect(mapped.single, contains('snippet_0.dart:3:1'));
+    });
+
+    test('lines that are not diagnostics are dropped', () {
+      expect(mapDiagnostics('Analyzing lib/generated...\n\n2 issues found.', const {}), isEmpty);
+    });
+  });
+}

--- a/tool/analyze_doc_snippets.dart
+++ b/tool/analyze_doc_snippets.dart
@@ -1,0 +1,334 @@
+// Compiles every Dart snippet in the README and the doc/ guides.
+//
+// The snippets are the first code a reader copies, so a snippet that no longer
+// compiles is a broken promise. `flutter analyze` at the root cannot catch it,
+// because the code lives in markdown.
+//
+// Each fenced dart block must be preceded by a directive comment saying how to
+// compile it. A block without one is an error, so a new snippet cannot be added
+// unchecked:
+//
+//   <!-- snippet: file -->          top-level declarations, used as they are
+//   <!-- snippet: statements -->    wrapped in an async function body
+//   <!-- snippet: expression -->    wrapped in a variable initializer
+//   <!-- snippet: continues -->     appended to the block above, for an example
+//                                   split by prose
+//   <!-- snippet: skip: reason -->  not compiled, reason required
+//
+// A snippet may assume only material.dart and kalender.dart. Anything else it
+// uses has to be imported in the block, so a snippet a reader copies whole
+// really does compile. Identifiers the docs use as placeholders, such as the
+// Event subclass, come from examples/doc_snippets/lib/preamble.dart.
+//
+// Usage: dart run tool/analyze_doc_snippets.dart
+
+import 'dart:io';
+
+/// Where the generated package lives, relative to the repository root.
+const snippetPackage = 'examples/doc_snippets';
+
+/// The imports every snippet may assume, because every file using this package
+/// already has them.
+///
+/// Deliberately short. Anything else has to appear in the snippet itself, so a
+/// snippet that presents as a file a reader can copy really is one. A wider
+/// header would have hidden the missing `gestures.dart` and `services.dart` in
+/// the zoom example, which is the failure this tool exists to catch.
+const impliedImports = <String>[
+  "import 'package:flutter/material.dart';",
+  "import 'package:kalender/kalender.dart';",
+  "import 'package:doc_snippets/preamble.dart';",
+];
+
+/// A directive comment naming how the block below it is compiled.
+final directivePattern =
+    RegExp(r'^\s*<!--\s*snippet:\s*(file|statements|expression|continues|skip)\s*(?::\s*(.*?))?\s*-->\s*$');
+
+/// The opening of a fenced dart block, capturing its indentation.
+final fenceOpenPattern = RegExp(r'^(\s*)```dart\s*$');
+
+/// An import or export line, which is lifted out of a snippet.
+final importPattern = RegExp(r"^\s*(?:import|export)\s+'[^']+'.*;\s*$");
+
+/// How a snippet is compiled.
+enum SnippetKind { file, statements, expression, continues, skip }
+
+/// A dart block found in a markdown file.
+class Snippet {
+  Snippet({required this.path, required this.line, required this.kind, required this.code, this.skipReason});
+
+  /// The markdown file the block came from.
+  final String path;
+
+  /// The 1-based line of the block's first code line.
+  final int line;
+
+  final SnippetKind kind;
+
+  /// The block, dedented, with imports still in place.
+  final String code;
+
+  final String? skipReason;
+
+  /// The import lines lifted out of [code].
+  List<String> get imports => code.split('\n').where(importPattern.hasMatch).map((line) => line.trim()).toList();
+
+  /// [code] without its import lines, and without the blank run they leave.
+  String get body {
+    final lines = code.split('\n').where((line) => !importPattern.hasMatch(line)).toList();
+    while (lines.isNotEmpty && lines.first.trim().isEmpty) {
+      lines.removeAt(0);
+    }
+    return lines.join('\n').trimRight();
+  }
+
+  /// How many lines [body] dropped from the front of [code], so a diagnostic can
+  /// be reported against the line the reader sees.
+  int get bodyOffset {
+    final lines = code.split('\n');
+    var offset = 0;
+    while (offset < lines.length && (importPattern.hasMatch(lines[offset]) || lines[offset].trim().isEmpty)) {
+      offset++;
+    }
+    return offset;
+  }
+}
+
+/// A missing or malformed directive, reported with the line to fix.
+class SnippetError implements Exception {
+  SnippetError(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+/// Every dart block in [markdown], in order.
+///
+/// Throws a [SnippetError] if a block has no directive above it.
+List<Snippet> parseSnippets(String markdown, String path) {
+  final lines = markdown.split('\n');
+  final snippets = <Snippet>[];
+
+  for (var i = 0; i < lines.length; i++) {
+    final open = fenceOpenPattern.firstMatch(lines[i]);
+    if (open == null) continue;
+
+    final indent = open.group(1)!;
+    final closing = '$indent```';
+
+    // Collect the block.
+    final code = <String>[];
+    var end = i + 1;
+    while (end < lines.length && lines[end].trimRight() != closing.trimRight()) {
+      code.add(_dedent(lines[end], indent));
+      end++;
+    }
+
+    final directive = _directiveAbove(lines, i);
+    if (directive == null) {
+      throw SnippetError(
+        '$path:${i + 1}: this dart block has no snippet directive above it.\n'
+        '  Add one of: <!-- snippet: file -->, <!-- snippet: statements -->, '
+        '<!-- snippet: expression -->, <!-- snippet: skip: reason -->',
+      );
+    }
+
+    final kind = SnippetKind.values.byName(directive.group(1)!);
+    final reason = directive.group(2);
+    if (kind == SnippetKind.skip && (reason == null || reason.trim().isEmpty)) {
+      throw SnippetError('$path:${i + 1}: a skipped snippet must say why, as <!-- snippet: skip: reason -->');
+    }
+    if (kind == SnippetKind.continues && snippets.every((s) => s.kind == SnippetKind.skip)) {
+      throw SnippetError('$path:${i + 1}: a continued snippet needs a compiled block above it in the same file');
+    }
+
+    snippets.add(
+      Snippet(path: path, line: i + 2, kind: kind, code: code.join('\n'), skipReason: reason),
+    );
+    i = end;
+  }
+
+  return snippets;
+}
+
+/// The directive comment above the fence at [fenceIndex], skipping blank lines.
+RegExpMatch? _directiveAbove(List<String> lines, int fenceIndex) {
+  for (var i = fenceIndex - 1; i >= 0; i--) {
+    if (lines[i].trim().isEmpty) continue;
+    return directivePattern.firstMatch(lines[i]);
+  }
+  return null;
+}
+
+/// [line] with [indent] removed from its front, when it is there.
+String _dedent(String line, String indent) {
+  if (indent.isEmpty) return line;
+  return line.startsWith(indent) ? line.substring(indent.length) : line.trimLeft();
+}
+
+/// One generated file, with the markdown line each of its lines came from.
+class GeneratedUnit {
+  GeneratedUnit({required this.name, required this.source, required this.origins});
+
+  final String name;
+  final String source;
+
+  /// 1-based generated line to the markdown line a reader sees.
+  final Map<int, ({String path, int line})> origins;
+}
+
+/// Groups snippets so that each `continues` block joins the block above it.
+List<List<Snippet>> groupSnippets(List<Snippet> snippets) {
+  final units = <List<Snippet>>[];
+  for (final snippet in snippets) {
+    if (snippet.kind == SnippetKind.skip) continue;
+    if (snippet.kind == SnippetKind.continues && units.isNotEmpty) {
+      units.last.add(snippet);
+    } else {
+      units.add([snippet]);
+    }
+  }
+  return units;
+}
+
+/// The Dart source compiled for [unit], recording where every line came from so
+/// a diagnostic points at the markdown a reader sees.
+GeneratedUnit generateUnit(List<Snippet> unit, int index) {
+  final base = unit.first;
+  final imports = <String>{...impliedImports, for (final s in unit) ...s.imports}.toList()..sort();
+
+  final out = <String>[
+    '// Generated from ${base.path}. Do not edit.',
+    '// ignore_for_file: type=lint',
+    ...imports,
+    '',
+  ];
+  final origins = <int, ({String path, int line})>{};
+
+  void emit(Snippet snippet) {
+    final firstMarkdownLine = snippet.line + snippet.bodyOffset;
+    final bodyLines = snippet.body.split('\n');
+    for (var i = 0; i < bodyLines.length; i++) {
+      out.add(bodyLines[i]);
+      origins[out.length] = (path: snippet.path, line: firstMarkdownLine + i);
+    }
+  }
+
+  switch (base.kind) {
+    case SnippetKind.file:
+    case SnippetKind.continues:
+      emit(base);
+    case SnippetKind.statements:
+      out.add('Future<void> _snippet$index() async {');
+      emit(base);
+      out.add('}');
+    case SnippetKind.expression:
+      out.add('final Object? _snippet$index =');
+      emit(base);
+      out.add(';');
+    case SnippetKind.skip:
+      throw StateError('a skipped snippet is never generated');
+  }
+
+  for (final continuation in unit.skip(1)) {
+    out.add('');
+    emit(continuation);
+  }
+
+  return GeneratedUnit(name: 'snippet_$index.dart', source: '${out.join('\n')}\n', origins: origins);
+}
+
+/// The markdown files whose snippets are compiled.
+List<String> snippetSources() {
+  final docs = Directory('doc').existsSync()
+      ? (Directory('doc').listSync().whereType<File>().map((f) => f.path).where((p) => p.endsWith('.md')).toList()
+        ..sort())
+      : <String>[];
+  return ['README.md', 'example/README.md', ...docs];
+}
+
+void main(List<String> args) async {
+  final sources = snippetSources();
+  final snippets = <Snippet>[];
+
+  try {
+    for (final path in sources) {
+      final file = File(path);
+      if (!file.existsSync()) continue;
+      snippets.addAll(parseSnippets(file.readAsStringSync(), path));
+    }
+  } on SnippetError catch (error) {
+    stderr.writeln(error.message);
+    exit(1);
+  }
+
+  final compiled = snippets.where((s) => s.kind != SnippetKind.skip).toList();
+  final skipped = snippets.where((s) => s.kind == SnippetKind.skip).toList();
+  final units = groupSnippets(snippets);
+
+  final generated = Directory('$snippetPackage/lib/generated');
+  if (generated.existsSync()) generated.deleteSync(recursive: true);
+  generated.createSync(recursive: true);
+
+  final byFile = <String, GeneratedUnit>{};
+  for (var i = 0; i < units.length; i++) {
+    final unit = generateUnit(units[i], i);
+    File('${generated.path}/${unit.name}').writeAsStringSync(unit.source);
+    byFile[unit.name] = unit;
+  }
+
+  stdout.writeln('Compiling ${compiled.length} snippets from ${sources.length} files.');
+  for (final snippet in skipped) {
+    stdout.writeln('  skipped ${snippet.path}:${snippet.line} (${snippet.skipReason})');
+  }
+
+  final pubGet = await Process.run('flutter', ['pub', 'get'], workingDirectory: snippetPackage);
+  if (pubGet.exitCode != 0) {
+    stderr.writeln(pubGet.stdout);
+    stderr.writeln(pubGet.stderr);
+    exit(1);
+  }
+
+  final analyze = await Process.run('flutter', ['analyze', 'lib/generated'], workingDirectory: snippetPackage);
+  final output = '${analyze.stdout}${analyze.stderr}';
+
+  if (analyze.exitCode == 0) {
+    stdout.writeln('All snippets compile.');
+    exit(0);
+  }
+
+  stderr.writeln('\nSnippets that do not compile:\n');
+  for (final line in mapDiagnostics(output, byFile)) {
+    stderr.writeln(line);
+  }
+  exit(1);
+}
+
+/// A generated-file location in an analyzer diagnostic.
+final diagnosticLocation = RegExp(r'lib[/\\]generated[/\\](snippet_\d+\.dart):(\d+):(\d+)');
+
+/// Rewrites analyzer diagnostics so they point at the markdown line a reader
+/// sees rather than at the generated file.
+List<String> mapDiagnostics(String output, Map<String, GeneratedUnit> byFile) {
+  final mapped = <String>[];
+
+  for (final line in output.split('\n')) {
+    final match = diagnosticLocation.firstMatch(line);
+    if (match == null) {
+      if (line.trim().isNotEmpty && line.contains('•')) mapped.add(line);
+      continue;
+    }
+
+    final unit = byFile[match.group(1)!];
+    final origin = unit?.origins[int.parse(match.group(2)!)];
+    if (origin == null) {
+      // A diagnostic on the generated header, which no markdown line produced.
+      mapped.add(line);
+      continue;
+    }
+
+    mapped.add(line.replaceRange(match.start, match.end, '${origin.path}:${origin.line}:${match.group(3)}'));
+  }
+
+  return mapped;
+}


### PR DESCRIPTION
## Description

The snippets are the first code a reader copies, and nothing checked that they still compiled. `flutter analyze` cannot see them, because they live in markdown. AGENTS.md already records a `copyWith` change that broke all seven examples while the root analyze stayed green, and the zoom example in the views guide had been missing two imports for as long as it had been there.

`tool/analyze_doc_snippets.dart` extracts all 41 blocks from `README.md`, `example/README.md` and `doc/*.md`, compiles them, and reports failures against the markdown line rather than the generated file.

Each block carries a directive comment saying how it is compiled, and a block without one fails the run, so a new snippet cannot go in unchecked:

```markdown
<!-- snippet: file -->          top-level declarations
<!-- snippet: statements -->    wrapped in an async function body
<!-- snippet: expression -->    wrapped in a variable initializer
<!-- snippet: continues -->     appended to the block above, for an example split by prose
<!-- snippet: skip: reason -->  not compiled, reason required
```

**A snippet may assume only `material.dart` and `kalender.dart`.** The first version of the tool implied a wider header and, tested against the zoom example with its imports removed again, passed. It would not have caught the bug it was built for. Anything beyond those two now has to appear in the block, which is also what a reader needs to see.

That rule found three more snippets that named `DateFormat` or `tz` without saying where either comes from, and five showing a partial `CalendarView` call missing its required arguments. Those now show the `CalendarComponents` value the prose already tells you to pass, or the full call.

Placeholder identifiers come from `examples/doc_snippets/lib/preamble.dart`, which is analyzed with everything else so the stubs cannot drift. Only the package skeleton is committed; `lib/generated/` is gitignored.

Also documents where the timeline's time format comes from. The times down the side of a multi-day view are the one string that does not follow the calendar's `locale`. They use Flutter's `TimeOfDay.format`, so they follow the device's 12-hour or 24-hour setting, which was written down nowhere.

## Testing
- [x] Unit Tests Added/Updated
- [ ] Widget Tests Added/Updated (if applicable)

`test/tool/analyze_doc_snippets_test.dart` covers directive parsing, the missing-directive and missing-reason errors, dedenting an indented block inside a `details` element, import lifting, grouping continuations, each wrapping mode, the implied import set, and mapping a diagnostic back to its markdown line.

The tool was checked to fail correctly by removing the zoom snippet's imports again and confirming it reports `doc/interaction.md` at the right lines.

## Checklist
- [x] I have run `flutter analyze` and fixed any issues
- [x] I have run `dart format .`

## Additional Notes

The new job cannot join the `analyze_examples.yml` matrix, which only runs `flutter analyze` with no generation step, so it is a separate job in `flutter_analyze_and_test.yml`.

Last of four stacked PRs. Based on #392.