### PR TITLE
feat: KalenderTheme is a widget, so a theme can be scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [MIGRATION.md](MIGRATION.md#v024x--v0250) for what to change.
 
 ### Features
 
+- `KalenderTheme` is a widget, so a theme can be applied to part of the tree instead of the whole app. Wrap a calendar in `KalenderTheme(data: ..., child: ...)` and two calendars in one app can look different. The nearest one wins when they nest, and fields it leaves out still come from the `KalenderThemeData` registered on `ThemeData.extensions`, which keeps working as before. It is an `InheritedTheme`, so the theme also reaches the tile that follows a drag, which is built into an `Overlay` rather than below the calendar.
 - The style classes and `KalenderThemeData` are `Diagnosticable`, so their resolved values appear in the Flutter devtools inspector and in `toString()` instead of a bare instance hash. Fields left unset are omitted rather than printed as null.
 
 ### Fixes

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -252,13 +252,45 @@ MaterialApp(
 )
 ```
 
-Styles resolve in three layers, most specific first:
+### Theming part of the app
+
+Registering on `ThemeData` covers every calendar in the app. To theme one of
+them differently, wrap it in a `KalenderTheme`:
+
+<!-- snippet: expression -->
+```dart
+KalenderTheme(
+  data: const KalenderThemeData(
+    hourLinesStyle: HourLinesStyle(thickness: 2),
+  ),
+  child: CalendarView(
+    eventsController: DefaultEventsController(),
+    calendarController: CalendarController(),
+    viewConfiguration: MultiDayViewConfiguration.week(),
+    body: CalendarBody(),
+  ),
+)
+```
+
+The nearest one wins when they nest, and fields it leaves out fall through to
+the theme registered on `ThemeData`, so a scope can change one thing without
+restating the rest.
+
+This is an `InheritedTheme`, so it also reaches widgets the calendar builds into
+an `Overlay`, such as the tile that follows a drag. Those are not descendants of
+your calendar, so an ordinary inherited widget would not reach them.
+
+### How a style is resolved
+
+Four layers, most specific first. Each one fills in the fields the layer above
+it leaves null.
 
 1. A style passed to a single calendar through `CalendarComponents` (see [Appearance](#appearance--custom-components)).
-2. The `KalenderThemeData` registered on the theme.
-3. The Material 3 defaults.
+2. The nearest `KalenderTheme` above the calendar.
+3. The `KalenderThemeData` registered on `ThemeData.extensions`.
+4. The Material 3 defaults.
 
-Theme changes animate: because `KalenderThemeData` is a `ThemeExtension` with `lerp`, switching themes transitions the calendar's colors along with the rest of the app.
+Theme changes animate: because `KalenderThemeData` is a `ThemeExtension` with `lerp`, switching themes transitions the calendar's colors along with the rest of the app. A `KalenderTheme` scope does not animate on its own, since it is a plain widget rather than part of `ThemeData`.
 
 ### The overflow overlay
 

--- a/lib/src/theme/kalender_theme.dart
+++ b/lib/src/theme/kalender_theme.dart
@@ -325,15 +325,56 @@ class KalenderThemeData extends ThemeExtension<KalenderThemeData> with Diagnosti
   }
 }
 
-/// Resolves the effective [KalenderThemeData] for a [BuildContext].
-abstract final class KalenderTheme {
-  /// The effective theme: the Material 3 defaults overlaid with the app's
-  /// [KalenderThemeData] extension, if one is registered on [ThemeData.extensions].
+/// Applies a [KalenderThemeData] to the calendars below it.
+///
+/// Use this to theme part of the tree. Registering a [KalenderThemeData] on
+/// [ThemeData.extensions] themes the whole app, which is the right place for an
+/// app-wide look, but two calendars in one app cannot differ that way.
+///
+/// ```dart
+/// KalenderTheme(
+///   data: const KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 2)),
+///   child: CalendarView(...),
+/// )
+/// ```
+///
+/// This extends [InheritedTheme], so the theme also reaches widgets the
+/// calendar builds into an [Overlay], such as the tile that follows a drag.
+/// Those are not descendants of this widget, so a plain [InheritedWidget] would
+/// not reach them.
+class KalenderTheme extends InheritedTheme {
+  /// The styles applied to the calendars below this widget.
+  final KalenderThemeData data;
+
+  /// Creates a [KalenderTheme].
+  const KalenderTheme({super.key, required this.data, required super.child});
+
+  /// The effective theme for [context].
   ///
-  /// A style passed directly to a widget still takes precedence over the
-  /// value returned here.
+  /// Resolved in this order, each layer filling in the fields the one above
+  /// leaves null:
+  ///
+  /// 1. the nearest [KalenderTheme] ancestor,
+  /// 2. a [KalenderThemeData] registered on [ThemeData.extensions],
+  /// 3. the Material 3 defaults from [KalenderThemeData.defaults].
+  ///
+  /// A style passed directly to a widget still takes precedence over all three.
   static KalenderThemeData of(BuildContext context) {
+    final defaults = KalenderThemeData.defaults(context);
     final extension = Theme.of(context).extension<KalenderThemeData>();
-    return KalenderThemeData.defaults(context).merge(extension);
+    final inherited = context.dependOnInheritedWidgetOfExactType<KalenderTheme>()?.data;
+    return defaults.merge(extension).merge(inherited);
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) => KalenderTheme(data: data, child: child);
+
+  @override
+  bool updateShouldNotify(KalenderTheme oldWidget) => data != oldWidget.data;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<KalenderThemeData>('data', data));
   }
 }

--- a/lib/src/widgets/event_tiles/tile_draggable.dart
+++ b/lib/src/widgets/event_tiles/tile_draggable.dart
@@ -54,11 +54,17 @@ class TileDraggable extends StatelessWidget {
     }(
       key: rescheduleDraggableKey,
       data: Reschedule(event: event),
-      feedback: FeedbackWidget(
-        event: event,
-        eventsController: context.eventsController,
-        feedbackWidgetSizeNotifier: context.feedbackWidgetSizeNotifier,
-        feedbackTileBuilder: feedbackTileBuilder,
+      // The feedback is built into the Overlay, which is not below this widget,
+      // so it inherits nothing from here. Capturing carries the themes across,
+      // which is why a scoped KalenderTheme reaches the dragged tile.
+      feedback: InheritedTheme.captureAll(
+        context,
+        FeedbackWidget(
+          event: event,
+          eventsController: context.eventsController,
+          feedbackWidgetSizeNotifier: context.feedbackWidgetSizeNotifier,
+          feedbackTileBuilder: feedbackTileBuilder,
+        ),
       ),
       dragAnchorStrategy: dragAnchorStrategy ?? childDragAnchorStrategy,
       onDragStarted: () {

--- a/test/widgets/kalender_theme_scoped_test.dart
+++ b/test/widgets/kalender_theme_scoped_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+/// Covers [KalenderTheme] as a widget: scoping a theme to part of the tree, and
+/// where it sits relative to the theme extension and the Material 3 defaults.
+void main() {
+  /// The rendered color of the day separator, which follows the theme.
+  Color? separatorColor(WidgetTester tester, {Finder? within}) {
+    final finder =
+        within == null ? find.byType(Container) : find.descendant(of: within, matching: find.byType(Container));
+    return tester.widget<Container>(finder.first).color;
+  }
+
+  Widget app({KalenderThemeData? extension, required Widget child}) {
+    return MaterialApp(
+      theme: ThemeData(extensions: [if (extension != null) extension]),
+      home: Scaffold(body: child),
+    );
+  }
+
+  testWidgets('a scoped theme applies below it', (tester) async {
+    const scoped = Color(0xFF00FF00);
+
+    await tester.pumpWidget(
+      app(
+        child: const KalenderTheme(
+          data: KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(color: scoped)),
+          child: DaySeparator(),
+        ),
+      ),
+    );
+
+    expect(separatorColor(tester), scoped);
+  });
+
+  testWidgets('a scoped theme beats the extension', (tester) async {
+    const fromExtension = Color(0xFFFF0000);
+    const fromScope = Color(0xFF00FF00);
+
+    await tester.pumpWidget(
+      app(
+        extension: const KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(color: fromExtension)),
+        child: const KalenderTheme(
+          data: KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(color: fromScope)),
+          child: DaySeparator(),
+        ),
+      ),
+    );
+
+    expect(separatorColor(tester), fromScope);
+  });
+
+  testWidgets('a scoped theme fills in from the extension field by field', (tester) async {
+    const fromExtension = Color(0xFFFF0000);
+
+    await tester.pumpWidget(
+      app(
+        extension: const KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(color: fromExtension)),
+        child: const KalenderTheme(
+          // Sets the width only, so the color still comes from the extension.
+          data: KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(width: 5)),
+          child: DaySeparator(),
+        ),
+      ),
+    );
+
+    expect(separatorColor(tester), fromExtension);
+  });
+
+  testWidgets('two calendars in one app can be themed differently', (tester) async {
+    const left = Color(0xFF00FF00);
+    const right = Color(0xFF0000FF);
+    final leftKey = UniqueKey();
+    final rightKey = UniqueKey();
+
+    await tester.pumpWidget(
+      app(
+        child: Row(
+          children: [
+            Expanded(
+              child: KalenderTheme(
+                data: const KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(color: left)),
+                child: SizedBox(key: leftKey, child: const DaySeparator()),
+              ),
+            ),
+            Expanded(
+              child: KalenderTheme(
+                data: const KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(color: right)),
+                child: SizedBox(key: rightKey, child: const DaySeparator()),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(separatorColor(tester, within: find.byKey(leftKey)), left);
+    expect(separatorColor(tester, within: find.byKey(rightKey)), right);
+  });
+
+  testWidgets('the nearest scope wins when they nest', (tester) async {
+    const outer = Color(0xFFFF0000);
+    const inner = Color(0xFF00FF00);
+
+    await tester.pumpWidget(
+      app(
+        child: const KalenderTheme(
+          data: KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(color: outer)),
+          child: KalenderTheme(
+            data: KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(color: inner)),
+            child: DaySeparator(),
+          ),
+        ),
+      ),
+    );
+
+    expect(separatorColor(tester), inner);
+  });
+
+  testWidgets('changing the data notifies dependents, an equal value does not', (tester) async {
+    // Counts didChangeDependencies, not builds. A build counter cannot tell a
+    // real notification from the child being replaced by its parent rebuilding.
+    _DependentState.notifications = 0;
+
+    Widget build(KalenderThemeData data) {
+      return app(child: KalenderTheme(data: data, child: const _Dependent()));
+    }
+
+    await tester.pumpWidget(build(const KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(width: 1))));
+    expect(_DependentState.notifications, 1);
+
+    // Same values, a different instance.
+    await tester.pumpWidget(build(const KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(width: 1))));
+    expect(_DependentState.notifications, 1, reason: 'an equal theme is not a change');
+
+    await tester.pumpWidget(build(const KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(width: 2))));
+    expect(_DependentState.notifications, 2);
+  });
+
+  testWidgets('wrap carries the theme into a detached tree', (tester) async {
+    // What InheritedTheme adds over a plain InheritedWidget, and the reason the
+    // dragged tile is themed: the captured themes are replayed somewhere that
+    // is not a descendant.
+    const scoped = Color(0xFF00FF00);
+    late Widget captured;
+
+    await tester.pumpWidget(
+      app(
+        child: KalenderTheme(
+          data: const KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(color: scoped)),
+          child: Builder(
+            builder: (context) {
+              captured = InheritedTheme.captureAll(context, const DaySeparator());
+              return const SizedBox();
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Pumped outside the scope entirely.
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: captured)));
+
+    expect(separatorColor(tester), scoped);
+  });
+}
+
+/// Reads the theme and records every time it is reported as changed.
+class _Dependent extends StatefulWidget {
+  const _Dependent();
+
+  @override
+  State<_Dependent> createState() => _DependentState();
+}
+
+class _DependentState extends State<_Dependent> {
+  static int notifications = 0;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    KalenderTheme.of(context);
+    notifications++;
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}


### PR DESCRIPTION
Stacked on #412. Review that one first, or read only the last commit here.

`KalenderTheme` was a holder class with a single static `of`. It is now an `InheritedTheme` with a `data` field, so a theme can be applied to part of the tree rather than only to the whole app:

```dart
KalenderTheme(
  data: const KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 2)),
  child: CalendarView(...),
)
```

Two calendars in one app can now look different, which was not possible at any price before.

## What does not change

`of` keeps its signature, so all 17 call sites are untouched. It now checks the nearest `KalenderTheme` ancestor first, then the `ThemeExtension`, then the Material 3 defaults, each layer filling in what the one above leaves null. Registering on `ThemeData.extensions` works exactly as before, and so does the animated theme transition that `ThemeData.lerp` gives it.

Additive. Nothing has to change to keep the current behaviour.

## Why InheritedTheme and not InheritedWidget

For `wrap`. The tile that follows a drag is built into the `Overlay`, which is not below the calendar, so it inherits nothing from it. `tile_draggable.dart:81` already documented that problem and worked around it by passing the events controller by hand. `InheritedTheme.captureAll` carries the themes across instead, so a scoped theme reaches the dragged tile rather than silently missing it.

A plain `InheritedWidget` would have shipped that gap. There is a test that pins it: a theme is captured inside a scope and the widget is then pumped in a completely separate tree, where it still resolves the scoped value.

## Verification

Seven new tests covering scoping, precedence against the extension, field-by-field fallthrough, two calendars side by side, nesting, notification on change, and the detached-tree case. Format, analyze and 1625 tests pass, doc snippets compile.

The notification test counts `didChangeDependencies` rather than builds. My first version counted builds, passed against broken behaviour, and had to be rewritten.