### PR TITLE
fix: components and tile components compare by value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Rebuilding the calendar no longer reports the components as changed to every widget that reads them. `CalendarComponents` and the containers reached through it compare by value and can be `const`, so a calendar given no components, or given components built inside the consumer's own `build` method, stops rebuilding every day header, separator, timeline, grid and trigger on each frame it rebuilds.
+- `TileComponents` and `ScheduleTileComponents` compare by value, so the same holds for the event tiles. This only takes effect when the builders are top-level or static functions. A builder written as an inline closure is a new object on every build and still reports a change.
 - `CalendarComponents` and the containers reached through it gain `copyWith`.
 
 ## 0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.25.0
+
+### Fixes
+
+- Rebuilding the calendar no longer reports the components as changed to every widget that reads them. `CalendarComponents` and the containers reached through it compare by value and can be `const`, so a calendar given no components, or given components built inside the consumer's own `build` method, stops rebuilding every day header, separator, timeline, grid and trigger on each frame it rebuilds.
+- `CalendarComponents` and the containers reached through it gain `copyWith`.
+
 ## 0.24.0
 
 See [MIGRATION.md](MIGRATION.md#v023x--v0240) for what to change.

--- a/lib/src/calendar_view.dart
+++ b/lib/src/calendar_view.dart
@@ -295,7 +295,7 @@ class CalendarViewState extends State<CalendarView> {
         child: Callbacks(
           callbacks: widget.callbacks,
           child: Components(
-            components: widget.components ?? CalendarComponents(),
+            components: widget.components ?? const CalendarComponents(),
             child: EventsControllerProvider(
               eventsController: widget.eventsController,
               child: CalendarControllerProvider(

--- a/lib/src/models/components/components.dart
+++ b/lib/src/models/components/components.dart
@@ -43,7 +43,7 @@ class CalendarComponents {
   /// If another style is provided in [multiDayComponentStyles] or [monthComponentStyles], that will be used instead.
   final OverlayStyles? overlayStyles;
 
-  CalendarComponents({
+  const CalendarComponents({
     this.monthComponents = const MonthComponents(),
     this.monthComponentStyles = const MonthComponentStyles(),
     this.multiDayComponents = const MultiDayComponents(),
@@ -53,6 +53,56 @@ class CalendarComponents {
     this.overlayBuilders,
     this.overlayStyles,
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  CalendarComponents copyWith({
+    MonthComponents? monthComponents,
+    MonthComponentStyles? monthComponentStyles,
+    MultiDayComponents? multiDayComponents,
+    MultiDayComponentStyles? multiDayComponentStyles,
+    ScheduleComponents? scheduleComponents,
+    ScheduleComponentStyles? scheduleComponentStyles,
+    OverlayBuilders? overlayBuilders,
+    OverlayStyles? overlayStyles,
+  }) {
+    return CalendarComponents(
+      monthComponents: monthComponents ?? this.monthComponents,
+      monthComponentStyles: monthComponentStyles ?? this.monthComponentStyles,
+      multiDayComponents: multiDayComponents ?? this.multiDayComponents,
+      multiDayComponentStyles: multiDayComponentStyles ?? this.multiDayComponentStyles,
+      scheduleComponents: scheduleComponents ?? this.scheduleComponents,
+      scheduleComponentStyles: scheduleComponentStyles ?? this.scheduleComponentStyles,
+      overlayBuilders: overlayBuilders ?? this.overlayBuilders,
+      overlayStyles: overlayStyles ?? this.overlayStyles,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is CalendarComponents &&
+        other.monthComponents == monthComponents &&
+        other.monthComponentStyles == monthComponentStyles &&
+        other.multiDayComponents == multiDayComponents &&
+        other.multiDayComponentStyles == multiDayComponentStyles &&
+        other.scheduleComponents == scheduleComponents &&
+        other.scheduleComponentStyles == scheduleComponentStyles &&
+        other.overlayBuilders == overlayBuilders &&
+        other.overlayStyles == overlayStyles;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        monthComponents,
+        monthComponentStyles,
+        multiDayComponents,
+        multiDayComponentStyles,
+        scheduleComponents,
+        scheduleComponentStyles,
+        overlayBuilders,
+        overlayStyles,
+      );
 }
 
 /// Builders used to create the overlayPortal, overlay and overlay button widgets.
@@ -78,6 +128,41 @@ class OverlayBuilders {
     this.multiDayPortalOverlayButtonBuilder,
     this.multiDayPortalOverlayButtonStringBuilder,
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  OverlayBuilders copyWith({
+    MultiDayOverlayBuilder? multiDayOverlayBuilder,
+    MultiDayOverlayPortalBuilder? multiDayOverlayPortalBuilder,
+    MultiDayPortalOverlayButtonBuilder? multiDayPortalOverlayButtonBuilder,
+    HiddenEventCountStringBuilder? multiDayPortalOverlayButtonStringBuilder,
+  }) {
+    return OverlayBuilders(
+      multiDayOverlayBuilder: multiDayOverlayBuilder ?? this.multiDayOverlayBuilder,
+      multiDayOverlayPortalBuilder: multiDayOverlayPortalBuilder ?? this.multiDayOverlayPortalBuilder,
+      multiDayPortalOverlayButtonBuilder: multiDayPortalOverlayButtonBuilder ?? this.multiDayPortalOverlayButtonBuilder,
+      multiDayPortalOverlayButtonStringBuilder:
+          multiDayPortalOverlayButtonStringBuilder ?? this.multiDayPortalOverlayButtonStringBuilder,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is OverlayBuilders &&
+        other.multiDayOverlayBuilder == multiDayOverlayBuilder &&
+        other.multiDayOverlayPortalBuilder == multiDayOverlayPortalBuilder &&
+        other.multiDayPortalOverlayButtonBuilder == multiDayPortalOverlayButtonBuilder &&
+        other.multiDayPortalOverlayButtonStringBuilder == multiDayPortalOverlayButtonStringBuilder;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        multiDayOverlayBuilder,
+        multiDayOverlayPortalBuilder,
+        multiDayPortalOverlayButtonBuilder,
+        multiDayPortalOverlayButtonStringBuilder,
+      );
 }
 
 /// Styles used by the overlay widgets.
@@ -88,10 +173,33 @@ class OverlayStyles {
   /// The style for the multi day overlay portal button.
   final MultiDayPortalOverlayButtonStyle? multiDayPortalOverlayButtonStyle;
 
-  OverlayStyles({
+  const OverlayStyles({
     this.multiDayOverlayStyle,
     this.multiDayPortalOverlayButtonStyle,
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  OverlayStyles copyWith({
+    MultiDayOverlayStyle? multiDayOverlayStyle,
+    MultiDayPortalOverlayButtonStyle? multiDayPortalOverlayButtonStyle,
+  }) {
+    return OverlayStyles(
+      multiDayOverlayStyle: multiDayOverlayStyle ?? this.multiDayOverlayStyle,
+      multiDayPortalOverlayButtonStyle: multiDayPortalOverlayButtonStyle ?? this.multiDayPortalOverlayButtonStyle,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is OverlayStyles &&
+        other.multiDayOverlayStyle == multiDayOverlayStyle &&
+        other.multiDayPortalOverlayButtonStyle == multiDayPortalOverlayButtonStyle;
+  }
+
+  @override
+  int get hashCode => Object.hash(multiDayOverlayStyle, multiDayPortalOverlayButtonStyle);
 }
 
 /// The trigger widget builder, should be constrained in width.

--- a/lib/src/models/components/month_components.dart
+++ b/lib/src/models/components/month_components.dart
@@ -20,6 +20,29 @@ class MonthComponents {
     this.bodyComponents = const MonthBodyComponents(),
     this.headerComponents = const MonthHeaderComponents(),
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MonthComponents copyWith({
+    MonthBodyComponents? bodyComponents,
+    MonthHeaderComponents? headerComponents,
+  }) {
+    return MonthComponents(
+      bodyComponents: bodyComponents ?? this.bodyComponents,
+      headerComponents: headerComponents ?? this.headerComponents,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MonthComponents &&
+        other.bodyComponents == bodyComponents &&
+        other.headerComponents == headerComponents;
+  }
+
+  @override
+  int get hashCode => Object.hash(bodyComponents, headerComponents);
 }
 
 /// The component builders used by the [MonthBody].
@@ -66,6 +89,56 @@ class MonthBodyComponents {
     this.rightTriggerBuilder,
     this.overlayBuilders,
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MonthBodyComponents copyWith({
+    MonthGridBuilder? monthGridBuilder,
+    MonthDayHeaderBuilder? monthDayHeaderBuilder,
+    DateStringBuilder? monthDayHeaderStringBuilder,
+    MonthDayCellBuilder? monthDayCellBuilder,
+    WeekNumberBuilder? weekNumberBuilder,
+    HorizontalTriggerWidgetBuilder? leftTriggerBuilder,
+    HorizontalTriggerWidgetBuilder? rightTriggerBuilder,
+    OverlayBuilders? overlayBuilders,
+  }) {
+    return MonthBodyComponents(
+      monthGridBuilder: monthGridBuilder ?? this.monthGridBuilder,
+      monthDayHeaderBuilder: monthDayHeaderBuilder ?? this.monthDayHeaderBuilder,
+      monthDayHeaderStringBuilder: monthDayHeaderStringBuilder ?? this.monthDayHeaderStringBuilder,
+      monthDayCellBuilder: monthDayCellBuilder ?? this.monthDayCellBuilder,
+      weekNumberBuilder: weekNumberBuilder ?? this.weekNumberBuilder,
+      leftTriggerBuilder: leftTriggerBuilder ?? this.leftTriggerBuilder,
+      rightTriggerBuilder: rightTriggerBuilder ?? this.rightTriggerBuilder,
+      overlayBuilders: overlayBuilders ?? this.overlayBuilders,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MonthBodyComponents &&
+        other.monthGridBuilder == monthGridBuilder &&
+        other.monthDayHeaderBuilder == monthDayHeaderBuilder &&
+        other.monthDayHeaderStringBuilder == monthDayHeaderStringBuilder &&
+        other.monthDayCellBuilder == monthDayCellBuilder &&
+        other.weekNumberBuilder == weekNumberBuilder &&
+        other.leftTriggerBuilder == leftTriggerBuilder &&
+        other.rightTriggerBuilder == rightTriggerBuilder &&
+        other.overlayBuilders == overlayBuilders;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        monthGridBuilder,
+        monthDayHeaderBuilder,
+        monthDayHeaderStringBuilder,
+        monthDayCellBuilder,
+        weekNumberBuilder,
+        leftTriggerBuilder,
+        rightTriggerBuilder,
+        overlayBuilders,
+      );
 }
 
 /// The component builders used by the [MonthHeader].
@@ -85,4 +158,27 @@ class MonthHeaderComponents {
     this.weekDayHeaderBuilder = WeekDayHeader.builder,
     this.weekDayHeaderStringBuilder,
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MonthHeaderComponents copyWith({
+    WeekDayHeaderBuilder? weekDayHeaderBuilder,
+    DateStringBuilder? weekDayHeaderStringBuilder,
+  }) {
+    return MonthHeaderComponents(
+      weekDayHeaderBuilder: weekDayHeaderBuilder ?? this.weekDayHeaderBuilder,
+      weekDayHeaderStringBuilder: weekDayHeaderStringBuilder ?? this.weekDayHeaderStringBuilder,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MonthHeaderComponents &&
+        other.weekDayHeaderBuilder == weekDayHeaderBuilder &&
+        other.weekDayHeaderStringBuilder == weekDayHeaderStringBuilder;
+  }
+
+  @override
+  int get hashCode => Object.hash(weekDayHeaderBuilder, weekDayHeaderStringBuilder);
 }

--- a/lib/src/models/components/month_styles.dart
+++ b/lib/src/models/components/month_styles.dart
@@ -19,6 +19,27 @@ class MonthComponentStyles {
     this.bodyStyles = const MonthBodyComponentStyles(),
     this.headerStyles = const MonthHeaderComponentStyles(),
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MonthComponentStyles copyWith({
+    MonthBodyComponentStyles? bodyStyles,
+    MonthHeaderComponentStyles? headerStyles,
+  }) {
+    return MonthComponentStyles(
+      bodyStyles: bodyStyles ?? this.bodyStyles,
+      headerStyles: headerStyles ?? this.headerStyles,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MonthComponentStyles && other.bodyStyles == bodyStyles && other.headerStyles == headerStyles;
+  }
+
+  @override
+  int get hashCode => Object.hash(bodyStyles, headerStyles);
 }
 
 /// The styles of the default components used by the [MonthBody].
@@ -44,6 +65,35 @@ class MonthBodyComponentStyles {
     ),
     this.overlayStyles,
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MonthBodyComponentStyles copyWith({
+    MonthGridStyle? monthGridStyle,
+    MonthDayHeaderStyle? monthDayHeaderStyle,
+    WeekNumberStyle? weekNumberStyle,
+    OverlayStyles? overlayStyles,
+  }) {
+    return MonthBodyComponentStyles(
+      monthGridStyle: monthGridStyle ?? this.monthGridStyle,
+      monthDayHeaderStyle: monthDayHeaderStyle ?? this.monthDayHeaderStyle,
+      weekNumberStyle: weekNumberStyle ?? this.weekNumberStyle,
+      overlayStyles: overlayStyles ?? this.overlayStyles,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MonthBodyComponentStyles &&
+        other.monthGridStyle == monthGridStyle &&
+        other.monthDayHeaderStyle == monthDayHeaderStyle &&
+        other.weekNumberStyle == weekNumberStyle &&
+        other.overlayStyles == overlayStyles;
+  }
+
+  @override
+  int get hashCode => Object.hash(monthGridStyle, monthDayHeaderStyle, weekNumberStyle, overlayStyles);
 }
 
 /// The styles of the default components used by the [MonthHeader].
@@ -53,4 +103,19 @@ class MonthHeaderComponentStyles {
 
   /// Creates a override(s) for the default styles used by the [MonthHeader].
   const MonthHeaderComponentStyles({this.weekDayHeaderStyle = const WeekDayHeaderStyle()});
+
+  /// Creates a copy of this with the given fields replaced.
+  MonthHeaderComponentStyles copyWith({WeekDayHeaderStyle? weekDayHeaderStyle}) {
+    return MonthHeaderComponentStyles(weekDayHeaderStyle: weekDayHeaderStyle ?? this.weekDayHeaderStyle);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MonthHeaderComponentStyles && other.weekDayHeaderStyle == weekDayHeaderStyle;
+  }
+
+  @override
+  int get hashCode => weekDayHeaderStyle.hashCode;
 }

--- a/lib/src/models/components/multi_day_components.dart
+++ b/lib/src/models/components/multi_day_components.dart
@@ -21,6 +21,29 @@ class MultiDayComponents {
     this.bodyComponents = const MultiDayBodyComponents(),
     this.headerComponents = const MultiDayHeaderComponents(),
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MultiDayComponents copyWith({
+    MultiDayHeaderComponents? headerComponents,
+    MultiDayBodyComponents? bodyComponents,
+  }) {
+    return MultiDayComponents(
+      headerComponents: headerComponents ?? this.headerComponents,
+      bodyComponents: bodyComponents ?? this.bodyComponents,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MultiDayComponents &&
+        other.headerComponents == headerComponents &&
+        other.bodyComponents == bodyComponents;
+  }
+
+  @override
+  int get hashCode => Object.hash(headerComponents, bodyComponents);
 }
 
 /// The component builders used by the [MultiDayHeader].
@@ -62,6 +85,52 @@ class MultiDayHeaderComponents {
     this.rightTriggerBuilder,
     this.overlayBuilders,
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MultiDayHeaderComponents copyWith({
+    DayHeaderBuilder? dayHeaderBuilder,
+    DateStringBuilder? dayHeaderStringBuilder,
+    DateStringBuilder? dayHeaderNumberStringBuilder,
+    WeekNumberBuilder? weekNumberBuilder,
+    HorizontalTriggerWidgetBuilder? leftTriggerBuilder,
+    HorizontalTriggerWidgetBuilder? rightTriggerBuilder,
+    OverlayBuilders? overlayBuilders,
+  }) {
+    return MultiDayHeaderComponents(
+      dayHeaderBuilder: dayHeaderBuilder ?? this.dayHeaderBuilder,
+      dayHeaderStringBuilder: dayHeaderStringBuilder ?? this.dayHeaderStringBuilder,
+      dayHeaderNumberStringBuilder: dayHeaderNumberStringBuilder ?? this.dayHeaderNumberStringBuilder,
+      weekNumberBuilder: weekNumberBuilder ?? this.weekNumberBuilder,
+      leftTriggerBuilder: leftTriggerBuilder ?? this.leftTriggerBuilder,
+      rightTriggerBuilder: rightTriggerBuilder ?? this.rightTriggerBuilder,
+      overlayBuilders: overlayBuilders ?? this.overlayBuilders,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MultiDayHeaderComponents &&
+        other.dayHeaderBuilder == dayHeaderBuilder &&
+        other.dayHeaderStringBuilder == dayHeaderStringBuilder &&
+        other.dayHeaderNumberStringBuilder == dayHeaderNumberStringBuilder &&
+        other.weekNumberBuilder == weekNumberBuilder &&
+        other.leftTriggerBuilder == leftTriggerBuilder &&
+        other.rightTriggerBuilder == rightTriggerBuilder &&
+        other.overlayBuilders == overlayBuilders;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        dayHeaderBuilder,
+        dayHeaderStringBuilder,
+        dayHeaderNumberStringBuilder,
+        weekNumberBuilder,
+        leftTriggerBuilder,
+        rightTriggerBuilder,
+        overlayBuilders,
+      );
 }
 
 /// The component builders used by the [MultiDayBody].
@@ -123,4 +192,62 @@ class MultiDayBodyComponents {
     this.topTriggerBuilder,
     this.bottomTriggerBuilder,
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MultiDayBodyComponents copyWith({
+    HourLinesBuilder? hourLines,
+    TimeLineBuilder? timeline,
+    TimeOfDayStringBuilder? timelineStringBuilder,
+    TimelineWidthBuilder? timelineWidth,
+    DaySeparatorBuilder? daySeparator,
+    TimeIndicatorBuilder? timeIndicator,
+    HorizontalTriggerWidgetBuilder? leftTriggerBuilder,
+    HorizontalTriggerWidgetBuilder? rightTriggerBuilder,
+    VerticalTriggerWidgetBuilder? topTriggerBuilder,
+    VerticalTriggerWidgetBuilder? bottomTriggerBuilder,
+  }) {
+    return MultiDayBodyComponents(
+      hourLines: hourLines ?? this.hourLines,
+      timeline: timeline ?? this.timeline,
+      timelineStringBuilder: timelineStringBuilder ?? this.timelineStringBuilder,
+      timelineWidth: timelineWidth ?? this.timelineWidth,
+      daySeparator: daySeparator ?? this.daySeparator,
+      timeIndicator: timeIndicator ?? this.timeIndicator,
+      leftTriggerBuilder: leftTriggerBuilder ?? this.leftTriggerBuilder,
+      rightTriggerBuilder: rightTriggerBuilder ?? this.rightTriggerBuilder,
+      topTriggerBuilder: topTriggerBuilder ?? this.topTriggerBuilder,
+      bottomTriggerBuilder: bottomTriggerBuilder ?? this.bottomTriggerBuilder,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MultiDayBodyComponents &&
+        other.hourLines == hourLines &&
+        other.timeline == timeline &&
+        other.timelineStringBuilder == timelineStringBuilder &&
+        other.timelineWidth == timelineWidth &&
+        other.daySeparator == daySeparator &&
+        other.timeIndicator == timeIndicator &&
+        other.leftTriggerBuilder == leftTriggerBuilder &&
+        other.rightTriggerBuilder == rightTriggerBuilder &&
+        other.topTriggerBuilder == topTriggerBuilder &&
+        other.bottomTriggerBuilder == bottomTriggerBuilder;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        hourLines,
+        timeline,
+        timelineStringBuilder,
+        timelineWidth,
+        daySeparator,
+        timeIndicator,
+        leftTriggerBuilder,
+        rightTriggerBuilder,
+        topTriggerBuilder,
+        bottomTriggerBuilder,
+      );
 }

--- a/lib/src/models/components/multi_day_styles.dart
+++ b/lib/src/models/components/multi_day_styles.dart
@@ -20,6 +20,27 @@ class MultiDayComponentStyles {
     this.headerStyles = const MultiDayHeaderComponentStyles(),
     this.bodyStyles = const MultiDayBodyComponentStyles(),
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MultiDayComponentStyles copyWith({
+    MultiDayHeaderComponentStyles? headerStyles,
+    MultiDayBodyComponentStyles? bodyStyles,
+  }) {
+    return MultiDayComponentStyles(
+      headerStyles: headerStyles ?? this.headerStyles,
+      bodyStyles: bodyStyles ?? this.bodyStyles,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MultiDayComponentStyles && other.headerStyles == headerStyles && other.bodyStyles == bodyStyles;
+  }
+
+  @override
+  int get hashCode => Object.hash(headerStyles, bodyStyles);
 }
 
 /// The styles of the default components used by the [MultiDayHeader].
@@ -39,6 +60,32 @@ class MultiDayHeaderComponentStyles {
     this.weekNumberStyle = const WeekNumberStyle(),
     this.overlayStyles,
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MultiDayHeaderComponentStyles copyWith({
+    DayHeaderStyle? dayHeaderStyle,
+    WeekNumberStyle? weekNumberStyle,
+    OverlayStyles? overlayStyles,
+  }) {
+    return MultiDayHeaderComponentStyles(
+      dayHeaderStyle: dayHeaderStyle ?? this.dayHeaderStyle,
+      weekNumberStyle: weekNumberStyle ?? this.weekNumberStyle,
+      overlayStyles: overlayStyles ?? this.overlayStyles,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MultiDayHeaderComponentStyles &&
+        other.dayHeaderStyle == dayHeaderStyle &&
+        other.weekNumberStyle == weekNumberStyle &&
+        other.overlayStyles == overlayStyles;
+  }
+
+  @override
+  int get hashCode => Object.hash(dayHeaderStyle, weekNumberStyle, overlayStyles);
 }
 
 /// The styles of the default components used by the [MultiDayBody].
@@ -62,4 +109,33 @@ class MultiDayBodyComponentStyles {
     this.hourLinesStyle = const HourLinesStyle(),
     this.timelineStyle = const TimelineStyle(),
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  MultiDayBodyComponentStyles copyWith({
+    DaySeparatorStyle? daySeparatorStyle,
+    TimeIndicatorStyle? timeIndicatorStyle,
+    HourLinesStyle? hourLinesStyle,
+    TimelineStyle? timelineStyle,
+  }) {
+    return MultiDayBodyComponentStyles(
+      daySeparatorStyle: daySeparatorStyle ?? this.daySeparatorStyle,
+      timeIndicatorStyle: timeIndicatorStyle ?? this.timeIndicatorStyle,
+      hourLinesStyle: hourLinesStyle ?? this.hourLinesStyle,
+      timelineStyle: timelineStyle ?? this.timelineStyle,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is MultiDayBodyComponentStyles &&
+        other.daySeparatorStyle == daySeparatorStyle &&
+        other.timeIndicatorStyle == timeIndicatorStyle &&
+        other.hourLinesStyle == hourLinesStyle &&
+        other.timelineStyle == timelineStyle;
+  }
+
+  @override
+  int get hashCode => Object.hash(daySeparatorStyle, timeIndicatorStyle, hourLinesStyle, timelineStyle);
 }

--- a/lib/src/models/components/schedule_components.dart
+++ b/lib/src/models/components/schedule_components.dart
@@ -33,6 +33,44 @@ class ScheduleComponents {
     this.emptyItemBuilder,
     this.monthItemBuilder,
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  ScheduleComponents copyWith({
+    ScheduleDateBuilder? leadingDateBuilder,
+    DateStringBuilder? leadingDateStringBuilder,
+    ScheduleTileHighlightBuilder? scheduleTileHighlightBuilder,
+    EmptyItemBuilder? emptyItemBuilder,
+    MonthItemBuilder? monthItemBuilder,
+  }) {
+    return ScheduleComponents(
+      leadingDateBuilder: leadingDateBuilder ?? this.leadingDateBuilder,
+      leadingDateStringBuilder: leadingDateStringBuilder ?? this.leadingDateStringBuilder,
+      scheduleTileHighlightBuilder: scheduleTileHighlightBuilder ?? this.scheduleTileHighlightBuilder,
+      emptyItemBuilder: emptyItemBuilder ?? this.emptyItemBuilder,
+      monthItemBuilder: monthItemBuilder ?? this.monthItemBuilder,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ScheduleComponents &&
+        other.leadingDateBuilder == leadingDateBuilder &&
+        other.leadingDateStringBuilder == leadingDateStringBuilder &&
+        other.scheduleTileHighlightBuilder == scheduleTileHighlightBuilder &&
+        other.emptyItemBuilder == emptyItemBuilder &&
+        other.monthItemBuilder == monthItemBuilder;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        leadingDateBuilder,
+        leadingDateStringBuilder,
+        scheduleTileHighlightBuilder,
+        emptyItemBuilder,
+        monthItemBuilder,
+      );
 }
 
 /// The builder for the empty item.

--- a/lib/src/models/components/schedule_styles.dart
+++ b/lib/src/models/components/schedule_styles.dart
@@ -12,4 +12,27 @@ class ScheduleComponentStyles {
     this.scheduleDateStyle = const ScheduleDateStyle(),
     this.scheduleTileHighlightStyle = const ScheduleTileHighlightStyle(),
   });
+
+  /// Creates a copy of this with the given fields replaced.
+  ScheduleComponentStyles copyWith({
+    ScheduleDateStyle? scheduleDateStyle,
+    ScheduleTileHighlightStyle? scheduleTileHighlightStyle,
+  }) {
+    return ScheduleComponentStyles(
+      scheduleDateStyle: scheduleDateStyle ?? this.scheduleDateStyle,
+      scheduleTileHighlightStyle: scheduleTileHighlightStyle ?? this.scheduleTileHighlightStyle,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ScheduleComponentStyles &&
+        other.scheduleDateStyle == scheduleDateStyle &&
+        other.scheduleTileHighlightStyle == scheduleTileHighlightStyle;
+  }
+
+  @override
+  int get hashCode => Object.hash(scheduleDateStyle, scheduleTileHighlightStyle);
 }

--- a/lib/src/models/components/tile_components.dart
+++ b/lib/src/models/components/tile_components.dart
@@ -71,6 +71,47 @@ class TileComponents {
       dropTargetTile: defaultDropTargetBuilder,
     );
   }
+
+  /// Compares the builders, so components built with the same ones are equal.
+  ///
+  /// A builder written as an inline closure is a new object on every build and
+  /// never compares equal. Pass a top-level or static function to keep two
+  /// instances equal, which is what stops the tiles rebuilding.
+  ///
+  /// [ScheduleTileComponents] restricts several of these to null, so the types
+  /// are compared too rather than only the fields.
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is TileComponents &&
+        other.runtimeType == runtimeType &&
+        other.tileBuilder == tileBuilder &&
+        other.overlayTileBuilder == overlayTileBuilder &&
+        other.tileWhenDraggingBuilder == tileWhenDraggingBuilder &&
+        other.feedbackTileBuilder == feedbackTileBuilder &&
+        other.dropTargetTile == dropTargetTile &&
+        other.dragAnchorStrategy == dragAnchorStrategy &&
+        other.resizeDragAnchorStrategy == resizeDragAnchorStrategy &&
+        other.resizeHandlePositioner == resizeHandlePositioner &&
+        other.verticalResizeHandle == verticalResizeHandle &&
+        other.horizontalResizeHandle == horizontalResizeHandle;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        runtimeType,
+        tileBuilder,
+        overlayTileBuilder,
+        tileWhenDraggingBuilder,
+        feedbackTileBuilder,
+        dropTargetTile,
+        dragAnchorStrategy,
+        resizeDragAnchorStrategy,
+        resizeHandlePositioner,
+        verticalResizeHandle,
+        horizontalResizeHandle,
+      );
 }
 
 /// The components used by the [ScheduleBody] to render the event tiles.

--- a/test/models/component_container_equality_test.dart
+++ b/test/models/component_container_equality_test.dart
@@ -78,6 +78,42 @@ void main() {
     });
   });
 
+  group('TileComponents equality', () {
+    test('the default components are one canonical instance', () {
+      expect(TileComponents.defaultComponents(), same(TileComponents.defaultComponents()));
+    });
+
+    test('components built with the same builders are equal', () {
+      // ignore: prefer_const_constructors
+      final a = TileComponents(tileBuilder: _tile);
+      // ignore: prefer_const_constructors
+      final b = TileComponents(tileBuilder: _tile);
+      expect(identical(a, b), isFalse);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('a builder written as a closure is never equal', () {
+      final a = TileComponents(tileBuilder: (event, tileRange) => const SizedBox());
+      final b = TileComponents(tileBuilder: (event, tileRange) => const SizedBox());
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differing a builder breaks equality', () {
+      expect(
+        const TileComponents(tileBuilder: _tile, dropTargetTile: _dropTarget),
+        isNot(equals(const TileComponents(tileBuilder: _tile))),
+      );
+    });
+
+    test('a schedule restriction is not equal to the base with the same builder', () {
+      expect(
+        const ScheduleTileComponents(tileBuilder: _tile),
+        isNot(equals(const TileComponents(tileBuilder: _tile))),
+      );
+    });
+  });
+
   group('Components rebuilds', () {
     /// Counts how often the components actually change for a dependent.
     ///
@@ -142,3 +178,7 @@ class _DependentState extends State<_Dependent> {
 String _dateLabel(BuildContext context, DateTime date) => '';
 
 String _hiddenEventCount(BuildContext context, int numberOfHiddenEvents) => '';
+
+Widget _tile(CalendarEvent event, DateTimeRange tileRange) => const SizedBox();
+
+Widget _dropTarget(CalendarEvent event) => const SizedBox();

--- a/test/models/component_container_equality_test.dart
+++ b/test/models/component_container_equality_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/providers/calendar_provider.dart';
+
+/// Exercises `==` / `hashCode` on the containers reached through
+/// [CalendarComponents], and the rebuild behaviour that depends on them.
+void main() {
+  group('CalendarComponents equality', () {
+    test('containers built with the same arguments are equal', () {
+      expect(const CalendarComponents(), equals(const CalendarComponents()));
+      expect(const CalendarComponents().hashCode, equals(const CalendarComponents().hashCode));
+    });
+
+    test('equality reads the fields rather than the identity', () {
+      // Built without const, so the comparison cannot return on identical().
+      // ignore: prefer_const_constructors
+      final a = CalendarComponents(monthComponentStyles: const MonthComponentStyles());
+      // ignore: prefer_const_constructors
+      final b = CalendarComponents(monthComponentStyles: const MonthComponentStyles());
+      expect(identical(a, b), isFalse);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    for (final entry in <String, CalendarComponents>{
+      'monthComponentStyles': const CalendarComponents(
+        monthComponentStyles: MonthComponentStyles(
+          bodyStyles: MonthBodyComponentStyles(monthGridStyle: MonthGridStyle(thickness: 4)),
+        ),
+      ),
+      'multiDayComponentStyles': const CalendarComponents(
+        multiDayComponentStyles: MultiDayComponentStyles(
+          bodyStyles: MultiDayBodyComponentStyles(hourLinesStyle: HourLinesStyle(thickness: 4)),
+        ),
+      ),
+      'scheduleComponentStyles': const CalendarComponents(
+        scheduleComponentStyles: ScheduleComponentStyles(
+          scheduleDateStyle: ScheduleDateStyle(numberTextStyle: TextStyle(fontSize: 40)),
+        ),
+      ),
+      'overlayStyles': const CalendarComponents(
+        overlayStyles: OverlayStyles(multiDayOverlayStyle: MultiDayOverlayStyle(width: 400)),
+      ),
+      'overlayBuilders': const CalendarComponents(
+        overlayBuilders: OverlayBuilders(multiDayPortalOverlayButtonStringBuilder: _hiddenEventCount),
+      ),
+      'multiDayComponents': const CalendarComponents(
+        multiDayComponents: MultiDayComponents(
+          headerComponents: MultiDayHeaderComponents(dayHeaderStringBuilder: _dateLabel),
+        ),
+      ),
+      'monthComponents': const CalendarComponents(
+        monthComponents: MonthComponents(
+          headerComponents: MonthHeaderComponents(weekDayHeaderStringBuilder: _dateLabel),
+        ),
+      ),
+      'scheduleComponents': const CalendarComponents(
+        scheduleComponents: ScheduleComponents(leadingDateStringBuilder: _dateLabel),
+      ),
+    }.entries) {
+      test('differing ${entry.key} breaks equality', () {
+        expect(entry.value, isNot(equals(const CalendarComponents())));
+      });
+    }
+
+    test('a builder held as a top-level function stays equal across instances', () {
+      const a = CalendarComponents(
+        scheduleComponents: ScheduleComponents(leadingDateStringBuilder: _dateLabel),
+      );
+      // Built without const so this is a separate instance, which is what a
+      // consumer constructing their components inside build() ends up with.
+      // ignore: prefer_const_constructors
+      final b = CalendarComponents(
+        scheduleComponents: const ScheduleComponents(leadingDateStringBuilder: _dateLabel),
+      );
+      expect(a, equals(b));
+    });
+  });
+
+  group('Components rebuilds', () {
+    /// Counts how often the components actually change for a dependent.
+    ///
+    /// [State.didChangeDependencies] runs only when an inherited dependency
+    /// reports a change, so it separates a real notification from the ordinary
+    /// rebuild that follows a parent rebuilding.
+    testWidgets('rebuilding the calendar does not report new components', (tester) async {
+      _DependentState.notifications = 0;
+      late StateSetter rebuild;
+
+      Widget build() {
+        return MaterialApp(
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              rebuild = setState;
+              return CalendarView(
+                eventsController: DefaultEventsController(),
+                calendarController: CalendarController(),
+                viewConfiguration: MultiDayViewConfiguration.week(),
+                body: const _Dependent(),
+              );
+            },
+          ),
+        );
+      }
+
+      await tester.pumpWidget(build());
+      expect(_DependentState.notifications, 1, reason: 'the first build always reads the components');
+
+      rebuild(() {});
+      await tester.pump();
+      rebuild(() {});
+      await tester.pump();
+
+      expect(_DependentState.notifications, 1);
+    });
+  });
+}
+
+/// Reads the components and records every time they are reported as changed.
+class _Dependent extends StatefulWidget {
+  const _Dependent();
+
+  @override
+  State<_Dependent> createState() => _DependentState();
+}
+
+class _DependentState extends State<_Dependent> {
+  static int notifications = 0;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    Components.of(context);
+    notifications++;
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}
+
+String _dateLabel(BuildContext context, DateTime date) => '';
+
+String _hiddenEventCount(BuildContext context, int numberOfHiddenEvents) => '';

--- a/test/utilities.dart
+++ b/test/utilities.dart
@@ -135,7 +135,7 @@ class TestProvider extends StatelessWidget {
         child: Callbacks(
           callbacks: null,
           child: Components(
-            components: components ?? CalendarComponents(),
+            components: components ?? const CalendarComponents(),
             child: Interaction(
               notifier: interaction ?? ValueNotifier(CalendarInteraction()),
               child: Snapping(

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -257,8 +257,8 @@ void main() {
 
     testWidgets('applies custom week number alignment from style', (tester) async {
       const rows = 5;
-      final components = CalendarComponents(
-        monthComponentStyles: const MonthComponentStyles(
+      final components = const CalendarComponents(
+        monthComponentStyles: MonthComponentStyles(
           bodyStyles: MonthBodyComponentStyles(
             weekNumberStyle: WeekNumberStyle(alignment: Alignment.topCenter),
           ),

--- a/test/widgets/schedule/schedule_body_test.dart
+++ b/test/widgets/schedule/schedule_body_test.dart
@@ -219,8 +219,8 @@ void main() {
           emptyDay: EmptyDayBehavior.hide,
           initialDate: DateTime(2025, 1, 15),
           nowCallback: () => DateTime(2025, 1, 15, 10),
-          components: CalendarComponents(
-            scheduleComponents: const ScheduleComponents(monthItemBuilder: _customMonthItem),
+          components: const CalendarComponents(
+            scheduleComponents: ScheduleComponents(monthItemBuilder: _customMonthItem),
           ),
         ),
       );
@@ -236,8 +236,8 @@ void main() {
           emptyDay: EmptyDayBehavior.showOnlyToday,
           initialDate: DateTime(2025, 1, 15),
           nowCallback: () => DateTime(2025, 1, 15, 10),
-          components: CalendarComponents(
-            scheduleComponents: const ScheduleComponents(emptyItemBuilder: _customEmptyItem),
+          components: const CalendarComponents(
+            scheduleComponents: ScheduleComponents(emptyItemBuilder: _customEmptyItem),
           ),
         ),
       );


### PR DESCRIPTION
Stacked on #408. Review that one first, or read only the last two commits here.

## The defect

`CalendarView.build` passed `widget.components ?? CalendarComponents()`. That constructor was not `const`, `CalendarComponents` had no `==`, and `Components.updateShouldNotify` compares with `!=`. So a calendar given no components, which is the default, allocated a fresh instance on every build and told all 17 widgets reading the components that they had changed. The same happened to anyone who did pass components but built the object inside their own `build` method.

None of the 19 containers reached through `CalendarComponents` had `==`, `hashCode` or `copyWith`. They all do now, and the constructor is `const`.

## The same defect on tiles

`TileComponentProvider.updateShouldNotify` compares with `!=` and `TileComponents` had no `==` either. The default path was already safe, since `TileComponents.defaultComponents()` returns a `const` instance that Dart canonicalizes. The documented path was not: `doc/appearance.md`, `doc/events.md` and the basic example all build `TileComponents(...)` inside a `build` method.

This half is worth more than the first, because `day_events_widget.dart` and `multi_day_events_widget.dart` read the tile components and those build every event tile.

## What bounds the benefit

Builder fields take part in `==`, matching `eventLayoutStrategy` and `generateMultiDayLayoutFrame` on the view configurations. A builder written as an inline closure is a new object every build and still reports a change, so it gets none of this. A builder held in a top-level or static function is stable and gets all of it.

That is never worse than before, where every field reported a change every build regardless. `advanced_example` already uses static builders and gets the full benefit. The basic example uses closures and gets nothing, which a follow-up commit addresses.

Issue #380 does not rescue this: it covers the strategy fields and deliberately excludes the widget-builder typedefs.

## Notes

`ScheduleTileComponents` restricts four members to null, so equality compares runtime types as well as fields, otherwise a restriction would equal a base instance built with the same tile builder.

No `copyWith` on `TileComponents`. It is a class consumers subclass, and a `copyWith` on a subclassed hierarchy is the defect 0.26.0 exists to fix on `CalendarEvent`.

## Verification

The regression test counts `didChangeDependencies` rather than builds, because a parent rebuild replaces the child widget either way and a build counter cannot tell a real notification from ordinary rebuilding. It was run against the previous code to confirm it fails there.

`flutter analyze` clean, full suite green, all eight examples analyze clean.