### PR TITLE
ci: set the test timezone with TZ only

### DIFF
--- a/.github/workflows/flutter_analyze_and_test.yml
+++ b/.github/workflows/flutter_analyze_and_test.yml
@@ -69,14 +69,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
 
-      - name: Set Time Zone
-        run: sudo timedatectl set-timezone ${{ matrix.timezone }}
-        shell: bash
-
-      - name: Verify Time Zone
-        run: timedatectl | grep "Time zone"
-        shell: bash
-
       - name: Install dependencies
         run: flutter pub get
         shell: bash


### PR DESCRIPTION
Every entry in the timezone matrix is failing, and has been since a GitHub runner image change overnight. `main` was green at 2026-07-29 14:17 UTC and red by 2026-07-30 05:20 UTC with no repository change in between.

The failure is in setup, before any Dart runs:

```
Run sudo timedatectl set-timezone UTC
Failed to set time zone: Access denied
##[error]Process completed with exit code 1.
```

`timedatectl` is a D-Bus call to `systemd-timedated` gated by polkit, not a file write, so `sudo` gets root but not an authorization. The runner image stopped permitting it.

## The step was redundant

The test step already sets the timezone the only way that matters:

```yaml
- name: Run tests (${{ matrix.timezone }})
  run: flutter test
  env:
    TZ: ${{ matrix.timezone }}
```

`TZ` is what the Dart VM reads on Linux, and `tool/test_timezones_linux.dart`, the local mirror of this matrix, has always used `TZ` alone with no `timedatectl`.

Both steps are removed. The verify step goes too, since reading the timezone is also a `timedatectl` call and fails the same way.

## Verification

- `TZ=Asia/Tokyo` reports JST +9, `TZ=America/New_York` reports EDT -4, `TZ=UTC` reports UTC.
- Full suite run locally under `TZ=Asia/Tokyo` and `TZ=America/New_York`: 1568 passed each.
- This PR exercises the change, since `pull_request` runs the workflow from the merge commit.

#394 is blocked on this and will need a rebase once it lands.