### PR TITLE
chore: release v0.24.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.24.0-dev.7
+version: 0.24.0
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
Bumps `pubspec.yaml` from `0.24.0-dev.7` to `0.24.0`. One line, no other changes.

Merging this does not release. Publishing is triggered by pushing a signed `v0.24.0` tag onto the merge commit, which is a separate deliberate step.

## Verification

- `dart analyze` and `flutter analyze` clean.
- 1595 tests pass, and the six-timezone matrix passes in every zone.
- `flutter pub publish --dry-run` reports **0 warnings**. The `## 0.24.0` changelog heading now matches the version, which clears the one warning every prerelease from dev.1 through dev.7 carried.

## What is in 0.24.0

Ten breaking changes, batched deliberately. The full list is in [CHANGELOG.md](CHANGELOG.md) with a matching section in [MIGRATION.md](MIGRATION.md) for each one that needs a code change. In short:

- kalender no longer re-exports the whole `timezone` package.
- The seven string builders deprecated in 0.23.0 are removed, along with `MonthDayHeaderStyle.textStyle` and three long-deprecated members.
- `MultiDayRule` decides what belongs in the multi-day header, replacing the duration guess. `isMultiDayEvent` is deprecated and goes in 0.25.0.
- `throttleMilliseconds` is gone, replaced by combining drag updates per frame.
- `DragTargetUtilities` can only be applied to a `State`.
- `ScheduleTileComponents` dropped three parameters that did nothing, and two row builders moved to `ScheduleComponents`.
- Value equality was widened across the configuration classes, so settings that silently did nothing now take effect.

## Before tagging

Worth running `dart run pana` and diffing against the 0.23.0 stable's 160 points. This is the release where the score actually changes, unlike the prereleases.
