### PR TITLE
docs: dispose the controllers in the quick starts, and fix stale top-level docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ git tag v0.23.0 && git push origin v0.23.0
 
 `publish.yml` refuses the tag unless it points at a commit on main and `pubspec.yaml` matches it, then analyzes, tests, pins the repository links to the tag and publishes. A published version is permanent: it can be retracted within seven days, but the number can never be reused.
 
-The published archive is not byte-identical to the tag. Before packaging, the workflow runs `dart run tool/pin_release_links.dart <tag>`, which rewrites README.md, example/README.md and CHANGELOG.md so the pub.dev pages link to the tag's documentation instead of main. The rewrite is committed only inside the runner to keep the publish validator's clean-git check meaningful and is never pushed, so the repository keeps its relative links. To preview the published pages locally, run the script with any release tag, inspect with `git diff`, then restore with `git checkout -- README.md example/README.md CHANGELOG.md`.
+The published archive is not byte-identical to the tag. Before packaging, the workflow runs `dart run tool/pin_release_links.dart <tag>`, which rewrites README.md, example/README.md, CHANGELOG.md and doc/*.md so the pub.dev pages link to the tag's documentation instead of main. The rewrite is committed only inside the runner to keep the publish validator's clean-git check meaningful and is never pushed, so the repository keeps its relative links. To preview the published pages locally, run the script with any release tag, inspect with `git diff`, then restore with `git checkout -- README.md example/README.md CHANGELOG.md doc/`.
 
 The same tag rebuilds the [live demo](https://werner-scholtz.github.io/kalender/), so it always shows the published package rather than whatever is on main. To rebuild it from main instead, push a commit whose message contains `web demo`.
 
@@ -255,6 +255,20 @@ Patching an older release after main has moved on does not need a branch prepare
 ```bash
 git branch release/0.23.x v0.23.0
 ```
+
+### Before 1.0.0
+
+A pre-1.0.0 release can carry unfinished work that a 1.0.0 cannot. Audit these
+before tagging it:
+
+- **TODOs on public API.** Several are renames or removals deferred to 1.0.0,
+  including `CreateEventGesture` to `EventInteractionGesture`, the `renderBox`
+  parameter on `OnEventTapped` and `OnEventTappedWithDetail`, and
+  `MultiDayBodyConfiguration` in favour of `VerticalConfiguration`. Find them
+  with `grep -rn "TODO" lib/`. They are `//` comments so they do not render as
+  prose in the API reference, but each one is a decision still owed.
+- **Deprecations past their window.** `CalendarEvent.isMultiDayEvent` is removed
+  in 0.25.0. See [Verifying a removal](#verifying-a-removal).
 
 Key breaking changes to be aware of:
 - **v0.16.0**: `CalendarEvent` removed generic type parameter (use subclassing instead of `CalendarEvent<T>`). Event IDs changed from `int` to `String`. `EventsController` refactored to abstract interface.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -22,7 +22,7 @@ flutter pub add timezone
 
 If you only ever pass a `Location` into the calendar, nothing changes.
 
-### Three removals that outlived their deprecation window
+### Removals that outlived their deprecation window
 
 - `CalendarCallbacks.onMultiDayTapped`: deprecated in 0.13.0 and never called since then, so deleting the argument changes nothing.
 - `DateTimeExtensions.monthNameEnglish` and `dayNameEnglish`: use `monthNameLocalized('en')` and `dayNameLocalized('en')`.
@@ -536,11 +536,11 @@ class MyEvent extends CalendarEvent {
 ```
 
 > [!IMPORTANT]
-> You **must** override `==` and `hashCode` to include your custom fields. The base `CalendarEvent` equality only compares `id`, `dateTimeRange`, and `interaction`. Without the override, calls like `eventsController.updateEvent(event: original, updatedEvent: updated)` will not cause tile rebuilds when only custom fields (title, color, etc.) change.
+> You **must** override `==` and `hashCode` to include your custom fields. The base `CalendarEvent` equality compared only `id`, `dateTimeRange`, and `interaction` at the time of this release, and `multiDayRule` joined it in 0.24.0. Either way it never covers your own fields, so without the override, calls like `eventsController.updateEvent(event: original, updatedEvent: updated)` will not cause tile rebuilds when only custom fields (title, color, etc.) change.
 
 #### `layoutEquals`
 
-`layoutEquals` is used internally to skip expensive layout recalculations. The default implementation compares `id`, `dateTimeRange`, and `interaction` — which is correct for most subclasses. Only override it if a custom property changes the **size or position** of the tile (e.g. a flag that makes a tile render taller). Do **not** override it for content-only changes like color or title.
+`layoutEquals` is used internally to skip expensive layout recalculations. The default implementation compares `id`, `dateTimeRange`, and `interaction`, joined by `multiDayRule` in 0.24.0, which is correct for most subclasses. Only override it if a custom property changes the **size or position** of the tile (e.g. a flag that makes a tile render taller). Do **not** override it for content-only changes like color or title.
 
 ### Event IDs are now `String`
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ class _MyCalendarState extends State<MyCalendar> {
   final calendarController = CalendarController();
 
   @override
+  void dispose() {
+    calendarController.dispose();
+    eventsController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return CalendarView(
       eventsController: eventsController,
@@ -139,7 +146,7 @@ Runnable apps in [`examples/`](examples/README.md):
 
 The detailed guides live in [`doc/`](doc/README.md):
 
-- [Views](doc/views.md): the four view families, what carries over when you switch, and each view's configuration class.
+- [Views](doc/views.md): the three view families, what carries over when you switch, and each view's configuration class.
 - [Events](doc/events.md): attach your own data by subclassing `CalendarEvent`, and what counts as multi-day.
 - [Interaction](doc/interaction.md): creating, rescheduling, resizing, snapping and zooming.
 - [Controllers & Callbacks](doc/controllers-and-callbacks.md): drive the calendar from code, react to the user, and build a toolbar around it.

--- a/example/README.md
+++ b/example/README.md
@@ -35,6 +35,13 @@ class _MyCalendarState extends State<MyCalendar> {
   final calendarController = CalendarController();
 
   @override
+  void dispose() {
+    calendarController.dispose();
+    eventsController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return CalendarView(
       eventsController: eventsController,


### PR DESCRIPTION
## Disposal in the quick starts

The README and `example/README.md` quick starts create both controllers in a `State` and never dispose them. Both hold listeners and both have a `dispose`. This is the first code a reader copies, and `example/README.md` is what pub.dev renders on the Example tab.

## Stale statements

- **README** called the view families four where `doc/views.md` documents three. Day is a `MultiDayViewConfiguration` constructor, so the feature bullet's "Four views, one widget" is right and the guide pointer was not.
- **MIGRATION.md** stated in the present tense that `CalendarEvent` equality and `layoutEquals` compare `id`, `dateTimeRange` and `interaction`. Both gained `multiDayRule` in 0.24.0. These are historical sections, so they now say what was true then and what changed, rather than being silently wrong about today. A heading also counted three removals across two bullets.
- **AGENTS.md** described `pin_release_links.dart` as rewriting three files when it also rewrites `doc/*.md`, which made the restore command it gives incomplete and would leave the guides rewritten in a working tree.

## Pre-1.0.0 checklist

AGENTS.md gains one, under Releasing. The TODOs left on public API are deferred renames and removals rather than notes: `CreateEventGesture` to `EventInteractionGesture`, the `renderBox` parameter on the two tap callbacks, `MultiDayBodyConfiguration` in favour of `VerticalConfiguration`. A pre-1.0.0 release can carry them where a 1.0.0 cannot, so the release section is where that debt should surface.

Not changed: the README's mixed relative and absolute image URLs. I flagged that as an inconsistency, then found `pin_release_links.dart` pins both forms correctly, so it is cosmetic and not worth the churn.

## Verification

- All doc snippets compile.
- Every relative link and anchor resolves.
- `flutter test test/tool/pin_release_links_test.dart` passes.