### PR TITLE
chore: drop the pub.dev screenshot gallery, and bump to 0.24.0-dev.6

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -5,13 +5,10 @@ coverage/
 __pycache__/
 
 test/
+readme_assets/
 examples/
 tool/
 benchmark/
-
-# readme_assets/ is published on purpose: the pubspec `screenshots` entries and
-# the README images both read from it, and pub.dev only serves files that are in
-# the archive.
 
 # Instructions for coding agents working on this repo, of no use to anyone
 # installing the package.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.24.0-dev.5
+version: 0.24.0-dev.6
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:
@@ -9,18 +9,6 @@ topics:
   - scheduler
   - timezone
   - drag-and-drop
-
-# pub.dev renders these as a gallery on the package page and takes the search
-# result thumbnail from the first one.
-screenshots:
-  - description: Week view on desktop in the light theme, with the time indicator and overlapping events.
-    path: readme_assets/desktop_light.png
-  - description: Week view on desktop in the dark theme.
-    path: readme_assets/desktop_dark.png
-  - description: Three-day view on mobile in the light theme.
-    path: readme_assets/mobile_light.png
-  - description: Three-day view on mobile in the dark theme.
-    path: readme_assets/mobile_dark.png
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
The screenshot gallery added in #399 does not look good on the package page, so it goes.

- The `screenshots` entries are removed from `pubspec.yaml`.
- `readme_assets/` returns to `.pubignore`, taking the archive from 529 KB back to 168 KB.
- The five topics and the `issue_tracker` link stay.

README images are unaffected either way, since pub.dev resolves those against the repository rather than the archive, and `tool/pin_release_links.dart` still pins them to the tag.

## Version

`0.24.0-dev.6`, not dev.5. `0.24.0-dev.5` is already published and a version can never be reused, so the removal needs a new number to reach pub.dev.

## Verification

`flutter pub publish --dry-run` reports 0 warnings when run the way `publish.yml` does, after `pin_release_links.dart`. `flutter analyze` clean, formatting clean.