### PR TITLE
test: cover the parts of KalenderThemeData no test reached

### DIFF
--- a/test/models/kalender_theme_test.dart
+++ b/test/models/kalender_theme_test.dart
@@ -105,6 +105,12 @@ void main() {
       expect(copy.hourLinesStyle, data.hourLinesStyle);
     });
 
+    test('copyWith keeps a style it is not given', () {
+      const data = KalenderThemeData(monthGridStyle: MonthGridStyle(thickness: 2));
+      final copy = data.copyWith(hourLinesStyle: const HourLinesStyle(thickness: 1));
+      expect(copy.monthGridStyle, data.monthGridStyle);
+    });
+
     test('merge overlays styles field by field', () {
       const base = KalenderThemeData(
         hourLinesStyle: HourLinesStyle(color: Color(0xFF000000), thickness: 1),
@@ -140,6 +146,40 @@ void main() {
       const c = KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 2));
       expect(a, b);
       expect(a == c, false);
+    });
+
+    test('equality compares every field', () {
+      // Built without const, otherwise the two are canonicalized to one instance
+      // and the comparison returns on identical() without reading any field.
+      // ignore: prefer_const_constructors
+      final a = KalenderThemeData(hourLinesStyle: const HourLinesStyle(thickness: 1));
+      // ignore: prefer_const_constructors
+      final b = KalenderThemeData(hourLinesStyle: const HourLinesStyle(thickness: 1));
+      expect(identical(a, b), isFalse);
+      expect(a, b);
+
+      // The last field compared, so no earlier one can short-circuit ahead of it.
+      final differsLast = a.copyWith(
+        multiDayPortalOverlayButtonStyle: const MultiDayPortalOverlayButtonStyle(
+          textOverflow: TextOverflow.ellipsis,
+        ),
+      );
+      expect(a == differsLast, false);
+    });
+
+    test('hashCode follows equality', () {
+      // Built without const, for the same reason as the case above.
+      // ignore: prefer_const_constructors
+      final a = KalenderThemeData(hourLinesStyle: const HourLinesStyle(thickness: 1));
+      // ignore: prefer_const_constructors
+      final b = KalenderThemeData(hourLinesStyle: const HourLinesStyle(thickness: 1));
+      final c = a.copyWith(
+        multiDayPortalOverlayButtonStyle: const MultiDayPortalOverlayButtonStyle(
+          textOverflow: TextOverflow.ellipsis,
+        ),
+      );
+      expect(a.hashCode, b.hashCode);
+      expect(a.hashCode, isNot(c.hashCode));
     });
 
     testWidgets('animated theme change interpolates through ThemeData.lerp', (tester) async {


### PR DESCRIPTION
First of a stack for 0.25.0. Tests only, no production change.

`lib/src/theme/kalender_theme.dart` sat at 78% of lines, the lowest in the package, going into the release that rewrites it. Three gaps accounted for all of it.

`hashCode` was never invoked by any test. `==` was never read past its third field: the only inequality case differed in `hourLinesStyle` and the `&&` chain short-circuited there, leaving the last ten comparisons unrun. The equal case did not reach them either, because both sides were `const` with identical arguments, so Dart canonicalized them into one instance and the comparison returned on `identical`. One `copyWith` fallback was unread for the same kind of reason.

The new cases build their operands without `const` and differ in the last field compared, so the whole chain runs. The file is now at 100%.

Verified with `flutter test --coverage` before and after.