### PR TITLE
docs: move the example tiles into their own widgets, and correct a claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ See [MIGRATION.md](MIGRATION.md#v024x--v0250) for what to change.
 
 ### Fixes
 
-- Rebuilding the calendar no longer reports the components as changed to every widget that reads them. `CalendarComponents` and the containers reached through it compare by value and can be `const`, so a calendar given no components, or given components built inside the consumer's own `build` method, stops rebuilding every day header, separator, timeline, grid and trigger on each frame it rebuilds.
-- `TileComponents` and `ScheduleTileComponents` compare by value, so the same holds for the event tiles. This only takes effect when the builders are top-level or static functions. A builder written as an inline closure is a new object on every build and still reports a change.
+- `CalendarComponents`, the containers reached through it, `TileComponents` and `ScheduleTileComponents` compare by value, and `CalendarComponents` can be `const`. The inherited widgets carrying them reported a change on every rebuild because they compared by identity, and now report one only when something differs.
 - `CalendarComponents` and the containers reached through it gain `copyWith`.
 
 ## 0.24.0

--- a/examples/example/lib/main.dart
+++ b/examples/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:example/tiles.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
@@ -180,70 +181,14 @@ class _MyHomePageState extends State<MyHomePage> {
           child: Column(
             children: [
               _calendarToolbar(),
-              CalendarHeader(multiDayTileComponents: _tileComponents()),
+              const CalendarHeader(multiDayTileComponents: tileComponents),
             ],
           ),
         ),
-        body: CalendarBody(
-          multiDayTileComponents: _tileComponents(),
-          monthTileComponents: _tileComponents(),
-          scheduleTileComponents: _scheduleTileComponents(),
-        ),
-      ),
-    );
-  }
-
-  Color _eventColor(CalendarEvent event) =>
-      (event is Event ? event.color : null) ?? Theme.of(context).colorScheme.primaryContainer;
-
-  TileComponents _tileComponents() {
-    final radius = BorderRadius.circular(8);
-    final scheme = Theme.of(context).colorScheme;
-
-    return TileComponents(
-      tileBuilder: (event, tileRange) => Card(
-        color: _eventColor(event),
-        child: Padding(
-          padding: const EdgeInsets.all(4),
-          child: Text(
-            (event is Event) ? event.title : '',
-            style: TextStyle(color: scheme.onPrimaryContainer, fontSize: 12),
-          ),
-        ),
-      ),
-      dropTargetTile: (event) => DecoratedBox(
-        decoration: BoxDecoration(
-          border: Border.all(color: scheme.onSurface.withAlpha(80), width: 2),
-          borderRadius: radius,
-        ),
-      ),
-      feedbackTileBuilder: (event, dropTargetWidgetSize) => AnimatedContainer(
-        duration: const Duration(milliseconds: 250),
-        width: dropTargetWidgetSize.width * 0.8,
-        height: dropTargetWidgetSize.height,
-        decoration: BoxDecoration(color: _eventColor(event).withAlpha(100), borderRadius: radius),
-      ),
-      tileWhenDraggingBuilder: (event) => Container(
-        decoration: BoxDecoration(color: _eventColor(event).withAlpha(80), borderRadius: radius),
-      ),
-      dragAnchorStrategy: pointerDragAnchorStrategy,
-      verticalResizeHandle: DecoratedBox(
-        decoration: BoxDecoration(color: scheme.onPrimaryContainer.withAlpha(150), shape: BoxShape.circle),
-      ),
-      horizontalResizeHandle: DecoratedBox(
-        decoration: BoxDecoration(color: scheme.onPrimaryContainer.withAlpha(150), shape: BoxShape.circle),
-      ),
-    );
-  }
-
-  ScheduleTileComponents _scheduleTileComponents() {
-    return ScheduleTileComponents(
-      tileBuilder: (event, tileRange) => Card(
-        margin: const EdgeInsets.symmetric(vertical: 1),
-        color: _eventColor(event),
-        child: Padding(
-          padding: const EdgeInsets.all(4),
-          child: Text((event is Event) ? event.title : ''),
+        body: const CalendarBody(
+          multiDayTileComponents: tileComponents,
+          monthTileComponents: tileComponents,
+          scheduleTileComponents: scheduleTileComponents,
         ),
       ),
     );

--- a/examples/example/lib/tiles.dart
+++ b/examples/example/lib/tiles.dart
@@ -1,0 +1,138 @@
+import 'package:example/main.dart';
+import 'package:flutter/material.dart';
+import 'package:kalender/kalender.dart';
+
+/// The tile widgets, each with a static `builder`.
+///
+/// Kept out of `main.dart` so the calendar setup there stays readable. Each
+/// tile reads the theme from its own context rather than capturing it from the
+/// enclosing build, which is what lets the builder be a static function and the
+/// components be a single `const`.
+///
+/// An inline builder works just as well. This is a readability choice.
+
+Color eventColor(BuildContext context, CalendarEvent event) =>
+    (event is Event ? event.color : null) ?? Theme.of(context).colorScheme.primaryContainer;
+
+BorderRadius get _radius => BorderRadius.circular(8);
+
+class EventTile extends StatelessWidget {
+  const EventTile({super.key, required this.event});
+
+  final CalendarEvent event;
+
+  static EventTile builder(CalendarEvent event, DateTimeRange tileRange) => EventTile(event: event);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: eventColor(context, event),
+      child: Padding(
+        padding: const EdgeInsets.all(4),
+        child: Text(
+          (event is Event) ? (event as Event).title : '',
+          style: TextStyle(color: Theme.of(context).colorScheme.onPrimaryContainer, fontSize: 12),
+        ),
+      ),
+    );
+  }
+}
+
+class DropTargetTile extends StatelessWidget {
+  const DropTargetTile({super.key});
+
+  static DropTargetTile builder(CalendarEvent event) => const DropTargetTile();
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: Theme.of(context).colorScheme.onSurface.withAlpha(80), width: 2),
+        borderRadius: _radius,
+      ),
+    );
+  }
+}
+
+class FeedbackTile extends StatelessWidget {
+  const FeedbackTile({super.key, required this.event, required this.size});
+
+  final CalendarEvent event;
+  final Size size;
+
+  static FeedbackTile builder(CalendarEvent event, Size dropTargetWidgetSize) =>
+      FeedbackTile(event: event, size: dropTargetWidgetSize);
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 250),
+      width: size.width * 0.8,
+      height: size.height,
+      decoration: BoxDecoration(color: eventColor(context, event).withAlpha(100), borderRadius: _radius),
+    );
+  }
+}
+
+class TileWhenDragging extends StatelessWidget {
+  const TileWhenDragging({super.key, required this.event});
+
+  final CalendarEvent event;
+
+  static TileWhenDragging builder(CalendarEvent event) => TileWhenDragging(event: event);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(color: eventColor(context, event).withAlpha(80), borderRadius: _radius),
+    );
+  }
+}
+
+/// Reads its color from the theme, so both handles can be one const widget.
+class ResizeHandle extends StatelessWidget {
+  const ResizeHandle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.onPrimaryContainer.withAlpha(150),
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+}
+
+class ScheduleEventTile extends StatelessWidget {
+  const ScheduleEventTile({super.key, required this.event});
+
+  final CalendarEvent event;
+
+  static ScheduleEventTile builder(CalendarEvent event, DateTimeRange tileRange) => ScheduleEventTile(event: event);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 1),
+      color: eventColor(context, event),
+      child: Padding(
+        padding: const EdgeInsets.all(4),
+        child: Text((event is Event) ? (event as Event).title : ''),
+      ),
+    );
+  }
+}
+
+/// Declared once rather than rebuilt by a method called from `build`.
+const tileComponents = TileComponents(
+  tileBuilder: EventTile.builder,
+  dropTargetTile: DropTargetTile.builder,
+  feedbackTileBuilder: FeedbackTile.builder,
+  tileWhenDraggingBuilder: TileWhenDragging.builder,
+  dragAnchorStrategy: pointerDragAnchorStrategy,
+  verticalResizeHandle: ResizeHandle(),
+  horizontalResizeHandle: ResizeHandle(),
+);
+
+const scheduleTileComponents = ScheduleTileComponents(tileBuilder: ScheduleEventTile.builder);


### PR DESCRIPTION
Next in the 0.25.0 stack, based on `main`.

## The correction

The changelog entry from #409 claimed that a builder written as an inline closure keeps the tile components from comparing equal, so every tile rebuilds whenever the calendar does, and that a static builder avoids it.

**Measured, and it is wrong.** Tile builds per parent rebuild, five events:

| | inline closures | static builders |
|---|---|---|
| before #409 (no `==` at all) | 5 | 5 |
| after #409 (with `==`) | 5 | 5 |

Identical in all four cells.

Flutter's own answer is the same: `SliverChildBuilderDelegate.shouldRebuild` returns `true` unconditionally, so a `ListView.builder` never compares its builder either. Rebuilding a widget subtree is cheap. An inherited widget reporting a change only adds work for dependents that would otherwise be *skipped*, and here they rebuild through the widget tree regardless.

The entry now says what is true: the components compare by value, and the inherited widgets carrying them stop reporting a change when nothing changed. That is a correctness fix rather than a performance one, and #409's code and test stand on that basis.

## The tidy-up

`examples/example` moves its tiles into `tiles.dart` as named widgets, which keeps the calendar setup in `main.dart` readable and lets each tile read the theme from its own context rather than capturing it. Same shape `advanced_example` already used.

**No documentation goes with it.** Extracting a widget is ordinary Flutter, not something this package needs to explain, and a section saying so would be filler now that there is no performance reason behind it.

## Verification

Format, analyze, 1615 tests, 45 doc snippets and the example all clean.
