### PR TITLE
chore: format the package and make CI check it

### DIFF
--- a/.github/workflows/flutter_analyze_and_test.yml
+++ b/.github/workflows/flutter_analyze_and_test.yml
@@ -25,12 +25,19 @@ jobs:
         shell: bash
         working-directory: ./
 
+      # Uses the width from analysis_options.yaml. The examples have their own
+      # and are formatted by the analyze_examples.yml workflow.
       - name: Formatting check
+        run: dart format --output=none --set-exit-if-changed lib test tool benchmark
+        shell: bash
+        working-directory: ./
+
+      - name: Analyze (dart)
         run: dart analyze
         shell: bash
         working-directory: ./
 
-      - name: Analyze
+      - name: Analyze (flutter)
         run: flutter analyze
         shell: bash
         working-directory: ./

--- a/benchmark/micro_benchmark_test.dart
+++ b/benchmark/micro_benchmark_test.dart
@@ -70,8 +70,7 @@ class _DatesBenchmark extends _KalenderBenchmark {
 
 /// `defaultMultiDayFrameGenerator` — O(N²·D) multi-day event row assignment.
 class _MultiDayFrameBenchmark extends _KalenderBenchmark {
-  _MultiDayFrameBenchmark(this.eventCount, this.days)
-      : super('multiDayFrame / ${eventCount}ev x ${days}d');
+  _MultiDayFrameBenchmark(this.eventCount, this.days) : super('multiDayFrame / ${eventCount}ev x ${days}d');
   final int eventCount;
   final int days;
   late InternalDateTimeRange range;
@@ -152,8 +151,7 @@ class _LongestChainBenchmark extends _KalenderBenchmark {
     // Staircase overlap: each event overlaps a handful of neighbours, giving a
     // realistic bounded chain depth rather than a pathological fully-dense set.
     data = [
-      for (var i = 0; i < count; i++)
-        VerticalLayoutData(id: i, top: i * 10.0, bottom: i * 10.0 + 35.0),
+      for (var i = 0; i < count; i++) VerticalLayoutData(id: i, top: i * 10.0, bottom: i * 10.0 + 35.0),
     ];
   }
 
@@ -185,36 +183,40 @@ class _EventQueryBenchmark extends _KalenderBenchmark {
 }
 
 void main() {
-  test('micro benchmarks', () {
-    final benchmarks = <_KalenderBenchmark>[
-      _DatesBenchmark(7),
-      _DatesBenchmark(30),
-      _DatesBenchmark(90),
-      _DatesBenchmark(365),
-      _MultiDayFrameBenchmark(100, 30),
-      _MultiDayFrameBenchmark(300, 30),
-      _MultiDayFrameDenseBenchmark(50, 7), // week at 50 events/day
-      _MultiDayFrameDenseBenchmark(50, 35), // month at 50 events/day
-      _LongestChainBenchmark(60),
-      _EventQueryBenchmark(1),
-      _EventQueryBenchmark(7),
-      _EventQueryBenchmark(30),
-    ];
+  test(
+    'micro benchmarks',
+    () {
+      final benchmarks = <_KalenderBenchmark>[
+        _DatesBenchmark(7),
+        _DatesBenchmark(30),
+        _DatesBenchmark(90),
+        _DatesBenchmark(365),
+        _MultiDayFrameBenchmark(100, 30),
+        _MultiDayFrameBenchmark(300, 30),
+        _MultiDayFrameDenseBenchmark(50, 7), // week at 50 events/day
+        _MultiDayFrameDenseBenchmark(50, 35), // month at 50 events/day
+        _LongestChainBenchmark(60),
+        _EventQueryBenchmark(1),
+        _EventQueryBenchmark(7),
+        _EventQueryBenchmark(30),
+      ];
 
-    final results = <Map<String, dynamic>>[];
-    for (final benchmark in benchmarks) {
-      final microseconds = benchmark.measure();
-      results.add({'name': benchmark.name, 'unit': 'us', 'value': microseconds});
+      final results = <Map<String, dynamic>>[];
+      for (final benchmark in benchmarks) {
+        final microseconds = benchmark.measure();
+        results.add({'name': benchmark.name, 'unit': 'us', 'value': microseconds});
+        // ignore: avoid_print
+        print('${benchmark.name}: ${microseconds.toStringAsFixed(3)} us');
+      }
+
+      final output = File('build/micro_results.json');
+      output.parent.createSync(recursive: true);
+      output.writeAsStringSync(const JsonEncoder.withIndent('  ').convert(results));
+
       // ignore: avoid_print
-      print('${benchmark.name}: ${microseconds.toStringAsFixed(3)} us');
-    }
-
-    final output = File('build/micro_results.json');
-    output.parent.createSync(recursive: true);
-    output.writeAsStringSync(const JsonEncoder.withIndent('  ').convert(results));
-
-    // ignore: avoid_print
-    print('Wrote ${results.length} results to ${output.path} (sink=$_sink)');
-    expect(results, isNotEmpty);
-  }, timeout: const Timeout(Duration(minutes: 5)),);
+      print('Wrote ${results.length} results to ${output.path} (sink=$_sink)');
+      expect(results, isNotEmpty);
+    },
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
 }

--- a/lib/src/extensions/internal_date_time.dart
+++ b/lib/src/extensions/internal_date_time.dart
@@ -1,6 +1,5 @@
 import 'package:kalender/kalender.dart';
 
-
 /// A [DateTime] subclass that stores date/time components as-is via [DateTime.utc],
 /// bypassing implicit timezone conversions.
 ///

--- a/lib/src/extensions/internal_date_time_range.dart
+++ b/lib/src/extensions/internal_date_time_range.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 
-
 /// A [DateTimeRange] that uses [InternalDateTime] for timezone-safe display and layout.
 ///
 /// Both [start] and [end] are stored as [InternalDateTime] values, so all

--- a/lib/src/widgets/components/day_header.dart
+++ b/lib/src/widgets/components/day_header.dart
@@ -124,8 +124,7 @@ class DayHeader extends StatelessWidget {
     final displayDate = localDate.forLocation(location: context.location);
 
     final numberText = Text(
-      components.dayHeaderNumberStringBuilder?.call(context, displayDate) ??
-          date.day.toString(),
+      components.dayHeaderNumberStringBuilder?.call(context, displayDate) ?? date.day.toString(),
       style: style.numberTextStyle,
     );
 
@@ -136,8 +135,7 @@ class DayHeader extends StatelessWidget {
     );
 
     final dayName = Text(
-      components.dayHeaderStringBuilder?.call(context, displayDate) ??
-          localDate.dayNameShortLocalized(context.locale),
+      components.dayHeaderStringBuilder?.call(context, displayDate) ?? localDate.dayNameShortLocalized(context.locale),
       style: style.textStyle,
     );
 

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -111,8 +111,7 @@ class MonthDayHeader extends StatelessWidget {
     final localDate = InternalDateTime.fromExternal(date, location: context.location);
     final stringBuilder = context.components.monthComponents.bodyComponents.monthDayHeaderStringBuilder;
     final displayDate = localDate.forLocation(location: context.location);
-    final numberText =
-        stringBuilder?.call(context, displayDate) ?? date.day.toString();
+    final numberText = stringBuilder?.call(context, displayDate) ?? date.day.toString();
 
     return Padding(
       padding: style.margin ?? EdgeInsets.zero,

--- a/lib/src/widgets/components/multi_day_overlay_portal_button.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal_button.dart
@@ -120,8 +120,7 @@ class MultiDayPortalOverlayButton extends StatelessWidget {
       child: Padding(
         padding: style.textPadding ?? const EdgeInsets.symmetric(horizontal: 4.0),
         child: Text(
-          stringBuilder?.call(context, numberOfHiddenRows) ??
-              defaultLabel(context, numberOfHiddenRows),
+          stringBuilder?.call(context, numberOfHiddenRows) ?? defaultLabel(context, numberOfHiddenRows),
           style: style.textStyle,
           overflow: style.textOverflow,
           key: textKey,

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -64,9 +64,7 @@ class ScheduleDateStyle {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    return other is ScheduleDateStyle &&
-        other.textStyle == textStyle &&
-        other.numberTextStyle == numberTextStyle;
+    return other is ScheduleDateStyle && other.textStyle == textStyle && other.numberTextStyle == numberTextStyle;
   }
 
   @override
@@ -96,8 +94,7 @@ class ScheduleDate extends StatelessWidget {
     final stringBuilder = context.components.scheduleComponents.leadingDateStringBuilder;
     final displayDate = date.forLocation(location: context.location);
     final text = Text(
-      stringBuilder?.call(context, displayDate) ??
-          date.dayNameShortLocalized(context.locale),
+      stringBuilder?.call(context, displayDate) ?? date.dayNameShortLocalized(context.locale),
       style: style.textStyle,
     );
 

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -378,7 +378,9 @@ class TimeLine extends StatelessWidget with TimeLineUtils {
 
             // Multi-day events belong in the header, not the body.
             // Don't show timeline tooltips for them.
-            if (eventBeingDragged.spansMultipleDays(location: context.location, defaultRule: context.multiDayRule)) return const SizedBox();
+            if (eventBeingDragged.spansMultipleDays(location: context.location, defaultRule: context.multiDayRule)) {
+              return const SizedBox();
+            }
 
             // Ensure that the event is visible.
             final eventRange = eventBeingDragged.internalRange(location: context.location);

--- a/lib/src/widgets/components/week_day_header.dart
+++ b/lib/src/widgets/components/week_day_header.dart
@@ -58,9 +58,7 @@ class WeekDayHeaderStyle {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    return other is WeekDayHeaderStyle &&
-        other.textStyle == textStyle &&
-        other.padding == padding;
+    return other is WeekDayHeaderStyle && other.textStyle == textStyle && other.padding == padding;
   }
 
   @override
@@ -85,8 +83,7 @@ class WeekDayHeader extends StatelessWidget {
     final style = (KalenderTheme.of(context).weekDayHeaderStyle ?? const WeekDayHeaderStyle()).merge(this.style);
     final padding = style.padding ?? const EdgeInsets.symmetric(vertical: 2);
     final stringBuilder = context.components.monthComponents.headerComponents.weekDayHeaderStringBuilder;
-    final dateText =
-        stringBuilder?.call(context, date) ?? date.dayNameLocalized(context.locale);
+    final dateText = stringBuilder?.call(context, date) ?? date.dayNameLocalized(context.locale);
     return Padding(padding: padding, child: Center(child: Text(dateText, style: style.textStyle)));
   }
 }

--- a/lib/src/widgets/drag_targets/horizontal_drag_target.dart
+++ b/lib/src/widgets/drag_targets/horizontal_drag_target.dart
@@ -192,7 +192,8 @@ class _HorizontalDragTargetState extends State<HorizontalDragTarget> with DragTa
   CalendarEvent? rescheduleEvent(CalendarEvent event, InternalDateTime cursorDateTime) {
     // If the configuration does not allow single-day events (e.g., multi-day header),
     // return null to prevent updating the selection while dragging over this area.
-    if (!widget.configuration.allowSingleDayEvents && !event.spansMultipleDays(location: context.location, defaultRule: context.multiDayRule)) {
+    if (!widget.configuration.allowSingleDayEvents &&
+        !event.spansMultipleDays(location: context.location, defaultRule: context.multiDayRule)) {
       return null;
     }
 

--- a/lib/src/widgets/events_widgets/day_events_widget.dart
+++ b/lib/src/widgets/events_widgets/day_events_widget.dart
@@ -406,7 +406,11 @@ class _DayDropTargetColumnState extends State<DayDropTargetColumn> {
     }
 
     // If the configuration does not allow multi-day events and the selected event is a multi-day event, clear the state.
-    if (!widget.configuration.showMultiDayEvents && selectedEvent.spansMultipleDays(location: widget.location, defaultRule: widget.viewConfiguration.multiDayRule)) {
+    if (!widget.configuration.showMultiDayEvents &&
+        selectedEvent.spansMultipleDays(
+          location: widget.location,
+          defaultRule: widget.viewConfiguration.multiDayRule,
+        )) {
       if (_selectedEvent != null) setState(() => _selectedEvent = null);
       return;
     }

--- a/lib/src/widgets/events_widgets/multi_day_events_widget.dart
+++ b/lib/src/widgets/events_widgets/multi_day_events_widget.dart
@@ -303,7 +303,8 @@ class _MultiDayEventLayoutWidgetState extends State<MultiDayEventLayoutWidget> {
       valueListenable: context.calendarController.selectedEvent,
       builder: (context, event, child) {
         if (event == null) return const SizedBox();
-        if (!widget.configuration.allowSingleDayEvents && !event.spansMultipleDays(location: context.location, defaultRule: context.multiDayRule)) {
+        if (!widget.configuration.allowSingleDayEvents &&
+            !event.spansMultipleDays(location: context.location, defaultRule: context.multiDayRule)) {
           return const SizedBox();
         }
         if (!event.internalRange(location: context.location).overlaps(widget.internalDateTimeRange)) {

--- a/test/configuration/default_initial_date_selection_strategies_test.dart
+++ b/test/configuration/default_initial_date_selection_strategies_test.dart
@@ -101,7 +101,6 @@ void main() {
     // ── kDefaultToMonthly ────────────────────────────────────────────────
 
     group('[$location] kDefaultToMonthly', () {
-
       test('from Month  → dominantMonthDate of visible range', () {
         final result = kDefaultToMonthly(buildMonth());
         expect(result, dominantJanuary, reason: 'Month → Month: expected $dominantJanuary but got $result');
@@ -141,7 +140,6 @@ void main() {
     // ── kDefaultToWeekly ─────────────────────────────────────────────────
 
     group('[$location] kDefaultToWeekly', () {
-
       test('from Month    → visible-range start', () {
         final result = kDefaultToWeekly(buildMonth());
         expect(result, monthOrWeekStart, reason: 'Month → Week: expected $monthOrWeekStart but got $result');
@@ -181,7 +179,6 @@ void main() {
     // ── kDefaultToDaily ──────────────────────────────────────────────────
 
     group('[$location] kDefaultToDaily', () {
-
       test('from Month  → dominantMonthDate of visible range', () {
         final result = kDefaultToDaily(buildMonth());
         expect(result, dominantJanuary, reason: 'Month → Day: expected $dominantJanuary but got $result');
@@ -221,7 +218,6 @@ void main() {
     // ── kDefaultToSchedule ───────────────────────────────────────────────
 
     group('[$location] kDefaultToSchedule', () {
-
       test('from Month    → visible-range start', () {
         final result = kDefaultToSchedule(buildMonth());
         expect(result, monthOrWeekStart, reason: 'Month → Schedule: expected $monthOrWeekStart but got $result');

--- a/test/extensions/date_time_i18n_extensions_test.dart
+++ b/test/extensions/date_time_i18n_extensions_test.dart
@@ -53,8 +53,18 @@ void main() {
 
     test('monthNameLocalized covers every month in English', () {
       const expected = [
-        'January', 'February', 'March', 'April', 'May', 'June',
-        'July', 'August', 'September', 'October', 'November', 'December',
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
       ];
       for (var month = 1; month <= 12; month++) {
         expect(DateTime(2024, month, 15).monthNameLocalized('en'), equals(expected[month - 1]));

--- a/test/models/default_events_controller_test.dart
+++ b/test/models/default_events_controller_test.dart
@@ -239,20 +239,26 @@ void main() {
 
     test('Notifies listeners exactly once', () {
       controller.addEvents([
-        CalendarEvent(dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 6, 1, 9), end: DateTime.utc(2024, 6, 1, 10))),
+        CalendarEvent(
+          dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 6, 1, 9), end: DateTime.utc(2024, 6, 1, 10)),
+        ),
       ]);
 
       var count = 0;
       controller.addListener(() => count++);
       controller.replaceEvents([
-        CalendarEvent(dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 7, 1, 9), end: DateTime.utc(2024, 7, 1, 10))),
+        CalendarEvent(
+          dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 7, 1, 9), end: DateTime.utc(2024, 7, 1, 10)),
+        ),
       ]);
       expect(count, 1, reason: 'A single atomic update, not a clear followed by an add.');
     });
 
     test('Replacing with an empty list clears all events', () {
       controller.addEvents([
-        CalendarEvent(dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 6, 1, 9), end: DateTime.utc(2024, 6, 1, 10))),
+        CalendarEvent(
+          dateTimeRange: DateTimeRange(start: DateTime.utc(2024, 6, 1, 9), end: DateTime.utc(2024, 6, 1, 10)),
+        ),
       ]);
       controller.replaceEvents([]);
       expect(controller.events, isEmpty);
@@ -382,7 +388,10 @@ void main() {
         start: InternalDateTime(2024, 12, 20),
         end: InternalDateTime(2024, 12, 21),
       );
-      expect(controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, oldRange), isNot(contains(updatedEvent)));
+      expect(
+        controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, oldRange),
+        isNot(contains(updatedEvent)),
+      );
       expect(controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, newRange), contains(updatedEvent));
     });
 
@@ -392,7 +401,12 @@ void main() {
       final event = CalendarEvent(dateTimeRange: DateTimeRange(start: start, end: end));
       controller.addEvent(event);
       final range = InternalDateTimeRange(start: InternalDateTime(2024, 9, 5), end: InternalDateTime(2024, 9, 6));
-      final result = controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, includeMultiDayEvents: false, includeDayEvents: false);
+      final result = controller.eventsFromDateTimeRange(
+        multiDayRule: defaultMultiDayRule,
+        range,
+        includeMultiDayEvents: false,
+        includeDayEvents: false,
+      );
       expect(result, isEmpty);
     });
   });
@@ -412,13 +426,26 @@ void main() {
           start: InternalDateTime.fromExternal(start, location: location),
           end: InternalDateTime.fromExternal(end, location: location),
         );
-        expect(controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location), contains(event));
         expect(
-          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location, includeDayEvents: false),
+          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location),
+          contains(event),
+        );
+        expect(
+          controller.eventsFromDateTimeRange(
+            multiDayRule: defaultMultiDayRule,
+            range,
+            location: location,
+            includeDayEvents: false,
+          ),
           isEmpty,
         );
         expect(
-          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location, includeMultiDayEvents: false),
+          controller.eventsFromDateTimeRange(
+            multiDayRule: defaultMultiDayRule,
+            range,
+            location: location,
+            includeMultiDayEvents: false,
+          ),
           contains(event),
         );
       });
@@ -434,13 +461,26 @@ void main() {
           start: InternalDateTime.fromExternal(start, location: location),
           end: InternalDateTime.fromExternal(end, location: location),
         );
-        expect(controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location), contains(event));
         expect(
-          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location, includeDayEvents: false),
+          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location),
           contains(event),
         );
         expect(
-          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location, includeMultiDayEvents: false),
+          controller.eventsFromDateTimeRange(
+            multiDayRule: defaultMultiDayRule,
+            range,
+            location: location,
+            includeDayEvents: false,
+          ),
+          contains(event),
+        );
+        expect(
+          controller.eventsFromDateTimeRange(
+            multiDayRule: defaultMultiDayRule,
+            range,
+            location: location,
+            includeMultiDayEvents: false,
+          ),
           isEmpty,
         );
       });
@@ -456,13 +496,26 @@ void main() {
           start: InternalDateTime.fromExternal(start, location: location),
           end: InternalDateTime.fromExternal(end, location: location),
         );
-        expect(controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location), contains(event));
         expect(
-          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location, includeDayEvents: false),
+          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location),
+          contains(event),
+        );
+        expect(
+          controller.eventsFromDateTimeRange(
+            multiDayRule: defaultMultiDayRule,
+            range,
+            location: location,
+            includeDayEvents: false,
+          ),
           isEmpty,
         );
         expect(
-          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, range, location: location, includeMultiDayEvents: false),
+          controller.eventsFromDateTimeRange(
+            multiDayRule: defaultMultiDayRule,
+            range,
+            location: location,
+            includeMultiDayEvents: false,
+          ),
           contains(event),
         );
       });
@@ -518,11 +571,21 @@ void main() {
           contains(updatedEvent),
         );
         expect(
-          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, newRange, location: location, includeDayEvents: false),
+          controller.eventsFromDateTimeRange(
+            multiDayRule: defaultMultiDayRule,
+            newRange,
+            location: location,
+            includeDayEvents: false,
+          ),
           contains(updatedEvent),
         );
         expect(
-          controller.eventsFromDateTimeRange(multiDayRule: defaultMultiDayRule, newRange, location: location, includeMultiDayEvents: false),
+          controller.eventsFromDateTimeRange(
+            multiDayRule: defaultMultiDayRule,
+            newRange,
+            location: location,
+            includeMultiDayEvents: false,
+          ),
           isEmpty,
         );
       });

--- a/test/widgets/free_scroll_band_test.dart
+++ b/test/widgets/free_scroll_band_test.dart
@@ -68,7 +68,8 @@ void main() {
   testWidgets('the spanning tile stays one tile and moves as the view scrolls', (tester) async {
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 4))),
+        dateTimeRange:
+            DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 4))),
       ),
     );
 

--- a/test/widgets/free_scroll_interaction_test.dart
+++ b/test/widgets/free_scroll_interaction_test.dart
@@ -88,7 +88,8 @@ void main() {
     // A 3-day event inside the first visible week.
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 4))),
+        dateTimeRange:
+            DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 4))),
       ),
     );
 
@@ -117,7 +118,8 @@ void main() {
   testWidgets('dragging an event to the viewport edge scrolls to adjacent days', (tester) async {
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 3))),
+        dateTimeRange:
+            DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 3))),
       ),
     );
 

--- a/test/widgets/free_scroll_rtl_test.dart
+++ b/test/widgets/free_scroll_rtl_test.dart
@@ -84,7 +84,10 @@ void main() {
 
   testWidgets('RTL: scrolling forward moves the tile toward the start side (right)', (tester) async {
     final id = eventsController.addEvent(
-      CalendarEvent(dateTimeRange: DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 4)))),
+      CalendarEvent(
+        dateTimeRange:
+            DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 4))),
+      ),
     );
 
     await pump(tester, TextDirection.rtl);

--- a/test/widgets/page_trigger_test.dart
+++ b/test/widgets/page_trigger_test.dart
@@ -55,7 +55,8 @@ void main() {
     // A 2-day event in the first visible week, shown in the multi-day header.
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 3))),
+        dateTimeRange:
+            DateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 3))),
       ),
     );
 

--- a/test/widgets/schedule/schedule_body_test.dart
+++ b/test/widgets/schedule/schedule_body_test.dart
@@ -58,8 +58,7 @@ void main() {
 
   ScheduleViewController schedule() => calendarController.viewController as ScheduleViewController;
 
-  double tileLeft(WidgetTester tester, String id) =>
-      tester.getTopLeft(find.byKey(ScheduleEventTile.tileKey(id))).dx;
+  double tileLeft(WidgetTester tester, String id) => tester.getTopLeft(find.byKey(ScheduleEventTile.tileKey(id))).dx;
 
   group('Row alignment', () {
     testWidgets('event tiles on the same day share one left edge', (tester) async {
@@ -85,13 +84,21 @@ void main() {
 
       await pumpAndSettleWithMaterialApp(
         tester,
-        buildSchedule(initialDate: DateTime(2025, 1, 15), nowCallback: () => DateTime(2025, 1, 15, 10), leadingWidth: 56),
+        buildSchedule(
+          initialDate: DateTime(2025, 1, 15),
+          nowCallback: () => DateTime(2025, 1, 15, 10),
+          leadingWidth: 56,
+        ),
       );
       final narrow = tileLeft(tester, ids.first);
 
       await pumpAndSettleWithMaterialApp(
         tester,
-        buildSchedule(initialDate: DateTime(2025, 1, 15), nowCallback: () => DateTime(2025, 1, 15, 10), leadingWidth: 120),
+        buildSchedule(
+          initialDate: DateTime(2025, 1, 15),
+          nowCallback: () => DateTime(2025, 1, 15, 10),
+          leadingWidth: 120,
+        ),
       );
       final wide = tileLeft(tester, ids.first);
 

--- a/test/widgets/string_builders_test.dart
+++ b/test/widgets/string_builders_test.dart
@@ -118,7 +118,6 @@ void main() {
 
       expect(find.text('wd'), findsWidgets);
     });
-
   });
 
   group('MonthDayHeader', () {
@@ -217,6 +216,5 @@ void main() {
 
       expect(labels(tester), everyElement(matches(RegExp(r'^\+\d+$'))));
     });
-
   });
 }


### PR DESCRIPTION
The analyze job has a step named "Formatting check" that runs `dart analyze`. Nothing has ever checked formatting, so it drifted.

`dart format --output=none --set-exit-if-changed lib test tool benchmark` reported 21 files, most still wrapped at 80 columns from before `analysis_options.yaml` set `page_width: 120`. pana runs a formatting check, so this costs points on the pub.dev score.

## The lint conflict

Running the formatter put two lint rules in conflict with it. Joining lines dropped trailing commas that `require_trailing_commas` wants, and moved an `if` body onto its own line, which `curly_braces_in_flow_control_structures` rejects. `flutter analyze` went from clean to 21 issues.

`dart fix --apply` resolved all 21. A trailing comma holds the split, so the result is stable: format then analyze then format again converges, and both are clean.

## The workflow

The step now runs the formatter, followed by separate `dart analyze` and `flutter analyze` steps rather than one mislabelled as the other. Scoped to `lib test tool benchmark` because the examples set their own width and are covered by `analyze_examples.yml`.

## Verification

- `dart format --set-exit-if-changed` clean, and stable across repeated runs.
- `flutter analyze` reports no issues.
- All 1568 tests pass.

Review note: the diff is large but entirely mechanical. It touches `lib/src/widgets/components/schedule_date.dart`, which `docs/dartdoc-corrections` also touches, in a different part of the file. The two merge cleanly in either order.