### PR TITLE
chore: add pub.dev screenshots, topics and issue tracker

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -5,10 +5,13 @@ coverage/
 __pycache__/
 
 test/
-readme_assets/
 examples/
 tool/
 benchmark/
+
+# readme_assets/ is published on purpose: the pubspec `screenshots` entries and
+# the README images both read from it, and pub.dev only serves files that are in
+# the archive.
 
 # Instructions for coding agents working on this repo, of no use to anyone
 # installing the package.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,9 +2,25 @@ name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
 version: 0.24.0-dev.4
 repository: https://github.com/werner-scholtz/kalender.git
-topics: 
+issue_tracker: https://github.com/werner-scholtz/kalender/issues
+topics:
   - calendar
   - widget
+  - scheduler
+  - timezone
+  - drag-and-drop
+
+# pub.dev renders these as a gallery on the package page and takes the search
+# result thumbnail from the first one.
+screenshots:
+  - description: Week view on desktop in the light theme, with the time indicator and overlapping events.
+    path: readme_assets/desktop_light.png
+  - description: Week view on desktop in the dark theme.
+    path: readme_assets/desktop_dark.png
+  - description: Three-day view on mobile in the light theme.
+    path: readme_assets/mobile_light.png
+  - description: Three-day view on mobile in the dark theme.
+    path: readme_assets/mobile_dark.png
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/tool/pin_release_links.dart
+++ b/tool/pin_release_links.dart
@@ -53,9 +53,9 @@ String packageName(String pubspec) {
 /// Rewrites relative links to `blob/<tag>` URLs and relative images to raw
 /// URLs on the tag, matching how pub.dev resolves each kind.
 ///
-/// Images are rewritten in both markdown and `<img>` form. `readme_assets/` is
-/// excluded from the published archive, so a relative image that survives is a
-/// broken image on pub.dev.
+/// Images are rewritten in both markdown and `<img>` form. pub.dev resolves a
+/// README image against the repository rather than the archive, so a relative
+/// image that survives shows the default branch instead of the tag.
 String pinRelativeLinks(String content, String repoUrl, String tag) {
   final rawBase = repoUrl.replaceFirst('https://github.com/', 'https://raw.githubusercontent.com/');
   return content


### PR DESCRIPTION
## Screenshots

pub.dev supports a `screenshots:` field: up to 10 images, max 4 MB each, png/jpg/gif/webp, descriptions capped at 160 characters. It renders them as a gallery on the package page and **takes the search result thumbnail from the first entry**, which the README images cannot do.

The four existing previews are listed, desktop light first so it becomes the thumbnail.

The files have to be in the archive for pub.dev to serve them, so `readme_assets/` is no longer in `.pubignore`. That adds about 370 KB, taking the archive from roughly 150 KB to 527 KB compressed. Worth checking you are happy with that trade, since every download pays it.

README images are unaffected in either direction. pub.dev resolves those against the repository, not the archive, and `tool/pin_release_links.dart` still pins them to the tag. Its comment gave "`readme_assets/` is excluded from the published archive" as the reason relative images must be rewritten, which is no longer true, so it now gives the actual reason.

## Topics

Two to the maximum of five. `scheduler`, `timezone` and `drag-and-drop` all describe what the package does and are what someone looking for it would search. Also drops a trailing space after `topics:`.

## Issue tracker

Puts a direct link in the pub.dev sidebar instead of leaving readers to find it through the repository.

## Verification

- `dart pub publish --dry-run` validates. The only warnings are the uncommitted working tree at the time of the run and the prerelease version, which is your release step.
- `flutter test test/tool/pin_release_links_test.dart` passes.