### PR TITLE
docs: fill the image row, and shorten the feature bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,24 +22,25 @@ A highly customizable Flutter calendar widget with Day, Multi-day, Month and Sch
 > 1.0.0 is close. If part of the API does not work for you, please [open an issue](https://github.com/werner-scholtz/kalender/issues).
 
 <p align="center">
-  <img src="readme_assets/desktop_light.png" alt="Week view on desktop, light theme" width="55%" />
-  <img src="readme_assets/mobile_light.png" alt="Three-day view on mobile, light theme" width="17%" />
+  <img src="readme_assets/desktop_light.png" alt="Week view on desktop, light theme" width="74%" />
+  <img src="readme_assets/mobile_light.png" alt="Three-day view on mobile, light theme" width="23%" />
 </p>
 <p align="center">
-  <img src="readme_assets/desktop_dark.png" alt="Week view on desktop, dark theme" width="55%" />
-  <img src="readme_assets/mobile_dark.png" alt="Three-day view on mobile, dark theme" width="17%" />
+  <img src="readme_assets/desktop_dark.png" alt="Week view on desktop, dark theme" width="74%" />
+  <img src="readme_assets/mobile_dark.png" alt="Three-day view on mobile, dark theme" width="23%" />
 </p>
 
 ## Features
 
-- **Four views, one widget.** Day, Multi-day, Month and Schedule. Swap the configuration and your events, controllers and styling carry over.
-- **Reschedule by hand.** Drag events between days and times, resize with handles that adapt to mouse, stylus, trackpad and touch, and zoom the day in and out.
-- **Snapping that fits your app.** Snap to an interval, to the time indicator, to other events, or to a rule you write.
-- **Your data on every event.** Subclass `CalendarEvent` and read your own fields in every builder. There is no fixed event model to work around.
-- **Driven from code too.** Controllers navigate, jump to a date and expose what is on screen. Callbacks fire on taps, long presses, event creation and changes.
-- **Replaceable, not just configurable.** Swap any default widget for your own, or keep it and restyle it. Follows your Material 3 theme out of the box.
-- **Timezone aware.** Events are stored as UTC and displayed in any IANA location, so a calendar can show a zone the device is not in.
-- **Localized, down to the last string.** Day and month names come from intl, and every piece of text the calendar writes can be replaced.
+- **Four views, one widget.** Day, Multi-day, Month and Schedule.
+- **Reschedule by hand.** Drag, resize and zoom, on mouse, stylus, trackpad or touch.
+- **Snapping you control.** To an interval, the time indicator, other events, or your own rule.
+- **No fixed event model.** Subclass `CalendarEvent` and read your own fields anywhere.
+- **Controllers and callbacks.** Navigate from code, and react to taps, creation and changes.
+- **Replaceable, not just configurable.** Swap any widget, or keep it and restyle it.
+- **Material 3 by default.** Follows your app's theme with no setup.
+- **Timezone aware.** Events stored as UTC, shown in any IANA location.
+- **Localized.** Day and month names from intl, and every string replaceable.
 
 ## Installation
 


### PR DESCRIPTION
Two things spotted on the published 0.24.0-dev.3 page.

## Screenshots

They were sized 55% and 17%, so the row stopped at 72% of the container and left a band of empty space down the right.

Now 74% and 23%. Equal rendered heights need a width ratio of 1.69492 / 0.525547 = 3.225 (desktop is 1200x708, mobile 360x685), and 74/23 is 3.217, so the two stay within a pixel of the same height. The remaining 3% leaves room for the inline whitespace between the two `<img>` tags, which would otherwise push the mobile image onto its own line.

## Feature bullets

Every bullet ran onto a second line, so the bold lead-in stopped reading as a label and the list lost its scannability.

Each is now one line, longest 89 characters against roughly 95 that fit at pub.dev's content width.

Two changed by more than length:

- **"Your data on every event" is now "No fixed event model."** That phrase was the differentiator and it was buried in a trailing second sentence. It earns the lead.
- **Material 3 gets its own bullet.** It was the tail of the "Replaceable, not just configurable" bullet, which was carrying two separate ideas. This is why the count goes from 8 to 9.

Dropped along the way: "jump to a date" and "long presses", both covered in the guides.

## Verification

- 56 relative links and anchors checked, 0 broken.
- No fenced code changed, so the snippet tool is unaffected.

README only, so this will not show on pub.dev until the next release.
