### PR TITLE
chore: bump version to 0.24.0-dev.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.24.0-dev.4
+version: 0.24.0-dev.5
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
A preview so the pub.dev page can be reviewed. This is the first release carrying the screenshot gallery, the five topics and the issue tracker link, so the package page changes visibly.

Since dev.4:

- #397 dartdoc corrections, so the API reference no longer carries stale defaults or TODO prose
- #398 formatting, plus a real formatting check in CI
- #399 pub.dev screenshots, topics and issue tracker
- #400 guide reference blocks at their true defaults, plus `timeOfDayRange` and `EventInteraction` coverage
- #401 controller disposal in the quick starts
- #402 `CalendarSnapping` compares and copies `eventSnapStrategy`

## What to look at on pub.dev

- The screenshot gallery, and the search-result thumbnail, which comes from `desktop_light.png`
- The five topics
- The archive is now 529 KB, up from about 150 KB, because `readme_assets/` ships for the screenshots
- The Example tab, which renders `example/README.md`

## Release path checked

`flutter pub publish --dry-run` reports **0 warnings** when run the way `publish.yml` does, after `pin_release_links.dart` has run.

Run directly against this branch it reports one warning, that CHANGELOG.md does not mention `0.24.0-dev.5`. That is expected and is how every dev release so far has looked: the changelog accumulates under `## 0.24.0`, and the pinning step rewrites the MIGRATION.md links to the tag, which puts the version string in the file and satisfies the check. Verified by reproducing the workflow's exact sequence locally.