### PR TITLE
docs: correct the dartdoc that ships to pub.dev

### DIFF
--- a/lib/src/calendar_view.dart
+++ b/lib/src/calendar_view.dart
@@ -95,7 +95,7 @@ class CalendarViewState extends State<CalendarView> {
     widget.calendarController.attach(_viewController);
   }
 
-  /// TODO: This needs to be improved on.
+  // TODO: This needs to be improved on.
   @override
   void didUpdateWidget(covariant CalendarView oldWidget) {
     super.didUpdateWidget(oldWidget);

--- a/lib/src/models/calendar_callbacks.dart
+++ b/lib/src/models/calendar_callbacks.dart
@@ -10,16 +10,16 @@ import 'package:kalender/src/widgets/drag_targets/vertical_drag_target.dart';
 class CalendarCallbacks {
   /// The callback for when an event is tapped.
   ///
-  /// If you provide neither [onEventTapped] nor [onEventTappedWithDetail],
-  /// Then the [GestureDetector] will not be enabled, and you can use your own gesture detector for event tiles.
-  /// /// See TODO: add link to event mixins.
+  /// If you provide neither [onEventTapped] nor [onEventTappedWithDetail], the [GestureDetector] is not enabled,
+  /// and a gesture detector inside your own tile receives the gesture instead. See [DayEventTileUtils] and
+  /// [MultiDayEventTileUtils] for tiles that resolve the tapped position themselves.
   final OnEventTapped? onEventTapped;
 
   /// The callback for when an event is tapped, with details.
   ///
-  /// If you provide neither [onEventTapped] nor [onEventTappedWithDetail],
-  /// Then the [GestureDetector] will not be enabled, and you can use your own gesture detector for event tiles.
-  /// /// See TODO: add link to event mixins.
+  /// If you provide neither [onEventTapped] nor [onEventTappedWithDetail], the [GestureDetector] is not enabled,
+  /// and a gesture detector inside your own tile receives the gesture instead. See [DayEventTileUtils] and
+  /// [MultiDayEventTileUtils] for tiles that resolve the tapped position themselves.
   final OnEventTappedWithDetail? onEventTappedWithDetail;
 
   /// The callback for when an event is secondary tapped.
@@ -63,7 +63,7 @@ class CalendarCallbacks {
   /// visible viewport. Only fires for views with vertical scroll (day/week/etc).
   final OnScrollPositionChanged? onScrollPositionChanged;
 
-  /// TODO: Check how these interact with the [Draggable] and [LongPressDraggable]s.
+  // TODO: Check how these interact with the Draggable and LongPressDraggables.
 
   /// The callback for when a user taps on the calendar.
   final OnTapped? onTapped;
@@ -190,8 +190,7 @@ class CalendarCallbacks {
 ///
 /// The [event] is the event that was tapped.
 /// The [renderBox] is the [RenderBox] of the event tile.
-///
-/// TODO: Remove renderBox in 1.0.0 as it is now included in the [OnEventTappedWithDetail].
+// TODO: Remove renderBox in 1.0.0 as it is now included in the OnEventTappedWithDetail.
 typedef OnEventTapped = void Function(CalendarEvent event, RenderBox renderBox);
 
 /// The callback for when an event is tapped.
@@ -200,8 +199,7 @@ typedef OnEventTapped = void Function(CalendarEvent event, RenderBox renderBox);
 /// The [renderBox] is the [RenderBox] of the event tile.
 /// The [detail] is the details of the date that was tapped.
 /// - The [detail] can be a [DayDetail] or a [MultiDayDetail].
-///
-/// TODO: Remove renderBox in 1.0.0 as it is now included in the detail.
+// TODO: Remove renderBox in 1.0.0 as it is now included in the detail.
 typedef OnEventTappedWithDetail = void Function(
   CalendarEvent event,
   RenderBox renderBox,

--- a/lib/src/models/calendar_events/calendar_event.dart
+++ b/lib/src/models/calendar_events/calendar_event.dart
@@ -12,7 +12,13 @@ import 'package:kalender/src/models/calendar_events/multi_day_rule.dart';
 ///
 /// ```dart
 /// class Event extends CalendarEvent {
-///   Event({super.id, required super.dateTimeRange, required this.title, super.interaction});
+///   Event({
+///     super.id,
+///     required super.dateTimeRange,
+///     required this.title,
+///     super.interaction,
+///     super.multiDayRule,
+///   });
 ///   final String title;
 ///
 ///   @override
@@ -21,6 +27,8 @@ import 'package:kalender/src/models/calendar_events/multi_day_rule.dart';
 ///         id: id,
 ///         dateTimeRange: dateTimeRange ?? this.dateTimeRange,
 ///         interaction: interaction ?? this.interaction,
+///         // copyWith takes no multiDayRule parameter. Forward it so copies keep the rule.
+///         multiDayRule: multiDayRule,
 ///         title: title ?? this.title,
 ///       );
 ///

--- a/lib/src/models/calendar_interaction.dart
+++ b/lib/src/models/calendar_interaction.dart
@@ -46,8 +46,7 @@ enum InputMode {
 }
 
 /// The [CreateEventGesture] is used to differentiate between the different ways to create an event.
-///
-/// TODO: Rename this to EventInteractionGesture.
+// TODO: Rename this to EventInteractionGesture.
 enum CreateEventGesture {
   /// Creates event on tap gesture.
   tap,
@@ -235,10 +234,7 @@ class EventInteraction {
     this.allowRescheduling = true,
   });
 
-  /// Creates an [EventInteraction] from the now deprecated [canModify] property.
-  ///
-  /// This constructor maintains backward compatibility by setting all interaction
-  /// permissions based on a single boolean value.
+  /// Creates an [EventInteraction] with every permission set to [canModify].
   EventInteraction.fromCanModify(bool canModify)
       : allowStartResize = canModify,
         allowEndResize = canModify,

--- a/lib/src/models/components/schedule_components.dart
+++ b/lib/src/models/components/schedule_components.dart
@@ -10,7 +10,7 @@ class ScheduleComponents {
 
   /// Builds the day name displayed above the day number.
   ///
-  /// Defaults to the first three characters of the day name in the calendar's locale.
+  /// Defaults to the short day name in the calendar's locale.
   final DateStringBuilder? leadingDateStringBuilder;
 
   /// A function that builds the highlight tile widget.

--- a/lib/src/models/controllers/events_controller.dart
+++ b/lib/src/models/controllers/events_controller.dart
@@ -74,7 +74,8 @@ abstract class EventsController with ChangeNotifier {
   /// The [dateTimeRange] is the range of dates to search for events.
   /// The [includeMultiDayEvents] determines if events spanning multiple days should be included.
   /// The [includeDayEvents] determines if events that are shorter than 1 day should be included.
-  /// The [location] is the current location TODO
+  /// The [location] is the calendar's timezone, used to place day boundaries when evaluating [multiDayRule].
+  /// Pass the same one the calendar renders with.
   /// [multiDayRule] decides which events count as multi-day. Pass the current
   /// view's [ViewConfiguration.multiDayRule]; an event overriding it with
   /// [CalendarEvent.multiDayRule] takes precedence.

--- a/lib/src/models/controllers/view_controller.dart
+++ b/lib/src/models/controllers/view_controller.dart
@@ -26,7 +26,7 @@ abstract class ViewController with CalendarNavigationFunctions {
   /// The [CalendarEvent]s that are currently visible.
   ValueNotifier<Set<CalendarEvent>> get visibleEvents;
 
-  /// TODO: this can be passed between ViewControllers, but for now it is created here.
+  // TODO: this can be passed between ViewControllers, but for now it is created here.
 
   /// The cache used by the event layout delegate.
   final EventLayoutDelegateCache cache = EventLayoutDelegateCache();

--- a/lib/src/models/view_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_view_configuration.dart
@@ -361,7 +361,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
 
 /// The configuration used by the [MultiDayBody].
 ///
-/// TODO: Depricate this in 1.0.0 and use [VerticalConfiguration] instead.
+// TODO: Deprecate this in 1.0.0 and use [VerticalConfiguration] instead.
 class MultiDayBodyConfiguration extends VerticalConfiguration {
   /// Whether to keep visited pages alive so navigating back to them does not
   /// rebuild their content.

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -26,8 +26,6 @@ class ScheduleDateStyle {
   /// The [TextStyle] used by the [ScheduleDate] widget to display the name of the day.
   final TextStyle? textStyle;
 
-  /// Use this function to customize the sting displayed by the [ScheduleDate].
-
   /// The [TextStyle] used by the [ScheduleDate] widget to display the day number of the week.
   final TextStyle? numberTextStyle;
 


### PR DESCRIPTION
Found while reviewing the documentation for a pub.dev release. Everything here is the API reference, which is where a reader lands from a pub.dev search.

## Wrong or stale

- **`CalendarEvent` class example.** The subclass it shows does not take `super.multiDayRule` and its `copyWith` does not forward it, so every drag or resize of such an event produces a copy without the rule. `doc/events.md`, `MIGRATION.md` and `copyWith`'s own dartdoc all say to forward it. The most-read example in the package demonstrated the mistake they warn about.
- **`ScheduleComponents.leadingDateStringBuilder`** described the pre-0.23.0 default, "the first three characters of the day name". The default has been `DateFormat.E` since #354.
- **`ScheduleDate`** carried a doc comment orphaned by the removal of its `stringBuilder` field, including a "sting" typo.
- **`EventInteraction.fromCanModify`** referred to a `canModify` property that no longer exists anywhere in the package.
- **`EventsController.eventsFromDateTimeRange`** documented `location` as "the current location TODO".

## Unusable prose

`CalendarCallbacks.onEventTapped` and `onEventTappedWithDetail` ended their description with "See TODO: add link to event mixins", after a doubled `///`. They now link `DayEventTileUtils` and `MultiDayEventTileUtils`, which is what that TODO was asking for.

## TODOs

The TODOs stay. The ones sitting on public API move from `///` to `//`, so they no longer render as prose in the API reference. They still show in the implementation source, as any comment does. `docs/top-level-cleanup` adds a pre-1.0.0 checklist to AGENTS.md so the deferred ones are not lost.

## Verification

- `dart doc` reports 0 warnings and 0 errors, so every new reference resolves.
- `flutter analyze` clean.
- Merges cleanly with the other four branches in this batch, in any order.