### PR TITLE
chore: act on the pre-release review, bump to 0.24.0-dev.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,9 +205,11 @@ A message without a version has no deadline and will sit there for years. Three 
 
 - Turning a getter into a method of the same name. Dart rejects declaring both (`duplicate_definition`), so the getter has to vanish the moment the method appears.
 - Adding a named parameter to a method that subclasses override, including optional ones. An override must accept every named parameter its supertype declares, so `copyWith` and `eventsFromDateTimeRange` break every implementer either way.
-- Adding a member to a public mixin or abstract class, such as `DragTargetUtilities.mounted`.
+- Adding a member to a public mixin or abstract class, or narrowing what it can be applied to, such as constraining `DragTargetUtilities` to `State`.
 
 **Record it in both places.** A deprecation gets a `### Deprecations` entry in the changelog naming the removal version. A breaking change gets a `### Breaking Changes` entry plus a section in [MIGRATION.md](MIGRATION.md) showing the before and after.
+
+**`### Breaking Changes` is for code that stops compiling. `### Behavior Changes` is for code that still compiles and renders differently.** They ask the reader for different things: one is "fix your code", the other is "look at your screenshots". Do not put them under one heading. 0.23.0 is the reference for the second kind, 0.24.0 for the first.
 
 **If the version is not tagged yet, amend the existing entries rather than appending.** Someone upgrading should read what the release does, not the history of how it got there.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,13 @@ See [MIGRATION.md](MIGRATION.md#v023x--v0240) for what to change.
 - `ScheduleTileComponents` no longer accepts `dropTargetTile`, `overlayTileBuilder` or `resizeDragAnchorStrategy`. None of them had any effect. Delete the arguments. To style the drop target, use `ScheduleComponents.scheduleTileHighlightBuilder` and `ScheduleTileHighlightStyle`. [#381](https://github.com/werner-scholtz/kalender/pull/381)
 - `ScheduleTileComponents.emptyItemBuilder` and `monthItemBuilder` are moved to `ScheduleComponents`. Set them on `CalendarComponents.scheduleComponents` instead. Signatures and defaults are unchanged. See [MIGRATION.md](MIGRATION.md#v023x--v0240). [#383](https://github.com/werner-scholtz/kalender/pull/383)
 - `CalendarInteraction.throttleMilliseconds` is removed. Drag updates are now combined into one per frame and follow the display's refresh rate. Nothing replaces it. Delete the argument. [#368](https://github.com/werner-scholtz/kalender/pull/368)
-- `DragTargetUtilities` requires a `mounted` getter. A class applying the mixin to a `State` already satisfies it. Anything else must supply one. [#368](https://github.com/werner-scholtz/kalender/pull/368)
+- `DragTargetUtilities` can only be applied to a `State`. It supplies `context` and `mounted` itself instead of requiring them from the host. A class applying the mixin to a `State` needs no change. Anything else no longer compiles. [#368](https://github.com/werner-scholtz/kalender/pull/368)
 
 ### Features
 
 - Dragging a multi-day event down over the body keeps moving its drop target in the header, instead of freezing it until the cursor returns. Releasing over the body applies the date and keeps the time of day and duration. [#369](https://github.com/werner-scholtz/kalender/pull/369)
 - `MultiDayRule` decides which events belong in the multi-day header rather than the day timeline. Set it once on the view configuration. `MultiDayRule.minimumDuration` at 24 hours is the default and matches the previous behavior. `MultiDayRule.calendarDays` treats anything crossing midnight as multi-day. A single event can override the rule with `CalendarEvent.multiDayRule`. [#367](https://github.com/werner-scholtz/kalender/pull/367) [#371](https://github.com/werner-scholtz/kalender/pull/371) [#376](https://github.com/werner-scholtz/kalender/pull/376)
+- In debug builds, a drag or resize asserts that the event's `copyWith` forwarded `id` and `multiDayRule`. `copyWith` takes no parameter for either, so an override that omits them drops them on every copy, silently until selection or multi-day placement goes wrong. The message names the subclass and the argument to add. [#367](https://github.com/werner-scholtz/kalender/pull/367)
 
 ### Deprecations
 
@@ -39,13 +40,23 @@ See [MIGRATION.md](MIGRATION.md#v023x--v0240) for what to change.
 - The two drag-target guards that decide whether an event may be dropped in the header or the body now use the calendar's location, so they agree with the rest of the calendar near midnight and across daylight saving changes. [#367](https://github.com/werner-scholtz/kalender/pull/367)
 - A calendar whose locale has no intl data loaded now names the locale, the `initializeDateFormatting()` call to add and the library it comes from, instead of throwing intl's `LocaleDataException` from inside a build. [#382](https://github.com/werner-scholtz/kalender/pull/382)
 - `TileComponents.overlayTileBuilder` is used again by the tiles in the multi-day overflow overlay. It had been ignored since 0.14.0. [#381](https://github.com/werner-scholtz/kalender/pull/381)
-- The vertical layout delegate returns layout data for every event, even when two events share a hash code. This is not reachable through `DefaultEventsController`. [#370](https://github.com/werner-scholtz/kalender/pull/370)
+- The vertical layout delegate returns layout data for every event, even when two events share a hash code. The layout cache is keyed by that hash, so events sharing one previously left a tile with no layout data. `CalendarEvent.hashCode` is built from `id`, `start`, `end`, `interaction` and `multiDayRule`, so this needs a custom `EventsController` that gives two events the same `id`. [#370](https://github.com/werner-scholtz/kalender/pull/370)
+
+### Tests
+
+- Added equality coverage for the configuration classes: every field of `VerticalConfiguration` and `HorizontalConfiguration` breaks equality when it differs, two configurations built from the same arguments compare equal, and `nowCallback`, `initialTimeOfDay` and `initialHeightPerMinute` take part. [#364](https://github.com/werner-scholtz/kalender/pull/364) [#404](https://github.com/werner-scholtz/kalender/pull/404)
+- Added `copyWith` round-trip coverage for the view and body configurations, so a field that is not being changed survives the copy. [#366](https://github.com/werner-scholtz/kalender/pull/366) [#387](https://github.com/werner-scholtz/kalender/pull/387)
+- Added coverage that the vertical layout delegate returns one entry per child when two events share a hash code, including a subclass whose `hashCode` ignores the id, and when the cache is already warm. [#370](https://github.com/werner-scholtz/kalender/pull/370)
+- Added coverage that a drag or resize asserts when the event's `copyWith` drops `id` or `multiDayRule`, and stays silent for an override that forwards both. [#367](https://github.com/werner-scholtz/kalender/pull/367)
+- Added coverage that `TileComponents.overlayTileBuilder` renders the overflow overlay tiles, and falls back to `tileBuilder` when it is not set. [#381](https://github.com/werner-scholtz/kalender/pull/381)
+- Added coverage that drag moves arriving within one frame coalesce into a single update, that the update uses the newest move, and that a move queued at the moment of the drop is discarded. [#368](https://github.com/werner-scholtz/kalender/pull/368)
+- Added coverage for the multi-day rule on the view configurations, and that dragging a multi-day tile into the body keeps moving its header preview. [#367](https://github.com/werner-scholtz/kalender/pull/367) [#369](https://github.com/werner-scholtz/kalender/pull/369) [#371](https://github.com/werner-scholtz/kalender/pull/371)
 
 ## 0.23.0
 
 Nothing in this release stops existing code from compiling. See [MIGRATION.md](MIGRATION.md#v022x--v0230) for what to change.
 
-### Breaking Changes
+### Behavior Changes
 
 Each of these changes what an unchanged calendar renders.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,16 @@
 # Migration Guide
 
+Each section covers one upgrade. Versions not listed below need no changes.
+
+| Upgrade | What changes |
+| --- | --- |
+| [v0.23.x → v0.24.0](#v023x--v0240) | The timezone re-export, the deprecated string builders, the multi-day rule, and six smaller removals. |
+| [v0.22.x → v0.23.0](#v022x--v0230) | String builders move off the style classes. Nothing stops compiling, but an unchanged calendar renders differently. |
+| v0.19.x → v0.22.x | No changes needed. |
+| [v0.18.x → v0.19.0](#v018x--v0190) | The timeline gutter width, view-transition controls, and the month day header's date type. |
+| [v0.16.x → v0.17.0](#v016x--v0170) | Input mode replaces the mobile/desktop split. |
+| [v0.15.x → v0.16.0](#v015x--v0160) | `CalendarEvent` is no longer generic and event ids become `String`. |
+
 ## v0.23.x → v0.24.0
 
 ### The deprecated string builders are gone
@@ -78,24 +89,24 @@ Delete the argument. Nothing replaces it.
 
 Drag updates are now coalesced to one per frame rather than throttled against the clock, so they follow whatever rate the display refreshes at. The old default of 16ms assumed a 60Hz screen and capped updates at about 62 per second, which is half what a 120Hz display can show. There is no longer a value to choose.
 
-### `DragTargetUtilities` requires `mounted`
+### `DragTargetUtilities` can only be applied to a `State`
 
-Only affects you if you apply the mixin yourself. A `State` already provides `mounted`, so this is nothing to do:
+Only affects you if you apply the mixin yourself. Applied to a `State`, which is the usual case, nothing changes. The type argument is inferred from the superclass:
 
 ```dart
 class _MyDragTargetState extends State<MyDragTarget> with DragTargetUtilities { }
 ```
 
-Anywhere else, supply it:
+Applied to anything else, it no longer compiles:
 
 ```dart
-  class MyDragHandler with DragTargetUtilities {
-+   @override
-+   bool get mounted => true;
-  }
+- class MyDragHandler with DragTargetUtilities {
+-   @override
+-   BuildContext get context => ...;
+- }
 ```
 
-The mixin defers move handling to the end of the frame, so it can outlive disposal and has to know whether its context is still usable. Reading `State.context` after disposal throws rather than returning null, which is why the check cannot live inside the mixin.
+The mixin defers move handling to the end of the frame, so it can outlive disposal and has to know whether its context is still usable. Reading `State.context` after disposal throws rather than returning null, so the host has to answer `mounted` correctly. `State` already does.
 
 ### `isMultiDayEvent` became `spansMultipleDays`
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ A highly customizable Flutter calendar widget with Day, Multi-day, Month and Sch
 
 **[Live Demo](https://werner-scholtz.github.io/kalender/)** · **[Benchmarks](https://werner-scholtz.github.io/kalender/dev/bench/)** · **[Migration Guide](MIGRATION.md)**
 
-> [!WARNING]
-> This package is still in development. API changes may occur before version 1.0.0, so pin an exact version in your `pubspec.yaml` rather than a caret range like `^0.24.0`.
->
-> 1.0.0 is close. If part of the API does not work for you, please [open an issue](https://github.com/werner-scholtz/kalender/issues).
-
 <p align="center">
   <img src="readme_assets/desktop_light.png" alt="Week view on desktop, light theme" width="74%" />
   <img src="readme_assets/mobile_light.png" alt="Three-day view on mobile, light theme" width="23%" />
@@ -39,8 +34,14 @@ A highly customizable Flutter calendar widget with Day, Multi-day, Month and Sch
 - **Controllers and callbacks.** Navigate from code, and react to taps, creation and changes.
 - **Replaceable, not just configurable.** Swap any widget, or keep it and restyle it.
 - **Material 3 by default.** Follows your app's theme with no setup.
-- **Timezone aware.** Events stored as UTC, shown in any IANA location.
+- **Timezone aware.** Events stored as UTC, shown in any IANA location. Tested under a matrix of timezones.
 - **Localized.** Day and month names from intl, and every string replaceable.
+- **MIT licensed.** No commercial license to buy.
+
+> [!WARNING]
+> This package is still in development, so breaking changes land in minor releases until 1.0.0. A caret range like `^0.24.0` keeps you on 0.24.x, which is where fixes land. Every minor bump has an entry in the [migration guide](MIGRATION.md).
+>
+> If part of the API does not work for you, please [open an issue](https://github.com/werner-scholtz/kalender/issues).
 
 ## Installation
 
@@ -146,13 +147,13 @@ Runnable apps in [`examples/`](examples/README.md):
 
 The detailed guides live in [`doc/`](doc/README.md):
 
-- [Views](doc/views.md): the three view families, what carries over when you switch, and each view's configuration class.
-- [Events](doc/events.md): attach your own data by subclassing `CalendarEvent`, and what counts as multi-day.
-- [Interaction](doc/interaction.md): creating, rescheduling, resizing, snapping and zooming.
-- [Controllers & Callbacks](doc/controllers-and-callbacks.md): drive the calendar from code, react to the user, and build a toolbar around it.
-- [Appearance](doc/appearance.md): tile builders, theming, and custom components.
-- [Layout](doc/layout.md): where tiles are placed and sized. Advanced, only needed for a custom strategy.
-- [Timezones & Locales](doc/timezones-and-locales.md): display timezones, localized names, and custom text.
+- **[Views](doc/views.md).** Multi-day (day, week, work week, custom day counts, free scroll), month and schedule. What carries over on a view switch: the focused date, the scroll position, the zoom level.
+- **[Events](doc/events.md).** Subclassing `CalendarEvent` to attach your own data, updating events through the controller, and the `MultiDayRule` that puts an event in the multi-day header rather than the day timeline.
+- **[Interaction](doc/interaction.md).** Creating, rescheduling and resizing, set separately for the header and the body and lockable per event. Snapping to an interval, the time indicator, other events, or your own strategy. Zoom driven from the controller.
+- **[Controllers & Callbacks](doc/controllers-and-callbacks.md).** Jumping and animating to a date or an event, switching views, reacting to taps, creation, resizing and rescheduling, and building a navigation toolbar.
+- **[Appearance](doc/appearance.md).** A `ThemeExtension` with Material 3 defaults that follows your app's `ThemeData`, and replacing components outright: event tiles, day headers, the timeline gutter, the time indicator, the multi-day overflow overlay.
+- **[Layout](doc/layout.md).** Where tiles are placed and sized, and how overlapping events share a column. Only needed for a custom layout strategy, such as one lane per person.
+- **[Timezones & Locales](doc/timezones-and-locales.md).** Events stored as UTC and displayed in any IANA location, across daylight saving changes and midnight. Day and month names from intl in the calendar's locale, right-to-left layouts, and replacing any string.
 
 ---
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -15,4 +15,4 @@ it covers the choice every calendar has to make first.
 
 The API reference is on
 [pub.dev](https://pub.dev/documentation/kalender/latest/kalender/kalender-library.html).
-Runnable apps are in [examples](https://github.com/werner-scholtz/kalender/tree/main/examples).
+Runnable apps are in [examples](../examples).

--- a/doc/controllers-and-callbacks.md
+++ b/doc/controllers-and-callbacks.md
@@ -181,7 +181,7 @@ Switching `viewConfiguration` is all a view change takes. What carries over,
 such as the date and scroll position, is set on the configuration itself, see
 [Views](views.md#switching-between-views).
 
-The [basic example](https://github.com/werner-scholtz/kalender/tree/main/examples/example) has a fuller version of this toolbar.
+The [basic example](../examples/example) has a fuller version of this toolbar.
 
 ---
 

--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -75,7 +75,7 @@ it through with `super.interaction`, as in [Custom Events](events.md#custom-even
 
 ## Zoom
 
-Zoom the calendar in and out by changing the `heightPerMinute` value on the `MultiDayViewController`. The [`web_demo`](https://github.com/werner-scholtz/kalender/tree/main/examples/web_demo) example shows a full implementation with [`ZoomDetector`](https://github.com/werner-scholtz/kalender/blob/main/examples/web_demo/lib/widgets/calendar/zoom.dart).
+Zoom the calendar in and out by changing the `heightPerMinute` value on the `MultiDayViewController`. The [`web_demo`](../examples/web_demo) example shows a full implementation with [`ZoomDetector`](../examples/web_demo/lib/widgets/calendar/zoom.dart).
 
 Here's a minimal example of wiring up zoom with Ctrl+scroll on desktop. `PointerScrollEvent` and `HardwareKeyboard` are not exported by `material.dart`, so both imports are needed:
 

--- a/doc/layout.md
+++ b/doc/layout.md
@@ -20,7 +20,7 @@ Built-in strategies (pass via `MultiDayBodyConfiguration.eventLayoutStrategy`):
 | `overlapLayoutStrategy`    | Tiles stack on top of each other (default) |
 | `sideBySideLayoutStrategy` | Tiles placed side by side                  |
 
-To create a custom strategy, subclass `EventLayoutDelegate`. See [`CustomSideBySideLayoutDelegate`](https://github.com/werner-scholtz/kalender/blob/main/examples/advanced_example/lib/layout_strategy.dart) in the advanced example.
+To create a custom strategy, subclass `EventLayoutDelegate`. See [`CustomSideBySideLayoutDelegate`](../examples/advanced_example/lib/layout_strategy.dart) in the advanced example.
 
 Here's a minimal skeleton:
 

--- a/doc/timezones-and-locales.md
+++ b/doc/timezones-and-locales.md
@@ -132,7 +132,7 @@ final eventsController = DefaultEventsController(
 );
 ```
 
-See the [timezone package](https://pub.dev/packages/timezone) for setup instructions per platform. The [web demo](https://github.com/werner-scholtz/kalender/tree/main/examples/web_demo) also provides a working example.
+See the [timezone package](https://pub.dev/packages/timezone) for setup instructions per platform. The [web demo](../examples/web_demo) also provides a working example.
 
 Changing `location` at runtime automatically updates visible date/time ranges. Location identifiers follow the [IANA Time Zone Database](https://www.iana.org/time-zones).
 
@@ -155,7 +155,7 @@ When events come from an `.ics` file, a device calendar, or an API, map each sou
 
 - **Floating time** (no zone, common in `.ics`): decide which zone it should mean, usually the calendar's `location`, and build a `TZDateTime` there.
 
-Then set `CalendarView(location:)` to the zone the calendar should display in. The [ics example](https://github.com/werner-scholtz/kalender/tree/main/examples/ics) shows this end to end.
+Then set `CalendarView(location:)` to the zone the calendar should display in. The [ics example](../examples/ics) shows this end to end.
 
 ### Now Callback
 

--- a/examples/doc_snippets/lib/preamble.dart
+++ b/examples/doc_snippets/lib/preamble.dart
@@ -73,7 +73,7 @@ final eventsController = DefaultEventsController();
 final calendarController = CalendarController();
 final viewConfiguration = MultiDayViewConfiguration.week();
 
-final location = tz.getLocation('UTC');
+final location = tz.getLocation('Etc/UTC');
 final range =
     DateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2025, 1, 2));
 final event = CalendarEvent(dateTimeRange: range);

--- a/lib/src/models/calendar_events/checked_copy.dart
+++ b/lib/src/models/calendar_events/checked_copy.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:kalender/kalender.dart';
+
+/// Copies used by the calendar's own drag and resize handling.
+extension CheckedEventCopy on CalendarEvent {
+  /// [CalendarEvent.copyWith], checking in debug mode that the override kept
+  /// the state it takes no parameter for.
+  ///
+  /// [CalendarEvent.id] and [CalendarEvent.multiDayRule] are carried over by the
+  /// base implementation, so a subclass that omits them returns a copy with a
+  /// new identity or without its rule.
+  CalendarEvent checkedCopyWith({
+    DateTimeRange? dateTimeRange,
+    EventInteraction? interaction,
+  }) {
+    final copy = copyWith(dateTimeRange: dateTimeRange, interaction: interaction);
+
+    assert(
+      copy.id == id,
+      '$runtimeType.copyWith did not forward id, so every drag and resize produces a copy the calendar '
+      'reads as a different event. Add "id: id" to the override.',
+    );
+    assert(
+      copy.multiDayRule == multiDayRule,
+      '$runtimeType.copyWith did not forward multiDayRule, so every drag and resize produces a copy that '
+      'falls back to the view configuration\'s rule. Add "multiDayRule: multiDayRule" to the override.',
+    );
+
+    return copy;
+  }
+}

--- a/lib/src/models/calendar_events/draggable_event.dart
+++ b/lib/src/models/calendar_events/draggable_event.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/calendar_events/checked_copy.dart';
 
 /// A class used by the [DragTargetUtilities] to determine that a [CalendarEvent] is being rescheduled.
 class Reschedule {
@@ -31,7 +32,7 @@ class Resize {
   Resize updateDateTimeRange(
     DateTimeRange dateTimeRange,
   ) {
-    final updatedEvent = event.copyWith(dateTimeRange: dateTimeRange);
+    final updatedEvent = event.checkedCopyWith(dateTimeRange: dateTimeRange);
     return Resize(event: updatedEvent, direction: direction);
   }
 }

--- a/lib/src/models/mixins/drag_target_utils.dart
+++ b/lib/src/models/mixins/drag_target_utils.dart
@@ -1,18 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/calendar_events/checked_copy.dart';
 import 'package:kalender/src/models/calendar_events/draggable_event.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
 typedef UpdatedEvent = (CalendarEvent, CalendarEvent);
 
-mixin DragTargetUtilities {
-  BuildContext get context;
-
-  /// Whether [context] is still usable.
-  ///
-  /// Satisfied by [State.mounted]. Checked before any deferred work, since
-  /// reading [State.context] after disposal throws rather than returning null.
-  bool get mounted;
+/// Shared drag-target behaviour for the calendar's [DragTarget] states.
+///
+/// Constrained to [State] for [context] and [mounted]. [mounted] is checked
+/// before any deferred work, since reading [State.context] after disposal
+/// throws rather than returning null.
+mixin DragTargetUtilities<T extends StatefulWidget> on State<T> {
   CalendarController get controller;
   EventsController get eventsController;
   CalendarCallbacks? get callbacks;
@@ -313,6 +312,6 @@ mixin DragTargetUtilities {
     );
 
     final range = InternalDateTimeRange(start: newStart, end: newStart.add(event.duration));
-    return event.copyWith(dateTimeRange: toLocationDateTimeRange(range));
+    return event.checkedCopyWith(dateTimeRange: toLocationDateTimeRange(range));
   }
 }

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -5,9 +5,8 @@ import 'package:kalender/src/widgets/internal_components/day_number.dart';
 
 /// The month day header builder.
 ///
-/// The [date] is provided as a wall-clock [DateTime] in the calendar's
-/// configured location (via `.forLocation()`), so consumer comparisons against
-/// `DateTime.now()` behave correctly. See #248.
+/// The [date] is a wall-clock [DateTime] in the calendar's configured location,
+/// so comparisons against `DateTime.now()` behave correctly.
 typedef MonthDayHeaderBuilder = Widget Function(
   DateTime date,
   MonthDayHeaderStyle? style,

--- a/lib/src/widgets/drag_targets/horizontal_drag_target.dart
+++ b/lib/src/widgets/drag_targets/horizontal_drag_target.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/calendar_events/checked_copy.dart';
 import 'package:kalender/src/models/calendar_events/draggable_event.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/internal_components/cursor_navigation_trigger.dart';
@@ -209,7 +210,7 @@ class _HorizontalDragTargetState extends State<HorizontalDragTarget> with DragTa
       _ => null
     };
     if (range == null) return null;
-    return event.copyWith(dateTimeRange: toLocationDateTimeRange(range));
+    return event.checkedCopyWith(dateTimeRange: toLocationDateTimeRange(range));
   }
 
   @override
@@ -226,6 +227,6 @@ class _HorizontalDragTargetState extends State<HorizontalDragTarget> with DragTa
       range = InternalDateTimeRange(start: cursor, end: range.start.endOfDay);
     }
 
-    return event.copyWith(dateTimeRange: toLocationDateTimeRange(range));
+    return event.checkedCopyWith(dateTimeRange: toLocationDateTimeRange(range));
   }
 }

--- a/lib/src/widgets/drag_targets/schedule_drag_target.dart
+++ b/lib/src/widgets/drag_targets/schedule_drag_target.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/calendar_events/checked_copy.dart';
 import 'package:kalender/src/models/calendar_events/draggable_event.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/internal_components/cursor_navigation_trigger.dart' show CursorNavigationTrigger;
@@ -201,7 +202,7 @@ class _ScheduleDragTargetState extends State<ScheduleDragTarget> with DragTarget
       final duration = rangeAsUtc.duration;
       final endTime = cursorDateTime.add(duration);
       final newRange = InternalDateTimeRange(start: cursorDateTime, end: endTime);
-      return event.copyWith(dateTimeRange: toLocationDateTimeRange(newRange));
+      return event.checkedCopyWith(dateTimeRange: toLocationDateTimeRange(newRange));
     } else {
       // Calculate the new dateTimeRange for the event.
       final newStartTime = cursorDateTime;
@@ -209,7 +210,7 @@ class _ScheduleDragTargetState extends State<ScheduleDragTarget> with DragTarget
       final endTime = newStartTime.add(duration);
       final newRange = InternalDateTimeRange(start: newStartTime, end: endTime);
 
-      return event.copyWith(dateTimeRange: toLocationDateTimeRange(newRange));
+      return event.checkedCopyWith(dateTimeRange: toLocationDateTimeRange(newRange));
     }
   }
 

--- a/lib/src/widgets/drag_targets/vertical_drag_target.dart
+++ b/lib/src/widgets/drag_targets/vertical_drag_target.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/calendar_events/checked_copy.dart';
 import 'package:kalender/src/models/calendar_events/draggable_event.dart';
 import 'package:kalender/src/models/mixins/snap_points.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -343,7 +344,7 @@ class _VerticalDragTargetState extends State<VerticalDragTarget> with SnapPoints
     // Convert only start and recompute end from the original duration to avoid
     // the DST spring-forward gap collapsing start and end to the same UTC instant.
     final convertedStart = start.forLocation(location: context.location);
-    final updatedEvent = event.copyWith(
+    final updatedEvent = event.checkedCopyWith(
       dateTimeRange: DateTimeRange(start: convertedStart, end: convertedStart.add(duration)),
     );
 
@@ -376,7 +377,7 @@ class _VerticalDragTargetState extends State<VerticalDragTarget> with SnapPoints
     };
     if (dateTimeRange == null) return null;
 
-    return event.copyWith(dateTimeRange: toLocationDateTimeRange(dateTimeRange));
+    return event.checkedCopyWith(dateTimeRange: toLocationDateTimeRange(dateTimeRange));
   }
 
   @override
@@ -393,6 +394,6 @@ class _VerticalDragTargetState extends State<VerticalDragTarget> with SnapPoints
       range = InternalDateTimeRange(start: cursorDateTime, end: range.start);
     }
 
-    return event.copyWith(dateTimeRange: toLocationDateTimeRange(range));
+    return event.checkedCopyWith(dateTimeRange: toLocationDateTimeRange(range));
   }
 }

--- a/lib/src/widgets/schedule/schedule_body.dart
+++ b/lib/src/widgets/schedule/schedule_body.dart
@@ -279,7 +279,7 @@ class _SchedulePositionListState extends State<SchedulePositionList> {
         switch (widget.configuration.emptyDay) {
           case EmptyDayBehavior.show:
             // Record the empty day as the first (only) row of its date so it can
-            // be scrolled/animated to directly (#253).
+            // be scrolled or animated to directly.
             viewController.addItem(item: EmptyItem(), date: date, isFirst: true);
             continue;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.24.0-dev.6
+version: 0.24.0-dev.7
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:

--- a/test/interactions/drag_target_utils_test.dart
+++ b/test/interactions/drag_target_utils_test.dart
@@ -4,17 +4,19 @@ import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/calendar_events/draggable_event.dart';
 import 'package:timezone/data/latest_10y.dart';
 
+class _HarnessWidget extends StatefulWidget {
+  const _HarnessWidget();
+
+  @override
+  State<_HarnessWidget> createState() => _DragUtilsHarness();
+}
+
 /// A minimal [DragTargetUtilities] host used to exercise the mixin's pure
-/// range-math helpers. Members that require a live widget tree throw, so only
-/// the context-free helpers may be called against this harness.
-class _DragUtilsHarness with DragTargetUtilities {
+/// range-math helpers. It is never pumped, so [State.context] throws and
+/// [State.mounted] is false. Only the helpers that touch neither may be called
+/// against this harness.
+class _DragUtilsHarness extends State<_HarnessWidget> with DragTargetUtilities<_HarnessWidget> {
   _DragUtilsHarness({CalendarController? controller}) : controller = controller ?? CalendarController();
-
-  @override
-  BuildContext get context => throw UnimplementedError();
-
-  @override
-  bool get mounted => true;
 
   @override
   final CalendarController controller;
@@ -44,6 +46,9 @@ class _DragUtilsHarness with DragTargetUtilities {
   @override
   InternalDateTime? calculateCursorDateTime(Offset offset, {Offset feedbackWidgetOffset = Offset.zero}) =>
       throw UnimplementedError();
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
 }
 
 void main() {

--- a/test/models/checked_copy_test.dart
+++ b/test/models/checked_copy_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/calendar_events/checked_copy.dart';
+
+/// A subclass whose `copyWith` forwards everything the base class carries over,
+/// matching the documented example on [CalendarEvent].
+class _GoodEvent extends CalendarEvent {
+  _GoodEvent({
+    super.id,
+    required super.dateTimeRange,
+    required this.title,
+    super.interaction,
+    super.multiDayRule,
+  });
+
+  final String title;
+
+  @override
+  _GoodEvent copyWith({DateTimeRange? dateTimeRange, EventInteraction? interaction, String? title}) => _GoodEvent(
+        id: id,
+        dateTimeRange: dateTimeRange ?? this.dateTimeRange,
+        interaction: interaction ?? this.interaction,
+        multiDayRule: multiDayRule,
+        title: title ?? this.title,
+      );
+}
+
+/// A subclass that omits `id`, so each copy is minted with a new identity.
+class _DropsId extends CalendarEvent {
+  _DropsId({required super.dateTimeRange, super.multiDayRule});
+
+  @override
+  _DropsId copyWith({DateTimeRange? dateTimeRange, EventInteraction? interaction}) =>
+      _DropsId(dateTimeRange: dateTimeRange ?? this.dateTimeRange, multiDayRule: multiDayRule);
+}
+
+/// A subclass that omits `multiDayRule`, so each copy falls back to the view
+/// configuration's rule.
+class _DropsRule extends CalendarEvent {
+  _DropsRule({super.id, required super.dateTimeRange, super.multiDayRule});
+
+  @override
+  _DropsRule copyWith({DateTimeRange? dateTimeRange, EventInteraction? interaction}) =>
+      _DropsRule(id: id, dateTimeRange: dateTimeRange ?? this.dateTimeRange);
+}
+
+void main() {
+  final range = DateTimeRange(start: DateTime.utc(2025, 1, 6, 9), end: DateTime.utc(2025, 1, 6, 10));
+  final moved = DateTimeRange(start: DateTime.utc(2025, 1, 6, 11), end: DateTime.utc(2025, 1, 6, 12));
+
+  group('checkedCopyWith', () {
+    test('a base CalendarEvent keeps its id and rule', () {
+      final event = CalendarEvent(dateTimeRange: range, multiDayRule: const MultiDayRule.calendarDays());
+      final copy = event.checkedCopyWith(dateTimeRange: moved);
+
+      expect(copy.id, equals(event.id));
+      expect(copy.multiDayRule, equals(event.multiDayRule));
+      expect(copy.dateTimeRange, equals(moved));
+    });
+
+    test('a subclass forwarding both fields does not trip the assert', () {
+      final event = _GoodEvent(
+        dateTimeRange: range,
+        title: 'standup',
+        multiDayRule: const MultiDayRule.calendarDays(),
+      );
+      final copy = event.checkedCopyWith(dateTimeRange: moved) as _GoodEvent;
+
+      expect(copy.id, equals(event.id));
+      expect(copy.multiDayRule, equals(event.multiDayRule));
+      expect(copy.title, equals('standup'));
+    });
+
+    test('a subclass that drops id names the missing forward', () {
+      final event = _DropsId(dateTimeRange: range);
+
+      expect(
+        () => event.checkedCopyWith(dateTimeRange: moved),
+        throwsA(
+          isA<AssertionError>().having((e) => e.message, 'message', allOf(contains('_DropsId'), contains('id: id'))),
+        ),
+      );
+    });
+
+    test('a subclass that drops multiDayRule names the missing forward', () {
+      final event = _DropsRule(dateTimeRange: range, multiDayRule: const MultiDayRule.calendarDays());
+
+      expect(
+        () => event.checkedCopyWith(dateTimeRange: moved),
+        throwsA(
+          isA<AssertionError>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('_DropsRule'), contains('multiDayRule: multiDayRule')),
+          ),
+        ),
+      );
+    });
+
+    test('dropping multiDayRule is only caught when the event sets one', () {
+      // The base default is null, so an override that omits the field still
+      // produces an equal value and there is nothing to report.
+      final event = _DropsRule(dateTimeRange: range);
+      expect(() => event.checkedCopyWith(dateTimeRange: moved), returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
Acts on an external review of 0.24.0-dev.6. Several of its points were already
done in the repo and are listed at the bottom so they are not raised again.

## Library changes

**`DragTargetUtilities` is constrained to `State`.** It declared `context` and
`mounted` and left the host to supply them, so a non-`State` host could answer
`mounted` unconditionally and reintroduce the disposal bug the member exists to
prevent. `State` supplies both. This replaces the breaking change already in
0.24.0 rather than adding a second one to the same mixin in a later release. The
three library consumers need no edit, since the type argument is inferred from
the superclass. The mixin's test harness is now an unpumped `State`, which
exercises the same paths: `mounted` is read in one place, the deferred-move
path, and `onAcceptWithDetails` does not touch it.

**A debug assert for base-class state dropped by an event's `copyWith`.**
`copyWith` takes no parameter for `id` or `multiDayRule`, so an override that
omits either drops it on every drag and resize, silently until selection or
multi-day placement goes wrong. The internal copy sites route through
`checkedCopyWith`, which names the subclass and the argument to add. 0.24.0
introduces `multiDayRule`, so this is the release to catch it in. All seven
example subclasses already forward both, so the assert is silent on them.
`checked_copy.dart` is not exported, so this adds no public API.

## README

The advice to pin an exact version was wrong. Below 1.0.0 a caret range already
resolves `^0.24.0` to `>=0.24.0 <0.25.0`, so pinning gave up patch fixes without
buying any protection. "1.0.0 is close" is removed rather than left to age into
evidence the project stalled. The warning block moves below the screenshots and
feature list. The documentation bullets carry enough of each guide's vocabulary
to be searchable on pub.dev, since the guides themselves live off-page. MIT
licensing and the timezone test matrix are both stated, having been visible only
as a badge and not at all.

## Release records

0.24.0 gains the `Tests` section that lapsed after 0.20.0. The layout-cache entry
now names what reaches it instead of only what does not. 0.23.0's heading becomes
`Behavior Changes`, since nothing in it stops compiling, and `AGENTS.md` records
the split so future releases keep the two apart. `MIGRATION.md` gains a table of
contents and the missing rung stating that 0.19.x through 0.22.x need no changes.

Six documentation links hardcoded `main`, so on a tagged release they could show
an example that no longer matches the installed API. All are now relative, which
pub.dev and GitHub rewrite to the published ref.

## Dependencies

`timezone` 0.11.1 renamed the built-in UTC location to `Etc/UTC` in a patch
release, so `getLocation('UTC')` now throws. Only the doc snippet preamble used
it. The library never did, since `DefaultEventStore.defaultLocation` is the
sentinel string `default`. Verified against `timezone` 0.11.1 and `intl` 0.20.3,
which the current constraints already allow. There is no `timezone` 0.12.0.

The real exposure is that `timezone` ships behaviour changes in patch releases,
which no version constraint prevents and a library cannot pin away. The CI
timezone matrix is what catches it, which is why the README now says so.

## Verification

`dart analyze` and `flutter analyze` clean, 1595 tests pass, the six-timezone
matrix passes in every zone, 45 doc snippets compile, all eight examples analyze
clean, `dart format` clean, and every relative link resolves.

`flutter pub publish --dry-run` reports one warning: the `## 0.24.0` heading does
not match version `0.24.0-dev.7`. Left as is. Every dev bump from dev.1 through
dev.6 carried the same warning, and the heading becomes correct at the 0.24.0
release.

## Raised by the review, no change needed

- Sweep the docs for inline closures passed to `nowCallback` and
  `eventSnapStrategy`. Already done. The guides use `DateTime.now` and
  `defaultSnapStrategy`, and `identical(DateTime.now, DateTime.now)` is true, so
  the tear-off compares equal across builds.
- Export a top-level default snap strategy. `defaultSnapStrategy` already exists
  and is already the default.
- Write down a deprecation policy. `AGENTS.md` already states the window, the
  `@Deprecated` message format, and what cannot be deprecated at all.
- Check `.pubignore` excludes `AGENTS.md`. Already excluded.

## Deferred

- Whether `MultiDayRule` should be joined by an explicit all-day flag. RFC 5545
  encodes all-day as a date-valued `DTSTART`, which a duration rule discards.
  A 1.0.0 decision, before the API freezes.
- Reapplying base-class state internally instead of routing it through the
  consumer's `copyWith`. Not reachable today, since `interaction` and
  `multiDayRule` are final.
- An extension to shorten `spansMultipleDays({location, defaultRule})`.
