### PR TITLE
docs: make the feature list sell, and rewrite the pub.dev description

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 # Kalender
 
-A highly customizable Flutter calendar widget with Day, MultiDay, Month, and Schedule views. It supports drag-and-drop rescheduling, event resizing, timezones, and full control over appearance and behavior.
+A highly customizable Flutter calendar widget with Day, Multi-day, Month and Schedule views. It supports drag-and-drop rescheduling, event resizing, timezones, and full control over appearance and behavior.
 
 **[Live Demo](https://werner-scholtz.github.io/kalender/)** · **[Benchmarks](https://werner-scholtz.github.io/kalender/dev/bench/)** · **[Migration Guide](MIGRATION.md)**
 
@@ -32,23 +32,14 @@ A highly customizable Flutter calendar widget with Day, MultiDay, Month, and Sch
 
 ## Features
 
-| Feature | What you get | Guide |
-| --- | --- | --- |
-| **Views** | Day, Multi-day, Month and Schedule, switched by passing a different configuration. | [Views](doc/views.md) |
-| **Extensible events** | Attach custom data (title, color, anything) by subclassing `CalendarEvent`. | [Events](doc/events.md#custom-events) |
-| **Reschedule** | Drag and drop events between days and times. | [Interaction](doc/interaction.md) |
-| **Resize** | Handles that adapt to mouse, stylus, trackpad or touch input. | [Interaction](doc/interaction.md) |
-| **Snapping** | Snap to an interval, to the time indicator, to other events, or to your own strategy. | [Interaction](doc/interaction.md#interaction--snapping) |
-| **Zoom** | Change the height per minute to zoom the day in and out. | [Interaction](doc/interaction.md#zoom) |
-| **Controllers** | Drive the calendar from code and watch what is on screen. | [Controllers & Callbacks](doc/controllers-and-callbacks.md#controllers) |
-| **Callbacks** | React to taps, long presses, event creation and changes. | [Controllers & Callbacks](doc/controllers-and-callbacks.md#callbacks) |
-| **Tile components** | Customize the stationary, dragging, feedback and resize-handle tiles. | [Appearance](doc/appearance.md#tile-components) |
-| **Theming** | Follows your Material 3 theme, or register a `KalenderThemeData`. | [Appearance](doc/appearance.md#theming) |
-| **Custom components** | Replace any default widget, or restyle it without writing one. | [Appearance](doc/appearance.md#appearance--custom-components) |
-| **Event layout** | Use a built-in layout strategy or supply your own. | [Layout](doc/layout.md) |
-| **Locale** | Localize day and month names via [intl](https://pub.dev/packages/intl), and replace any string. | [Timezones & Locales](doc/timezones-and-locales.md#locale) |
-| **Location** | Timezone-aware display via the [timezone](https://pub.dev/packages/timezone) package. | [Timezones & Locales](doc/timezones-and-locales.md#location) |
-| **Now callback** | Override what "now" means for the time indicator and today highlighting, for when the calendar's `Location` differs from the user's wall-clock time. | [Timezones & Locales](doc/timezones-and-locales.md#now-callback) |
+- **Four views, one widget.** Day, Multi-day, Month and Schedule. Swap the configuration and your events, controllers and styling carry over.
+- **Reschedule by hand.** Drag events between days and times, resize with handles that adapt to mouse, stylus, trackpad and touch, and zoom the day in and out.
+- **Snapping that fits your app.** Snap to an interval, to the time indicator, to other events, or to a rule you write.
+- **Your data on every event.** Subclass `CalendarEvent` and read your own fields in every builder. There is no fixed event model to work around.
+- **Driven from code too.** Controllers navigate, jump to a date and expose what is on screen. Callbacks fire on taps, long presses, event creation and changes.
+- **Replaceable, not just configurable.** Swap any default widget for your own, or keep it and restyle it. Follows your Material 3 theme out of the box.
+- **Timezone aware.** Events are stored as UTC and displayed in any IANA location, so a calendar can show a zone the device is not in.
+- **Localized, down to the last string.** Day and month names come from intl, and every piece of text the calendar writes can be replaced.
 
 ## Installation
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: kalender
-description: This Flutter package offers a Calendar Widget featuring Day, MultiDay, Month and Schedule views. Moreover, it empowers you to tailor the visual aspects of the calendar widget.
+description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
 version: 0.24.0-dev.2
 repository: https://github.com/werner-scholtz/kalender.git
 topics: 


### PR DESCRIPTION
Follow-up to #390-#393, after looking at the rendered page.

## Features section

The table had fifteen rows across three columns. Its Guide column repeated seven links (Interaction three times, Appearance three, Timezones & Locales three, Controllers & Callbacks twice), and the long link text wrapped most rows onto two lines. It also duplicated the Documentation section forty lines below, which already lists all seven guides with a description each.

It is now eight bullets with no links. The section describes the package, and the Documentation section does the routing. Event layout and the now callback lose their headline mention and stay documented in their guides.

## pub.dev description

Before:

> This Flutter package offers a Calendar Widget featuring Day, MultiDay, Month and Schedule views. Moreover, it empowers you to tailor the visual aspects of the calendar widget.

175 of the 180 characters pub.dev prefers, with the first thirty spent on "This Flutter package offers a", "calendar widget" used twice, and no mention of drag-and-drop rescheduling.

After, at 150 characters:

> A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.

The README's opening sentence now spells it "Multi-day" to match. The five remaining "MultiDay" spellings name the API (`MultiDayViewConfiguration`, `MultiDayBody`, `MultiDayHeader`) and are unchanged.

No changelog entry: the section is documentation and the description is package metadata.

## Verification

- All seven guides still linked from the Documentation section, plus `doc/README.md` and `examples/README.md`.
- 56 relative links and anchors checked, 0 broken.
- `dart run tool/analyze_doc_snippets.dart`: 41 snippets, all compile.
- `flutter test`: 1568 passed.
- `flutter pub get` parses the new description.