### PR TITLE
feat: the style classes are Diagnosticable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ See [MIGRATION.md](MIGRATION.md#v024x--v0250) for what to change.
 
 - `CalendarEvent.isMultiDayEvent` is removed. It was deprecated in 0.24.0, which named this release. Use `spansMultipleDays(location:, defaultRule:)`. See [MIGRATION.md](MIGRATION.md#v024x--v0250).
 
+### Features
+
+- The style classes and `KalenderThemeData` are `Diagnosticable`, so their resolved values appear in the Flutter devtools inspector and in `toString()` instead of a bare instance hash. Fields left unset are omitted rather than printed as null.
+
 ### Fixes
 
 - `CalendarComponents`, the containers reached through it, `TileComponents` and `ScheduleTileComponents` compare by value, and `CalendarComponents` can be `const`. The inherited widgets carrying them reported a change on every rebuild because they compared by identity, and now report one only when something differs.

--- a/lib/src/theme/kalender_theme.dart
+++ b/lib/src/theme/kalender_theme.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 
@@ -21,7 +22,7 @@ import 'package:kalender/kalender.dart';
 ///   ),
 /// )
 /// ```
-class KalenderThemeData extends ThemeExtension<KalenderThemeData> {
+class KalenderThemeData extends ThemeExtension<KalenderThemeData> with Diagnosticable {
   /// The style of the [DayHeader].
   final DayHeaderStyle? dayHeaderStyle;
 
@@ -287,6 +288,41 @@ class KalenderThemeData extends ThemeExtension<KalenderThemeData> {
         multiDayOverlayStyle,
         multiDayPortalOverlayButtonStyle,
       );
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<DayHeaderStyle>('dayHeaderStyle', dayHeaderStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<TimelineStyle>('timelineStyle', timelineStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<HourLinesStyle>('hourLinesStyle', hourLinesStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<DaySeparatorStyle>('daySeparatorStyle', daySeparatorStyle, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<TimeIndicatorStyle>('timeIndicatorStyle', timeIndicatorStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<WeekNumberStyle>('weekNumberStyle', weekNumberStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<MonthGridStyle>('monthGridStyle', monthGridStyle, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<MonthDayHeaderStyle>('monthDayHeaderStyle', monthDayHeaderStyle, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<WeekDayHeaderStyle>('weekDayHeaderStyle', weekDayHeaderStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<ScheduleDateStyle>('scheduleDateStyle', scheduleDateStyle, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty<ScheduleTileHighlightStyle>(
+        'scheduleTileHighlightStyle',
+        scheduleTileHighlightStyle,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty<MultiDayOverlayStyle>('multiDayOverlayStyle', multiDayOverlayStyle, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty<MultiDayPortalOverlayButtonStyle>(
+        'multiDayPortalOverlayButtonStyle',
+        multiDayPortalOverlayButtonStyle,
+        defaultValue: null,
+      ),
+    );
+  }
 }
 
 /// Resolves the effective [KalenderThemeData] for a [BuildContext].

--- a/lib/src/widgets/components/day_header.dart
+++ b/lib/src/widgets/components/day_header.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -17,7 +18,7 @@ typedef DayHeaderBuilder = Widget Function(
 ///
 /// This class allows you to customize the appearance of the [DayHeader] widget.
 /// You can change the text style, the string displayed, the number text style, and the alignment.
-class DayHeaderStyle {
+class DayHeaderStyle with Diagnosticable {
   /// The [TextStyle] used by the [DayHeader] widget to display the name of the day.
   final TextStyle? textStyle;
 
@@ -87,6 +88,14 @@ class DayHeaderStyle {
 
   @override
   int get hashCode => Object.hash(textStyle, numberTextStyle, mainAxisAlignment);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<TextStyle>('textStyle', textStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<TextStyle>('numberTextStyle', numberTextStyle, defaultValue: null));
+    properties.add(EnumProperty<MainAxisAlignment>('mainAxisAlignment', mainAxisAlignment, defaultValue: null));
+  }
 }
 
 /// A widget that displays the name of the day and the day number of the week.

--- a/lib/src/widgets/components/day_separator.dart
+++ b/lib/src/widgets/components/day_separator.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' show lerpDouble;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
@@ -12,7 +13,7 @@ typedef DaySeparatorBuilder = Widget Function(
 );
 
 /// The style for the [DaySeparator] widget.
-class DaySeparatorStyle {
+class DaySeparatorStyle with Diagnosticable {
   /// The [Color] of the day separator.
   final Color? color;
 
@@ -82,6 +83,15 @@ class DaySeparatorStyle {
 
   @override
   int get hashCode => Object.hash(color, width, topIndent, bottomIndent);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(DoubleProperty('width', width, defaultValue: null));
+    properties.add(DoubleProperty('topIndent', topIndent, defaultValue: null));
+    properties.add(DoubleProperty('bottomIndent', bottomIndent, defaultValue: null));
+  }
 }
 
 /// A widget that displays a separator between days.

--- a/lib/src/widgets/components/hour_lines.dart
+++ b/lib/src/widgets/components/hour_lines.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' show lerpDouble;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -18,7 +19,7 @@ typedef HourLinesBuilder = Widget Function(
 );
 
 /// The style of the [HourLines] widget.
-class HourLinesStyle {
+class HourLinesStyle with Diagnosticable {
   /// The [Color] of the hour lines.
   final Color? color;
 
@@ -88,6 +89,15 @@ class HourLinesStyle {
 
   @override
   int get hashCode => Object.hash(color, thickness, indent, endIndent);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(DoubleProperty('thickness', thickness, defaultValue: null));
+    properties.add(DoubleProperty('indent', indent, defaultValue: null));
+    properties.add(DoubleProperty('endIndent', endIndent, defaultValue: null));
+  }
 }
 
 /// A widget that displays lines for each hour based on the [timeOfDayRange] and [heightPerMinute].

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -13,7 +14,7 @@ typedef MonthDayHeaderBuilder = Widget Function(
 );
 
 /// The style of the [MonthDayHeader].
-class MonthDayHeaderStyle {
+class MonthDayHeaderStyle with Diagnosticable {
   /// Creates a new [MonthDayHeaderStyle].
   const MonthDayHeaderStyle({
     this.numberTextStyle,
@@ -82,6 +83,14 @@ class MonthDayHeaderStyle {
 
   @override
   int get hashCode => Object.hash(numberTextStyle, buttonSize, margin);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<TextStyle>('numberTextStyle', numberTextStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<Size>('buttonSize', buttonSize, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('margin', margin, defaultValue: null));
+  }
 }
 
 /// A widget that displays the day number.

--- a/lib/src/widgets/components/month_grid.dart
+++ b/lib/src/widgets/components/month_grid.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' show lerpDouble;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
@@ -13,7 +14,7 @@ typedef MonthGridBuilder = Widget Function(
 );
 
 /// The [MonthGridStyle] class is used by the [MonthGrid] widget.
-class MonthGridStyle {
+class MonthGridStyle with Diagnosticable {
   const MonthGridStyle({
     this.color,
     this.thickness,
@@ -60,6 +61,13 @@ class MonthGridStyle {
 
   @override
   int get hashCode => Object.hash(color, thickness);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(DoubleProperty('thickness', thickness, defaultValue: null));
+  }
 }
 
 /// A widget that displays the month grid.

--- a/lib/src/widgets/components/multi_day_overlay.dart
+++ b/lib/src/widgets/components/multi_day_overlay.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 import 'dart:ui' show lerpDouble;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -43,7 +44,7 @@ typedef MultiDayOverlayBuilder = Widget Function({
   required MultiDayOverlayStyle? style,
 });
 
-class MultiDayOverlayStyle {
+class MultiDayOverlayStyle with Diagnosticable {
   /// The function that returns the name of the day.
   final String Function(DateTime date)? dayNameBuilder;
 
@@ -214,6 +215,23 @@ class MultiDayOverlayStyle {
         width,
         headerHeight,
       );
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(ObjectFlagProperty<String Function(DateTime)>.has('dayNameBuilder', dayNameBuilder));
+    properties.add(DiagnosticsProperty<TextStyle>('dayNameTextStyle', dayNameTextStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<TextStyle>('dateTextStyle', dateTextStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<Icon>('closeIcon', closeIcon, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('headerPadding', headerPadding, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('eventsPadding', eventsPadding, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('eventPadding', eventPadding, defaultValue: null));
+    properties.add(DiagnosticsProperty<CardThemeData>('cardTheme', cardTheme, defaultValue: null));
+    properties.add(DiagnosticsProperty<ButtonStyle>('closeButtonStyle', closeButtonStyle, defaultValue: null));
+    properties.add(ColorProperty('barrierColor', barrierColor, defaultValue: null));
+    properties.add(DoubleProperty('width', width, defaultValue: null));
+    properties.add(DoubleProperty('headerHeight', headerHeight, defaultValue: null));
+  }
 }
 
 /// Positions the overlay card, keeping all four of its edges inside the overlay.

--- a/lib/src/widgets/components/multi_day_overlay_portal_button.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal_button.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:kalender/src/models/components/string_builders.dart';
@@ -15,7 +16,7 @@ typedef MultiDayPortalOverlayButtonBuilder = Widget Function(
   MultiDayPortalOverlayButtonStyle? style,
 );
 
-class MultiDayPortalOverlayButtonStyle {
+class MultiDayPortalOverlayButtonStyle with Diagnosticable {
   /// The text style of the button.
   final TextStyle? textStyle;
 
@@ -76,6 +77,14 @@ class MultiDayPortalOverlayButtonStyle {
 
   @override
   int get hashCode => Object.hash(textStyle, textPadding, textOverflow);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<TextStyle>('textStyle', textStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('textPadding', textPadding, defaultValue: null));
+    properties.add(EnumProperty<TextOverflow>('textOverflow', textOverflow, defaultValue: null));
+  }
 }
 
 class MultiDayPortalOverlayButton extends StatelessWidget {

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -16,7 +17,7 @@ typedef ScheduleDateBuilder = Widget Function(
 );
 
 /// The style of the [ScheduleDate].
-class ScheduleDateStyle {
+class ScheduleDateStyle with Diagnosticable {
   /// Creates a new [ScheduleDateStyle].
   const ScheduleDateStyle({
     this.textStyle,
@@ -67,6 +68,13 @@ class ScheduleDateStyle {
 
   @override
   int get hashCode => Object.hash(textStyle, numberTextStyle);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<TextStyle>('textStyle', textStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<TextStyle>('numberTextStyle', numberTextStyle, defaultValue: null));
+  }
 }
 
 /// A widget that displays the name of the day and the day number of the week.

--- a/lib/src/widgets/components/schedule_tile_highlight.dart
+++ b/lib/src/widgets/components/schedule_tile_highlight.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
@@ -15,7 +16,7 @@ typedef ScheduleTileHighlightBuilder = Widget Function(
   Widget child,
 );
 
-class ScheduleTileHighlightStyle {
+class ScheduleTileHighlightStyle with Diagnosticable {
   /// Creates a new [ScheduleTileHighlightStyle].
   const ScheduleTileHighlightStyle({this.decoration});
 
@@ -48,6 +49,12 @@ class ScheduleTileHighlightStyle {
 
   @override
   int get hashCode => decoration.hashCode;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<BoxDecoration>('decoration', decoration, defaultValue: null));
+  }
 }
 
 /// A widget that highlights the list item if the date is within the given dateTimeRange.

--- a/lib/src/widgets/components/time_indicator.dart
+++ b/lib/src/widgets/components/time_indicator.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui' show lerpDouble;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -18,7 +19,7 @@ typedef TimeIndicatorBuilder = Widget Function(
 );
 
 /// The style of the [TimeIndicator] widget.
-class TimeIndicatorStyle {
+class TimeIndicatorStyle with Diagnosticable {
   /// The [Color] of the time indicator.
   final Color? lineColor;
 
@@ -89,6 +90,15 @@ class TimeIndicatorStyle {
 
   @override
   int get hashCode => Object.hash(lineColor, thickness, circleColor, circleSize);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(ColorProperty('lineColor', lineColor, defaultValue: null));
+    properties.add(DoubleProperty('thickness', thickness, defaultValue: null));
+    properties.add(ColorProperty('circleColor', circleColor, defaultValue: null));
+    properties.add(DiagnosticsProperty<Size>('circleSize', circleSize, defaultValue: null));
+  }
 }
 
 /// A widget that displays the current time as a line and a circle.

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' show lerpDouble;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -78,7 +79,7 @@ double defaultTimelineWidth(BuildContext context, TimeOfDayRange timeOfDayRange,
 }
 
 /// The style of the [TimeLine] widget.
-class TimelineStyle {
+class TimelineStyle with Diagnosticable {
   /// The style of the text.
   final TextStyle? textStyle;
 
@@ -198,6 +199,19 @@ class TimelineStyle {
         startDecoration,
         endDecoration,
       );
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<TextStyle>('textStyle', textStyle, defaultValue: null));
+    properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
+    properties.add(EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
+    properties.add(EnumProperty<TextOverflow>('textOverflow', textOverflow, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('textPadding', textPadding, defaultValue: null));
+    properties.add(DoubleProperty('width', width, defaultValue: null));
+    properties.add(DiagnosticsProperty<Decoration>('startDecoration', startDecoration, defaultValue: null));
+    properties.add(DiagnosticsProperty<Decoration>('endDecoration', endDecoration, defaultValue: null));
+  }
 }
 
 /// A mixin that provides utility methods for the [TimeLine] and [HourLines] widget.

--- a/lib/src/widgets/components/week_day_header.dart
+++ b/lib/src/widgets/components/week_day_header.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -13,7 +14,7 @@ typedef WeekDayHeaderBuilder = Widget Function(
 );
 
 /// The [WeekDayHeaderStyle] class is used by the default [WeekDayHeader] widget.
-class WeekDayHeaderStyle {
+class WeekDayHeaderStyle with Diagnosticable {
   const WeekDayHeaderStyle({
     this.textStyle,
     this.padding,
@@ -63,6 +64,13 @@ class WeekDayHeaderStyle {
 
   @override
   int get hashCode => Object.hash(textStyle, padding);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<TextStyle>('textStyle', textStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('padding', padding, defaultValue: null));
+  }
 }
 
 /// A widget that displays the name of the day of the week.

--- a/lib/src/widgets/components/week_number.dart
+++ b/lib/src/widgets/components/week_number.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
@@ -13,7 +14,7 @@ typedef WeekNumberBuilder = Widget Function(
 );
 
 /// The style of the [WeekNumber].
-class WeekNumberStyle {
+class WeekNumberStyle with Diagnosticable {
   /// Creates a new [WeekNumberStyle].
   const WeekNumberStyle({
     this.textStyle,
@@ -93,6 +94,16 @@ class WeekNumberStyle {
 
   @override
   int get hashCode => Object.hash(textStyle, visualDensity, tooltip, padding, alignment);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<TextStyle>('textStyle', textStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<VisualDensity>('visualDensity', visualDensity, defaultValue: null));
+    properties.add(StringProperty('tooltip', tooltip, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('padding', padding, defaultValue: null));
+    properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null));
+  }
 }
 
 /// A widget that displays the week number.

--- a/test/models/component_styles_test.dart
+++ b/test/models/component_styles_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
@@ -472,6 +473,52 @@ void main() {
         const MultiDayPortalOverlayButtonStyle(textStyle: TextStyle(fontSize: 10), textPadding: EdgeInsets.all(4)),
       );
       expect(a == b, false);
+    });
+  });
+
+  group('Diagnosticable', () {
+    test('a style reports the fields it sets and omits the ones it does not', () {
+      const style = HourLinesStyle(color: Color(0xFF00FF00), thickness: 3);
+      final description = style.toString();
+
+      expect(description, startsWith('HourLinesStyle'));
+      expect(description, contains('thickness: 3.0'));
+      expect(description, contains('color:'));
+      // Unset fields are left out rather than printed as null.
+      expect(description, isNot(contains('indent')));
+    });
+
+    test('the theme reports the styles it carries', () {
+      const theme = KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 3));
+      final description = theme.toString();
+
+      expect(description, startsWith('KalenderThemeData'));
+      expect(description, contains('hourLinesStyle: HourLinesStyle'));
+      expect(description, isNot(contains('monthGridStyle')));
+    });
+
+    test('every style class is diagnosticable', () {
+      const styles = <Diagnosticable>[
+        DayHeaderStyle(),
+        TimelineStyle(),
+        HourLinesStyle(),
+        DaySeparatorStyle(),
+        TimeIndicatorStyle(),
+        WeekNumberStyle(),
+        MonthGridStyle(),
+        MonthDayHeaderStyle(),
+        WeekDayHeaderStyle(),
+        ScheduleDateStyle(),
+        ScheduleTileHighlightStyle(),
+        MultiDayOverlayStyle(),
+        MultiDayPortalOverlayButtonStyle(),
+        KalenderThemeData(),
+      ];
+
+      expect(styles, hasLength(14));
+      for (final style in styles) {
+        expect(style.toString(), startsWith(style.runtimeType.toString()));
+      }
     });
   });
 }


### PR DESCRIPTION
Stacked on #411. Review that one first, or read only the last commit here.

The 13 component style classes and `KalenderThemeData` now describe their fields, so devtools and `toString()` show resolved values rather than an instance hash:

```
HourLinesStyle#7f1fc(color: Color(alpha: 1.0000, red: 0.0000, green: 1.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB), thickness: 3.0)
KalenderThemeData#8b4d7(hourLinesStyle: HourLinesStyle#7f1fc(...))
```

Fields left unset are omitted rather than printed as null, so the output says what was actually set.

This is how Flutter's own theme classes are written, `CardThemeData` among them, and it was the one convention the theming here did not follow. Nothing in `lib/` used `Diagnosticable` before this.

## Worth knowing for anyone adding more

`material.dart` does not give you these types. `widgets.dart` re-exports only `Brightness` and `UniqueKey` from foundation, so every file needs `package:flutter/foundation.dart` directly. The whole set failed to compile until that went in, which was not obvious given how much else `material.dart` provides.

## Scope

Additive, and the style classes keep their const constructors since the mixin declares no fields.

The containers under `models/components` are deliberately left out. They exist to hold styles, and 0.26.0 removes that role, so they would be gaining a method shortly before being deleted.

## Verification

Root analyze clean, 1618 tests pass, all eight examples clean. The new tests assert the output names the type, includes set fields, and omits unset ones, plus a case that walks all 14 classes.