### PR TITLE
feat!: remove CalendarEvent.isMultiDayEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.25.0
 
+See [MIGRATION.md](MIGRATION.md#v024x--v0250) for what to change.
+
+### Breaking Changes
+
+- `CalendarEvent.isMultiDayEvent` is removed. It was deprecated in 0.24.0, which named this release. Use `spansMultipleDays(location:, defaultRule:)`. See [MIGRATION.md](MIGRATION.md#v024x--v0250).
+
 ### Fixes
 
 - Rebuilding the calendar no longer reports the components as changed to every widget that reads them. `CalendarComponents` and the containers reached through it compare by value and can be `const`, so a calendar given no components, or given components built inside the consumer's own `build` method, stops rebuilding every day header, separator, timeline, grid and trigger on each frame it rebuilds.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,12 +4,26 @@ Each section covers one upgrade. Versions not listed below need no changes.
 
 | Upgrade | What changes |
 | --- | --- |
+| [v0.24.x → v0.25.0](#v024x--v0250) | The deprecated `isMultiDayEvent` getter is removed. |
 | [v0.23.x → v0.24.0](#v023x--v0240) | The timezone re-export, the deprecated string builders, the multi-day rule, and six smaller removals. |
 | [v0.22.x → v0.23.0](#v022x--v0230) | String builders move off the style classes. Nothing stops compiling, but an unchanged calendar renders differently. |
 | v0.19.x → v0.22.x | No changes needed. |
 | [v0.18.x → v0.19.0](#v018x--v0190) | The timeline gutter width, view-transition controls, and the month day header's date type. |
 | [v0.16.x → v0.17.0](#v016x--v0170) | Input mode replaces the mobile/desktop split. |
 | [v0.15.x → v0.16.0](#v015x--v0160) | `CalendarEvent` is no longer generic and event ids become `String`. |
+
+## v0.24.x → v0.25.0
+
+### `isMultiDayEvent` is removed
+
+```dart
+- if (event.isMultiDayEvent) { ... }
++ if (event.spansMultipleDays(location: location, defaultRule: viewConfiguration.multiDayRule)) { ... }
+```
+
+Deprecated in 0.24.0, and the deprecation message named this release. The 0.24.0 section below covers why the name changed and what to pass.
+
+To keep the old answer exactly, including its two limitations, pass `location: null` and `defaultRule: defaultMultiDayRule`. Prefer the calendar's own location and rule unless you are pinning existing behaviour in a test.
 
 ## v0.23.x → v0.24.0
 
@@ -117,7 +131,7 @@ The mixin defers move handling to the end of the frame, so it can outlive dispos
 
 Pass the calendar's `location` and the rule from your view configuration. If you never set one, that rule is `defaultMultiDayRule`.
 
-The old getter still works and is removed in 0.25.0. It answers as if the calendar were in UTC, because a getter cannot take a location, and as if no rule were set on the view.
+The old getter still works in 0.24.0 and is gone in 0.25.0. It answers as if the calendar were in UTC, because a getter cannot take a location, and as if no rule were set on the view.
 
 The name had to change. Dart rejects a class declaring both a getter and a method called `isMultiDayEvent`, so reusing the name would have meant no deprecation period at all. Worse, `event.isMultiDayEvent` would have kept compiling anywhere a `dynamic` is accepted, silently becoming a function object rather than a boolean.
 

--- a/lib/src/models/calendar_events/calendar_event.dart
+++ b/lib/src/models/calendar_events/calendar_event.dart
@@ -114,16 +114,6 @@ class CalendarEvent {
     return (multiDayRule ?? defaultRule).isMultiDay(this, location: location);
   }
 
-  /// Whether this event spans more than one day.
-  ///
-  /// Cannot take a location, so it measures calendar days in UTC, and cannot
-  /// see the calendar's [ViewConfiguration.multiDayRule], so it answers as if
-  /// none were set. That is why it is deprecated: rules such as
-  /// [MultiDayRule.calendarDays] give the wrong answer near midnight and across
-  /// daylight saving changes without a location.
-  @Deprecated('Use spansMultipleDays, which takes a location. Will be removed in 0.25.0.')
-  bool get isMultiDayEvent => spansMultipleDays(location: null, defaultRule: defaultMultiDayRule);
-
   /// All dates this event spans, adjusted for [location].
   List<InternalDateTime> datesSpanned({Location? location}) => internalRange(location: location).dates();
 

--- a/test/interactions/drag_target_edge_cases_test.dart
+++ b/test/interactions/drag_target_edge_cases_test.dart
@@ -55,7 +55,7 @@ CalendarEvent _singleDayEvent({DateTime? start, DateTime? end}) => CalendarEvent
       ),
     );
 
-/// A midnight-to-midnight event (always isMultiDayEvent).
+/// A midnight-to-midnight event (always spans multiple days).
 CalendarEvent _multiDayEvent() => CalendarEvent(
       dateTimeRange: DateTimeRange(
         start: DateTime(2025, 1, 6, 0, 0),
@@ -139,7 +139,7 @@ void main() {
 
     test('Reschedule single-day event, header config (allowSingleDayEvents=false) → false', () {
       final event = _singleDayEvent();
-      expect(event.isMultiDayEvent, isFalse);
+      expect(event.spansMultipleDays(location: null, defaultRule: defaultMultiDayRule), isFalse);
       expect(
         HorizontalDragTarget.onWillAcceptWithDetails(
           _dragDetails(Reschedule(event: event)),
@@ -164,7 +164,7 @@ void main() {
 
     test('Reschedule multi-day event, header config → true', () {
       final event = _multiDayEvent();
-      expect(event.isMultiDayEvent, isTrue);
+      expect(event.spansMultipleDays(location: null, defaultRule: defaultMultiDayRule), isTrue);
       expect(
         HorizontalDragTarget.onWillAcceptWithDetails(
           _dragDetails(Reschedule(event: event)),
@@ -289,7 +289,7 @@ void main() {
           end: DateTime(2025, 1, 6, 18, 0),
         ),
       );
-      expect(hugeEvent.isMultiDayEvent, isFalse);
+      expect(hugeEvent.spansMultipleDays(location: null, defaultRule: defaultMultiDayRule), isFalse);
 
       expect(
         VerticalDragTarget.onWillAcceptWithDetails(
@@ -553,7 +553,7 @@ void main() {
       final state = await pumpMonthState(tester, ec: ec);
 
       final event = ec.events.first;
-      expect(event.isMultiDayEvent, isTrue);
+      expect(event.spansMultipleDays(location: null, defaultRule: defaultMultiDayRule), isTrue);
 
       final cursor = InternalDateTime(2025, 1, 9);
       final result = state.rescheduleEvent(event, cursor) as CalendarEvent?;

--- a/test/widgets/free_scroll_interaction_test.dart
+++ b/test/widgets/free_scroll_interaction_test.dart
@@ -78,7 +78,11 @@ void main() {
 
     expect(created, isNotNull, reason: 'a drag across the header should create an event');
     expect(confirmed, isNotNull, reason: 'the created event should be confirmed');
-    expect(created!.isMultiDayEvent, isTrue, reason: 'dragging across days should create a multi-day event');
+    expect(
+      created!.spansMultipleDays(location: null, defaultRule: defaultMultiDayRule),
+      isTrue,
+      reason: 'dragging across days should create a multi-day event',
+    );
   });
 
   testWidgets('dragging an existing multi-day tile reschedules it', (tester) async {


### PR DESCRIPTION
Stacked on #409. Review that one first, or read only the last commit here.

Deprecated in 0.24.0, whose deprecation message and changelog both named 0.25.0 as the release that removes it.

Nothing in `lib/` or `examples/` called it. Five call sites in two test files did, and they now call `spansMultipleDays(location: null, defaultRule: defaultMultiDayRule)`, which is exactly what the getter did, so they keep pinning the behaviour they were written for rather than quietly testing something else.

No subclass overrode the getter. `_StrictMultiDayEvent` in the event tests overrides `spansMultipleDays`, and the getter dispatched through that, so this is a caller-side break only.

The migration guide keeps the 0.24.0 entry explaining why the name had to change, and the new section says how to reproduce the old answer exactly for anyone who needs it.

## Verification

`flutter analyze` at the root cannot catch this: `analysis_options.yaml` excludes `examples/**` and `deprecated_member_use_from_same_package` is not enabled. Ran `flutter analyze` in each of the eight examples separately, per AGENTS.md. All clean, plus the full suite green.