### PR TITLE
docs: make the guide reference blocks show the real defaults

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -5,7 +5,7 @@ it covers the choice every calendar has to make first.
 
 | Guide | Covers |
 | --- | --- |
-| [Views](views.md) | The four view families, what carries over when you switch, and each view's configuration class. |
+| [Views](views.md) | The three view families, what carries over when you switch, and each view's configuration class. |
 | [Events](events.md) | Attaching your own data by subclassing `CalendarEvent`, updating events, and what counts as multi-day. |
 | [Interaction](interaction.md) | Creating, rescheduling, resizing, snapping and zooming. |
 | [Controllers & Callbacks](controllers-and-callbacks.md) | Driving the calendar from code, reacting to what the user did, and building a toolbar around it. |

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -38,6 +38,8 @@ CalendarBody(
 ### All TileComponents options
 
 Every aspect of an event tile's appearance and drag behavior can be overridden.
+Only `tileBuilder` is required. Every other field defaults to null, which keeps
+the package's own behavior, so set only what you want to change.
 
 <details>
   <summary>TileComponents reference</summary>
@@ -48,23 +50,20 @@ Every aspect of an event tile's appearance and drag behavior can be overridden.
     // Required: the stationary event tile.
     tileBuilder: (event, tileRange) => Container(),
 
-    // Optional: shown over the calendar in portal overlays instead of tileBuilder.
+    // Shown over the calendar in portal overlays instead of tileBuilder.
     overlayTileBuilder: (event, tileRange) => Container(),
 
-    // Optional: shown in place of the tile while it is being dragged.
+    // Shown in place of the tile while it is being dragged.
     tileWhenDraggingBuilder: (event) => Container(),
 
-    // Optional: the tile that follows the cursor / finger during a drag.
+    // The tile that follows the cursor / finger during a drag.
     feedbackTileBuilder: (event, dropTargetWidgetSize) => Container(),
 
-    // Optional: rendered beneath the dragged tile to show where it will land.
+    // Rendered beneath the dragged tile to show where it will land.
     dropTargetTile: (event) => Container(),
 
     // The drag anchor strategy used by feedbackTileBuilder.
     dragAnchorStrategy: childDragAnchorStrategy,
-
-    // The drag anchor strategy used while resizing.
-    resizeDragAnchorStrategy: childDragAnchorStrategy,
 
     // Position and size the resize handles (a function returning your ResizeHandles subclass).
     resizeHandlePositioner: myResizeHandlePositioner,
@@ -77,6 +76,12 @@ Every aspect of an event tile's appearance and drag behavior can be overridden.
   )
   ```
 </details>
+
+> [!WARNING]
+> `resizeDragAnchorStrategy` is left out above on purpose. It defaults to a
+> pointer anchor, and setting it to `childDragAnchorStrategy` makes a vertical
+> resize jump to the neighbouring day on the smallest sideways movement. Change
+> it only if you have a reason to.
 
 ### ScheduleTileComponents
 
@@ -91,10 +96,10 @@ Schedule view tiles have a different set of builders since they are laid out in 
     // Required: the stationary event tile.
     tileBuilder: (event, tileRange) => Container(),
 
-    // Optional: shown in place of the tile while it is being dragged.
+    // Shown in place of the tile while it is being dragged.
     tileWhenDraggingBuilder: (event) => Container(),
 
-    // Optional: the tile that follows the cursor / finger during a drag.
+    // The tile that follows the cursor / finger during a drag.
     feedbackTileBuilder: (event, dropTargetWidgetSize) => Container(),
 
     // The drag anchor strategy used by feedbackTileBuilder.

--- a/doc/controllers-and-callbacks.md
+++ b/doc/controllers-and-callbacks.md
@@ -27,6 +27,9 @@ did. Together they are how the calendar connects to the rest of your app.
 | `clearEvents()`                      | Remove all events                                                                                                              |
 | `eventsFromDateTimeRange(range)`     | Events occurring during the given range (requires the view's `multiDayRule`, plus optional `includeMultiDayEvents`, `includeDayEvents`, and `location` filters) |
 
+`eventsFromDateTimeRange` takes an `InternalDateTimeRange`, not a `DateTimeRange`.
+Convert with `InternalDateTimeRange.fromDateTimeRange(range)`.
+
 ### CalendarController
 
 [`CalendarController`](https://pub.dev/documentation/kalender/latest/kalender/CalendarController-class.html) drives a single `CalendarView` widget.
@@ -47,7 +50,43 @@ did. Together they are how the calendar connects to the rest of your app.
 - `animateToDate(date)` / `animateToDateTime(dateTime)`
 - `animateToEvent(event)`
 
+**Selection methods:** `selectEvent(event)` focuses an event from code, which is
+what draws its drop target and resize handles. `deselectEvent()` clears it. Both
+drive the `selectedEvent` notifier above.
+
 > Internally the controller delegates to a [`ViewController`](https://pub.dev/documentation/kalender/latest/kalender/ViewController-class.html) (`MultiDayViewController`, `MonthViewController`, or `ScheduleViewController`) depending on the active `ViewConfiguration`.
+
+### Disposing
+
+Both controllers hold listeners, so dispose them with the widget that owns them.
+
+<!-- snippet: file -->
+```dart
+class MyCalendar extends StatefulWidget {
+  const MyCalendar({super.key});
+
+  @override
+  State<MyCalendar> createState() => _MyCalendarState();
+}
+
+class _MyCalendarState extends State<MyCalendar> {
+  final eventsController = DefaultEventsController();
+  final calendarController = CalendarController();
+
+  @override
+  void dispose() {
+    calendarController.dispose();
+    eventsController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+```
+
+An `EventsController` shared across screens belongs to whatever owns it for the
+life of the app, and is disposed there rather than in a single screen.
 
 ### Building the surrounding UI
 
@@ -67,6 +106,13 @@ class CalendarScreen extends StatefulWidget {
 class _CalendarScreenState extends State<CalendarScreen> {
   final eventsController = DefaultEventsController();
   final calendarController = CalendarController();
+
+  @override
+  void dispose() {
+    calendarController.dispose();
+    eventsController.dispose();
+    super.dispose();
+  }
 
   late final viewConfigurations = <ViewConfiguration>[
     MultiDayViewConfiguration.week(),

--- a/doc/events.md
+++ b/doc/events.md
@@ -123,7 +123,7 @@ CalendarCallbacks(
 
 ## Multi-day events
 
-A `MultiDayRule` decides whether an event renders in the multi-day header lane or in the day timeline. The rule is set on the view configuration (see [Views & Interaction](views.md#views)) and defaults to counting events of 24 hours or longer as multi-day.
+A `MultiDayRule` decides whether an event renders in the multi-day header lane or in the day timeline. The rule is set on the view configuration (see [Shared options](views.md#shared-options)) and defaults to counting events of 24 hours or longer as multi-day.
 
 A single event can override the calendar's rule:
 

--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -10,11 +10,12 @@ Reacting to what they did is separate, see
 
 ## Interaction & Snapping
 
-`CalendarHeader` and `CalendarBody` both accept these, so a calendar can allow
-different things in its header than in its body.
+`interaction` sets what the user may do. `CalendarHeader` and `CalendarBody` both
+accept it, so a calendar can allow different things in its header than in its
+body. `snapping` is accepted by `CalendarBody` only, and only the multi-day body
+reads it.
 
-- `interaction: CalendarInteraction`: toggling resize / reschedule / create.
-- `snapping: CalendarSnapping`: (body only, MultiDay) snap interval, snap-to-indicator, snap-to-events, custom snap strategy.
+Both blocks below show every option **at its default value**.
 
 <!-- snippet: expression -->
 ```dart
@@ -23,27 +24,52 @@ CalendarBody(
     allowResizing: true,
     allowRescheduling: true,
     allowEventCreation: true,
-    // Tap to create (desktop default) or long-press to create (mobile default):
+    // Tap on desktop, long-press on mobile, when left unset.
     createEventGesture: CreateEventGesture.tap,
-    // The gesture that starts modifying an existing event, same defaults:
+    // The gesture that starts modifying an existing event, same defaults.
     modifyEventGesture: CreateEventGesture.tap,
     // Input mode affects resize handle positioning and visibility:
-    //   auto (default): detects dynamically from pointer events
-    //   precise:        mouse, stylus, trackpad (full-width handles, hover-to-show)
-    //   imprecise:      touch/finger (corner handles, selection-to-show)
+    //   auto:      detects dynamically from pointer events
+    //   precise:   mouse, stylus, trackpad (full-width handles, hover-to-show)
+    //   imprecise: touch/finger (corner handles, selection-to-show)
     inputMode: InputMode.auto,
-    // Opt-in to horizontal resize handles in imprecise/touch mode (default: false):
+    // Opt in to horizontal resize handles in imprecise/touch mode.
     allowHorizontalImpreciseResize: false,
   ),
   snapping: CalendarSnapping(
-    snapIntervalMinutes: 15,
+    snapIntervalMinutes: 10,
     snapToTimeIndicator: true,
     snapToOtherEvents: true,
-    snapRange: const Duration(minutes: 5),
+    snapRange: const Duration(minutes: 15),
     eventSnapStrategy: defaultSnapStrategy,
   ),
 )
 ```
+
+---
+
+## Locking a single event
+
+`CalendarInteraction` applies to the whole calendar. To hold one event in place
+while the rest stay editable, give it an `EventInteraction`. Anything the event
+forbids stays forbidden even where the calendar allows it.
+
+<!-- snippet: expression -->
+```dart
+CalendarEvent(
+  dateTimeRange: range,
+  // Movable, but its start and end are fixed.
+  interaction: EventInteraction(
+    allowStartResize: false,
+    allowEndResize: false,
+    allowRescheduling: true,
+  ),
+)
+```
+
+`EventInteraction.allowNone()` makes an event fully read-only, and
+`EventInteraction.allowAll()` is the default every event gets. A subclass passes
+it through with `super.interaction`, as in [Custom Events](events.md#custom-events).
 
 ---
 

--- a/doc/views.md
+++ b/doc/views.md
@@ -18,9 +18,11 @@ For custom logic, provide a `dateResolver` / `scrollResolver` / `zoomResolver`. 
 ## Shared options
 
 All configurations accept:
-- `displayRange`: the total date range the calendar can navigate within (e.g. Jan 2024 to Dec 2025). Defaults to two years either side of today.
+- `displayRange`: the total date range the calendar can navigate within (e.g. Jan 2024 to Dec 2025). Defaults to 1 January two years back through 1 January two years ahead.
 - `initialDateTime`: the date to show on first render. Defaults to `DateTime.now()`.
 - `multiDayRule`: what counts as a multi-day event and so renders in the multi-day header rather than the day timeline. Defaults to events lasting 24 hours or more (`MultiDayRule.minimumDuration`). `MultiDayRule.calendarDays()` instead counts anything that crosses midnight. A single event can override the rule, see [Multi-day events](events.md#multi-day-events).
+- `name`: identifies the view. Each constructor sets one already (`'Day'`, `'Week'`, `'Work Week'`, `'Custom'`, `'Free Scroll'`, `'Month'`, `'Schedule'`). It is what `DateTransition.restorePerView` matches on, so two configurations that should restore separately need different names. It is also a ready-made label for a view switcher, see [Building the surrounding UI](controllers-and-callbacks.md#building-the-surrounding-ui).
+- `nowCallback`: overrides how the calendar resolves "now", see [Now Callback](timezones-and-locales.md#now-callback).
 
 <!-- snippet: expression -->
 ```dart
@@ -44,16 +46,24 @@ Displays one or more days with time on the vertical axis.
 | `MultiDayViewConfiguration.custom(numberOfDays: n)`      | Custom number of days                          |
 | `MultiDayViewConfiguration.freeScroll(numberOfDays: n)`  | Scrolls freely across days, without page snaps |
 
-These views also control where the day opens vertically and how tall an hour is:
+These views also control which hours exist, where the day opens vertically, and how tall an hour is:
 
-- `initialTimeOfDay`: the time at the top of the viewport on first render. Defaults to midnight, so set it to the hour your users actually start at or the calendar opens on empty overnight hours.
+- `timeOfDayRange`: the hours the body lays out. Defaults to `TimeOfDayRange.allDay()`, which is 00:00 to 23:59. Narrowing it makes the page shorter, so there is less to scroll through at the same zoom. Positions are measured from `start`, so an event falling outside the range is drawn outside the page and clipped. Narrow it only when events cannot fall outside it.
+- `initialTimeOfDay`: the time at the top of the viewport on first render. Defaults to midnight, so set it to the hour your users actually start at or the calendar opens on empty overnight hours. The offset is measured from `timeOfDayRange.start`, so keep this value inside the range.
 - `initialHeightPerMinute`: the starting zoom, in logical pixels per minute. Defaults to `0.7`, giving a 42 pixel hour. Change it later through the controller, see [Zoom](interaction.md#zoom).
+- `firstDayOfWeek`: which day a week starts on, as `DateTime.monday` through `DateTime.sunday`. Defaults to `DateTime.monday`. Applies to `week`, `singleDay` and `custom`. `workWeek` and `freeScroll` fix it themselves.
 
 <!-- snippet: expression -->
 ```dart
 MultiDayViewConfiguration.week(
-  initialTimeOfDay: const TimeOfDay(hour: 7, minute: 0),
+  // Working hours only. The timeline runs 08:00 to 18:00 and nothing else exists.
+  timeOfDayRange: TimeOfDayRange(
+    start: const TimeOfDay(hour: 8, minute: 0),
+    end: const TimeOfDay(hour: 18, minute: 0),
+  ),
+  initialTimeOfDay: const TimeOfDay(hour: 8, minute: 0),
   initialHeightPerMinute: 0.7,
+  firstDayOfWeek: DateTime.sunday,
 )
 ```
 
@@ -97,9 +107,11 @@ Presents events in a chronological scrollable list.
 | Month    | None                          | `MonthBodyConfiguration`    |
 | Schedule | None                          | `ScheduleBodyConfiguration` |
 
-Both also accept `interaction` and `snapping`, covered in [Interaction](interaction.md).
+Both also accept `interaction`. `CalendarBody` additionally accepts `snapping`, which the header has no equivalent of. Both are covered in [Interaction](interaction.md).
 
-Each view has its own configuration class with sensible defaults. Expand the references below for the full set of options.
+Each configuration class has defaults that suit most apps. The references below
+spell every option out **at its default value**, so a block copied whole leaves
+the calendar exactly as it was. Change only the lines you care about.
 
 <details>
   <summary>MultiDayHeaderConfiguration</summary>
@@ -111,10 +123,12 @@ Each view has its own configuration class with sensible defaults. Expand the ref
       showTiles: true,
       allowSingleDayEvents: false,
       tileHeight: 24,
-      generateMultiDayLayoutFrame: defaultMultiDayFrameGenerator,
-      maximumNumberOfVerticalEvents: null,
       eventPadding: EdgeInsets.only(left: 0, right: 4, bottom: 2),
       pageTriggerConfiguration: PageTriggerConfiguration(),
+      // Null uses defaultMultiDayFrameGenerator, see Layout.
+      generateMultiDayLayoutFrame: null,
+      // Null means no cap on the rows of events shown per day.
+      maximumNumberOfVerticalEvents: null,
     ),
   )
   ```
@@ -127,15 +141,18 @@ Each view has its own configuration class with sensible defaults. Expand the ref
   ```dart
   CalendarBody(
     multiDayBodyConfiguration: MultiDayBodyConfiguration(
-      showMultiDayEvents: true,
+      showMultiDayEvents: false,
       horizontalPadding: EdgeInsets.only(left: 0, right: 4),
-      minimumTileHeight: 24.0,
+      eventLayoutStrategy: overlapLayoutStrategy,
       pageTriggerConfiguration: PageTriggerConfiguration(),
       scrollTriggerConfiguration: ScrollTriggerConfiguration(),
-      eventLayoutStrategy: overlapLayoutStrategy,
-      scrollPhysics: BouncingScrollPhysics(),
-      pageScrollPhysics: BouncingScrollPhysics(),
       keepPagesAlive: false,
+      // Null lets a tile be as short as its duration. Set a floor, e.g. 24, to
+      // keep short events readable.
+      minimumTileHeight: null,
+      // Null uses the ambient physics. Set your own, e.g. BouncingScrollPhysics().
+      scrollPhysics: null,
+      pageScrollPhysics: null,
     ),
   )
   ```
@@ -149,9 +166,10 @@ Each view has its own configuration class with sensible defaults. Expand the ref
   CalendarBody(
     monthBodyConfiguration: MonthBodyConfiguration(
       tileHeight: 24,
-      generateMultiDayLayoutFrame: defaultMultiDayFrameGenerator,
       eventPadding: EdgeInsets.only(left: 0, right: 4, bottom: 2),
       pageTriggerConfiguration: PageTriggerConfiguration(),
+      // Null uses defaultMultiDayFrameGenerator, see Layout.
+      generateMultiDayLayoutFrame: null,
     ),
   )
   ```
@@ -164,12 +182,13 @@ Each view has its own configuration class with sensible defaults. Expand the ref
   ```dart
   CalendarBody(
     scheduleBodyConfiguration: ScheduleBodyConfiguration(
-      emptyDay: EmptyDayBehavior.hide,
+      emptyDay: EmptyDayBehavior.showOnlyToday,
       leadingWidth: 56,
       pageTriggerConfiguration: PageTriggerConfiguration(),
       scrollTriggerConfiguration: ScrollTriggerConfiguration(),
-      scrollPhysics: BouncingScrollPhysics(),
-      pageScrollPhysics: BouncingScrollPhysics(),
+      // Null uses the ambient physics. Set your own, e.g. BouncingScrollPhysics().
+      scrollPhysics: null,
+      pageScrollPhysics: null,
     ),
   )
   ```


### PR DESCRIPTION
## The defaults were wrong

`doc/views.md` introduced its configuration references as "sensible defaults" and listed concrete values. Six were not the defaults, and copying a block whole changed what the calendar rendered:

| Doc | Showed | Actual default |
| --- | --- | --- |
| `MultiDayBodyConfiguration.showMultiDayEvents` | `true` | `false` |
| `MultiDayBodyConfiguration.minimumTileHeight` | `24.0` | `null` |
| `scrollPhysics` / `pageScrollPhysics` (both bodies) | `BouncingScrollPhysics()` | `null` |
| `ScheduleBodyConfiguration.emptyDay` | `EmptyDayBehavior.hide` | `showOnlyToday` |
| `generateMultiDayLayoutFrame` (header and month) | `defaultMultiDayFrameGenerator` | `null` |

`showMultiDayEvents: true` moves multi-day events into the body, and `emptyDay: hide` drops today's empty row. `doc/interaction.md` had the same problem with `snapIntervalMinutes` (10, not 15) and `snapRange` (15 minutes, not 5).

Every reference block now lists options at their true default, so a block copied whole is a no-op, and the framing says so. Where a default is null, a comment names a value worth setting instead, since `scrollPhysics: null` on its own teaches nothing.

## A default the docs recommended against

`doc/appearance.md` showed `resizeDragAnchorStrategy: childDragAnchorStrategy`. That is the value its own dartdoc warns about: it makes a vertical resize jump to the neighbouring day on the smallest sideways movement. Dropped from the block and called out separately.

## Undocumented options

- **`timeOfDayRange`** had no coverage at all. Restricting a view to working hours is a common requirement and was unreachable from the guides. Documented with what it actually does, including that positions are measured from `start`, so an event outside the range is drawn outside the page.
- **`EventInteraction`** appeared only as an untyped `super.interaction` in the events example. Making one event read-only now has a section. Verified against `resize_handles.dart:107` and `tile_draggable.dart:47` that it is ANDed with `CalendarInteraction`.
- **`firstDayOfWeek`** was documented for the month view only, though the multi-day views take it too.
- **`name`** was referenced by the view-transition and toolbar sections without ever being introduced.

## Disposal

Nothing in the guides disposed the controllers. Both hold listeners, both have a `dispose`, and the toolbar example is the code readers lift into a real screen. Adds a Disposing section and fixes the example.

## Smaller corrections

- `eventsFromDateTimeRange` takes an `InternalDateTimeRange`, not a `DateTimeRange`. It is the only entry in that table whose argument type is not the obvious one.
- `CalendarHeader` does not accept `snapping`. Two guides said it did.
- The default display range runs 1 January two years back through 1 January two years ahead, not "two years either side of today".
- `selectEvent` and `deselectEvent` were missing beside the `selectedEvent` notifier they drive.
- `doc/README.md` called the view families four where the guide documents three.
- An events-guide link was labelled "Views & Interaction", a page that no longer exists.

## Verification

- All 43 doc snippets compile via `dart run tool/analyze_doc_snippets.dart`, up from 41.
- Every relative link and heading anchor across the guides resolves.