### PR TITLE
fix: CalendarSnapping drops eventSnapStrategy from == and copyWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ See [MIGRATION.md](MIGRATION.md#v023x--v0240) for what to change.
 ### Fixes
 
 - `CalendarInteraction` and `HorizontalConfiguration` compare every field in `==`. Four fields were missing, so changing only one of them never updated the calendar. [#364](https://github.com/werner-scholtz/kalender/pull/364)
+- `CalendarSnapping` compares `eventSnapStrategy` in `==` and carries it through `copyWith`, which now takes it as a parameter. Changing only the strategy on a live calendar had no effect, and `copyWith` reset a custom strategy to `defaultSnapStrategy`. Pass a top-level or static function, since an inline closure now makes every rebuild read as a change. [#402](https://github.com/werner-scholtz/kalender/pull/402)
 - Dragging to create an event no longer reacts to a drag that started on a different calendar. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - `ScrollTriggerConfiguration.copyWith` keeps `scrollAmount` instead of resetting it to the default. [#366](https://github.com/werner-scholtz/kalender/pull/366)
 - `MultiDayViewConfiguration.copyWith` and `MonthViewConfiguration.copyWith` keep `multiDayRule` instead of resetting it to the default, and take a parameter to change it. `MonthViewConfiguration.copyWith` also keeps `nowCallback` and no longer takes an `eventPadding` parameter, which set nothing. [#387](https://github.com/werner-scholtz/kalender/pull/387)

--- a/lib/src/models/calendar_interaction.dart
+++ b/lib/src/models/calendar_interaction.dart
@@ -311,6 +311,10 @@ class CalendarSnapping {
   /// The strategy used to snap events to specific intervals.
   ///
   /// This strategy is only used by the multi-day body.
+  ///
+  /// Takes part in `==`, so pass a top-level or static function. An inline
+  /// closure is a new object on every build, which makes each rebuild look like
+  /// a change.
   final EventSnapStrategy eventSnapStrategy;
 
   /// Creates a new [CalendarSnapping] instance with the specified settings.
@@ -331,22 +335,27 @@ class CalendarSnapping {
     bool? snapToTimeIndicator,
     bool? snapToOtherEvents,
     Duration? snapRange,
+    EventSnapStrategy? eventSnapStrategy,
   }) {
     return CalendarSnapping(
       snapIntervalMinutes: snapIntervalMinutes ?? this.snapIntervalMinutes,
       snapToTimeIndicator: snapToTimeIndicator ?? this.snapToTimeIndicator,
       snapToOtherEvents: snapToOtherEvents ?? this.snapToOtherEvents,
       snapRange: snapRange ?? this.snapRange,
+      eventSnapStrategy: eventSnapStrategy ?? this.eventSnapStrategy,
     );
   }
 
   @override
   operator ==(Object other) {
+    if (identical(this, other)) return true;
+
     return other is CalendarSnapping &&
         other.snapIntervalMinutes == snapIntervalMinutes &&
         other.snapToTimeIndicator == snapToTimeIndicator &&
         other.snapToOtherEvents == snapToOtherEvents &&
-        other.snapRange == snapRange;
+        other.snapRange == snapRange &&
+        other.eventSnapStrategy == eventSnapStrategy;
   }
 
   @override
@@ -355,5 +364,6 @@ class CalendarSnapping {
         snapToTimeIndicator,
         snapToOtherEvents,
         snapRange,
+        eventSnapStrategy,
       );
 }

--- a/test/models/calendar_interaction_test.dart
+++ b/test/models/calendar_interaction_test.dart
@@ -217,6 +217,18 @@ void main() {
       expect(copy.snapRange, equals(const Duration(minutes: 15)));
     });
 
+    test('copyWith preserves a custom eventSnapStrategy', () {
+      const original = CalendarSnapping(eventSnapStrategy: _noSnapStrategy);
+      final copy = original.copyWith(snapIntervalMinutes: 30);
+      expect(copy.eventSnapStrategy, same(_noSnapStrategy));
+    });
+
+    test('copyWith replaces eventSnapStrategy when given one', () {
+      const original = CalendarSnapping();
+      final copy = original.copyWith(eventSnapStrategy: _noSnapStrategy);
+      expect(copy.eventSnapStrategy, same(_noSnapStrategy));
+    });
+
     test('identical configurations are equal with matching hashCodes', () {
       expect(const CalendarSnapping(), equals(const CalendarSnapping()));
       expect(const CalendarSnapping().hashCode, equals(const CalendarSnapping().hashCode));
@@ -227,10 +239,22 @@ void main() {
       'snapToTimeIndicator': const CalendarSnapping(snapToTimeIndicator: false),
       'snapToOtherEvents': const CalendarSnapping(snapToOtherEvents: false),
       'snapRange': const CalendarSnapping(snapRange: Duration(minutes: 30)),
+      'eventSnapStrategy': const CalendarSnapping(eventSnapStrategy: _noSnapStrategy),
     }.entries) {
       test('differing ${entry.key} breaks equality', () {
         expect(entry.value, isNot(equals(const CalendarSnapping())));
+        expect(entry.value.hashCode, isNot(equals(const CalendarSnapping().hashCode)));
       });
     }
   });
+}
+
+/// A strategy that snaps nothing, so it is distinguishable from
+/// [defaultSnapStrategy].
+InternalDateTime _noSnapStrategy(
+  InternalDateTime cursorDate,
+  InternalDateTime startOfDay,
+  int snapIntervalMinutes,
+) {
+  return cursorDate;
 }

--- a/test/widgets/calendar_snapping_update_test.dart
+++ b/test/widgets/calendar_snapping_update_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/providers/calendar_provider.dart';
+
+import '../utilities.dart';
+
+/// A strategy that snaps nothing, so it is distinguishable from
+/// [defaultSnapStrategy] by behavior rather than by identity alone.
+InternalDateTime noSnapStrategy(
+  InternalDateTime cursorDate,
+  InternalDateTime startOfDay,
+  int snapIntervalMinutes,
+) {
+  return cursorDate;
+}
+
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  tearDown(() {
+    calendarController.dispose();
+    eventsController.dispose();
+  });
+
+  Widget buildCalendar(CalendarSnapping snapping) {
+    return CalendarView(
+      eventsController: eventsController,
+      calendarController: calendarController,
+      viewConfiguration: MultiDayViewConfiguration.week(
+        displayRange: year2025DisplayRange,
+        initialDateTime: DateTime(2025, 1, 1),
+      ),
+      body: CalendarBody(snapping: snapping),
+    );
+  }
+
+  /// The snapping the calendar's widget tree is actually reading.
+  CalendarSnapping resolvedSnapping(WidgetTester tester) {
+    return tester.widget<Snapping>(find.byType(Snapping)).notifier!.value;
+  }
+
+  /// 00:08 with a 15 minute interval. [defaultSnapStrategy] moves it to 00:15,
+  /// [noSnapStrategy] leaves it alone, so the result names the strategy in use.
+  InternalDateTime applyStrategy(CalendarSnapping snapping) {
+    return snapping.eventSnapStrategy(
+      InternalDateTime(2025, 1, 1, 0, 8),
+      InternalDateTime(2025, 1, 1),
+      15,
+    );
+  }
+
+  testWidgets('the initial eventSnapStrategy reaches the widget tree', (tester) async {
+    await pumpAndSettleWithMaterialApp(
+      tester,
+      buildCalendar(const CalendarSnapping(eventSnapStrategy: noSnapStrategy)),
+    );
+
+    expect(applyStrategy(resolvedSnapping(tester)), equals(InternalDateTime(2025, 1, 1, 0, 8)));
+  });
+
+  testWidgets('changing only eventSnapStrategy updates the widget tree', (tester) async {
+    await pumpAndSettleWithMaterialApp(tester, buildCalendar(const CalendarSnapping()));
+
+    // The default strategy rounds 00:08 up to 00:15.
+    expect(applyStrategy(resolvedSnapping(tester)), equals(InternalDateTime(2025, 1, 1, 0, 15)));
+
+    // Rebuild with a snapping that differs only by its strategy.
+    await pumpAndSettleWithMaterialApp(
+      tester,
+      buildCalendar(const CalendarSnapping(eventSnapStrategy: noSnapStrategy)),
+    );
+
+    expect(
+      applyStrategy(resolvedSnapping(tester)),
+      equals(InternalDateTime(2025, 1, 1, 0, 8)),
+      reason: 'the new strategy should be in effect, so 00:08 is left alone',
+    );
+  });
+
+  testWidgets('changing eventSnapStrategy alongside another field updates the widget tree', (tester) async {
+    await pumpAndSettleWithMaterialApp(tester, buildCalendar(const CalendarSnapping()));
+
+    await pumpAndSettleWithMaterialApp(
+      tester,
+      buildCalendar(const CalendarSnapping(snapIntervalMinutes: 30, eventSnapStrategy: noSnapStrategy)),
+    );
+
+    final snapping = resolvedSnapping(tester);
+    expect(snapping.snapIntervalMinutes, equals(30));
+    expect(applyStrategy(snapping), equals(InternalDateTime(2025, 1, 1, 0, 8)));
+  });
+}


### PR DESCRIPTION
Follow-up to the pre-release review. `CalendarSnapping` compared four of its five fields and copied four of its five fields. `eventSnapStrategy` was in neither.

## Proof, before the fix

Three tests were written first and fail on `main`.

**1. `copyWith` silently resets a custom strategy.** It neither took the parameter nor forwarded the existing value.

```
Expected: same instance as <Closure: ... from Function '_noSnapStrategy'>
  Actual: <Closure: ... from Function 'defaultSnapStrategy'>
```

Adding an `eventSnapStrategy:` argument to `copyWith` did not even compile: `Error: No named parameter with the name 'eventSnapStrategy'.`

**2. Two configurations differing only by strategy compared equal.**

**3. Changing only the strategy on a live calendar did nothing.** This is the user-visible one. `CalendarBody` holds the snapping in a `ValueNotifier` and gates the update on `oldWidget.snapping != widget.snapping`, so a strategy-only change failed that guard, and `ValueNotifier.value` would have rejected the assignment on the same comparison anyway. The old strategy stayed in effect for the life of the widget.

```
Expected: InternalDateTime:<2025-01-01 00:08:00.000Z>
  Actual: InternalDateTime:<2025-01-01 00:15:00.000Z>
```

The widget test asserts through behavior rather than identity: it applies the resolved strategy to 00:08 with a 15 minute interval, which `defaultSnapStrategy` moves to 00:15 and the test's strategy leaves alone, so the result names the strategy actually in use.

## Scope, narrower than I first reported

Changing the strategy **alongside another field** always worked, because the other field makes `!=` true and the whole object is then assigned. Only a strategy-only change was dropped. That is why this went unnoticed, and the third test covers it so it stays working.

The initial strategy passed at construction also always worked. Only updates were affected.

## The tradeoff

Including a function field in `==` follows what `VerticalConfiguration.eventLayoutStrategy` and `HorizontalConfiguration.generateMultiDayLayoutFrame` already do, so this makes `CalendarSnapping` consistent with its siblings rather than introducing a new pattern.

The cost is that an inline closure is a new object on every build, so every rebuild now reads as a change where previously it read as none. For a calendar that passes one, `_snapping.value` is reassigned per rebuild, which re-runs `VerticalDragTarget._updateSnapPoints` (a no-op unless `snapToOtherEvents` is set) and rebuilds the widgets reading `context.snapping`. The field's dartdoc now says to pass a top-level or static function. Worth a look, since it is the one behavior change here that is not strictly a fix.

## Verification

- The three new tests fail on the parent commit and pass here.
- All 1574 tests pass, across all six timezones via `dart tool/test_timezones_linux.dart`.
- `flutter analyze` clean, formatting clean.
- No example sets a custom `eventSnapStrategy`, so nothing in `examples/` changes behavior.