### PR TITLE
refactor!: deprecate the style fields on CalendarComponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ See [MIGRATION.md](MIGRATION.md#v024x--v0250) for what to change.
 - `KalenderTheme` is a widget, so a theme can be applied to part of the tree instead of the whole app. Wrap a calendar in `KalenderTheme(data: ..., child: ...)` and two calendars in one app can look different. The nearest one wins when they nest, and fields it leaves out still come from the `KalenderThemeData` registered on `ThemeData.extensions`, which keeps working as before. It is an `InheritedTheme`, so the theme also reaches the tile that follows a drag, which is built into an `Overlay` rather than below the calendar.
 - The style classes and `KalenderThemeData` are `Diagnosticable`, so their resolved values appear in the Flutter devtools inspector and in `toString()` instead of a bare instance hash. Fields left unset are omitted rather than printed as null.
 
+### Deprecations
+
+- The style fields on `CalendarComponents` are deprecated and are removed in 0.26.0. Use `KalenderThemeData` for the whole app, or a `KalenderTheme` to scope one calendar. The same thirteen styles were reachable both ways, and `multiDayOverlayStyle` had four different homes. `CalendarComponents` keeps its builder fields. See [MIGRATION.md](MIGRATION.md#v024x--v0250).
+
 ### Fixes
 
+- Styling the month view's week number no longer moves it to the middle of its row. The top alignment came from a default on `MonthBodyComponentStyles`, so setting any week number style there replaced it. The month body now applies that alignment itself, and anything you set merges over it.
 - `CalendarComponents`, the containers reached through it, `TileComponents` and `ScheduleTileComponents` compare by value, and `CalendarComponents` can be `const`. The inherited widgets carrying them reported a change on every rebuild because they compared by identity, and now report one only when something differs.
 - `CalendarComponents` and the containers reached through it gain `copyWith`.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -14,6 +14,35 @@ Each section covers one upgrade. Versions not listed below need no changes.
 
 ## v0.24.x → v0.25.0
 
+### Styles move off `CalendarComponents`
+
+Deprecated in 0.25.0, removed in 0.26.0. Nothing breaks yet.
+
+```dart
+- CalendarComponents(
+-   multiDayComponentStyles: MultiDayComponentStyles(
+-     bodyStyles: MultiDayBodyComponentStyles(
+-       hourLinesStyle: HourLinesStyle(thickness: 2),
+-     ),
+-   ),
+- )
+
++ KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 2))
+```
+
+Register that on `ThemeData.extensions` for the whole app, or wrap one calendar in a `KalenderTheme` to scope it. The same thirteen styles are reachable either way, and `multiDayOverlayStyle` in particular had four different homes.
+
+`CalendarComponents` keeps its builder fields. Styles go to the theme, builders stay where they are.
+
+**If you styled the same thing differently per view,** the containers were how you did it, and a `KalenderTheme` around `CalendarHeader` or `CalendarBody` is how you do it now:
+
+```dart
+CalendarView(
+  header: KalenderTheme(data: headerStyles, child: CalendarHeader()),
+  body: KalenderTheme(data: bodyStyles, child: CalendarBody()),
+)
+```
+
 ### `isMultiDayEvent` is removed
 
 ```dart

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -316,9 +316,16 @@ KalenderThemeData(
 
 ## Appearance / Custom Components
 
-Pass a `CalendarComponents` object to `CalendarView` to override default widget builders or just pass style objects to tweak colors, text styles, and padding without defining your own widgets. Styles passed here apply to that one `CalendarView` and win over the [theme](#theming).
+Pass a `CalendarComponents` object to `CalendarView` to override the default widget builders.
 
-Style classes: [`MultiDayComponentStyles`](https://pub.dev/documentation/kalender/latest/kalender/MultiDayComponentStyles-class.html), [`MonthComponentStyles`](https://pub.dev/documentation/kalender/latest/kalender/MonthComponentStyles-class.html), [`ScheduleComponentStyles`](https://pub.dev/documentation/kalender/latest/kalender/ScheduleComponentStyles-class.html).
+> [!WARNING]
+> The style fields on `CalendarComponents` are deprecated and are removed in
+> 0.26.0. Use `KalenderThemeData` for the whole app, or wrap a calendar in a
+> [`KalenderTheme`](#theming-part-of-the-app) to style one of them. That is the
+> same set of styles reached one way instead of four.
+>
+> `CalendarComponents` keeps its builder fields. Styles move to the theme,
+> builders stay here.
 
 <details>
   <summary>MultiDayComponents</summary>

--- a/lib/src/models/components/components.dart
+++ b/lib/src/models/components/components.dart
@@ -19,18 +19,21 @@ class CalendarComponents {
   final MonthComponents monthComponents;
 
   /// Styles used by the month view.
+  @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
   final MonthComponentStyles monthComponentStyles;
 
   /// Components used to override the default multi day components.
   final MultiDayComponents multiDayComponents;
 
   /// Styles used by the multi day view.
+  @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
   final MultiDayComponentStyles multiDayComponentStyles;
 
   /// Components used to override the default schedule components.
   final ScheduleComponents scheduleComponents;
 
   /// Styles used by the schedule view.
+  @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
   final ScheduleComponentStyles scheduleComponentStyles;
 
   /// Default override for the overlay widgets.
@@ -41,28 +44,37 @@ class CalendarComponents {
   /// Default styles for the overlay widgets.
   ///
   /// If another style is provided in [multiDayComponentStyles] or [monthComponentStyles], that will be used instead.
+  @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
   final OverlayStyles? overlayStyles;
 
   const CalendarComponents({
     this.monthComponents = const MonthComponents(),
+    @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
     this.monthComponentStyles = const MonthComponentStyles(),
     this.multiDayComponents = const MultiDayComponents(),
+    @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
     this.multiDayComponentStyles = const MultiDayComponentStyles(),
     this.scheduleComponents = const ScheduleComponents(),
+    @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
     this.scheduleComponentStyles = const ScheduleComponentStyles(),
     this.overlayBuilders,
+    @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
     this.overlayStyles,
   });
 
   /// Creates a copy of this with the given fields replaced.
   CalendarComponents copyWith({
     MonthComponents? monthComponents,
+    @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
     MonthComponentStyles? monthComponentStyles,
     MultiDayComponents? multiDayComponents,
+    @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
     MultiDayComponentStyles? multiDayComponentStyles,
     ScheduleComponents? scheduleComponents,
+    @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
     ScheduleComponentStyles? scheduleComponentStyles,
     OverlayBuilders? overlayBuilders,
+    @Deprecated('Style through KalenderThemeData, or scope one with KalenderTheme. Removed in 0.26.0.')
     OverlayStyles? overlayStyles,
   }) {
     return CalendarComponents(

--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -110,7 +110,7 @@ class MonthBody extends StatelessWidget {
                   visibleRange: visibleRange,
                   numberOfRows: numberOfRows,
                   weekNumberBuilder: monthComponents.bodyComponents.weekNumberBuilder,
-                  weekNumberStyle: monthStyles.weekNumberStyle,
+                  weekNumberStyle: monthWeekNumberDefaults.merge(monthStyles.weekNumberStyle),
                   dividerSide: dividerSide,
                 ),
               ),
@@ -231,3 +231,10 @@ class _MonthDayCellBackground extends StatelessWidget {
     );
   }
 }
+
+/// The month grid puts the week number at the top of its row, where the theme
+/// leaves it centred.
+///
+/// Applied as a default rather than an override, so anything set on the theme
+/// or through a [KalenderTheme] still wins.
+const monthWeekNumberDefaults = WeekNumberStyle(alignment: Alignment.topCenter);

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -262,6 +262,44 @@ void main() {
       );
     });
 
+    testWidgets('the month week number sits at the top of its row by default', (tester) async {
+      // The month grid overrides the theme's centred alignment. This used to
+      // come from a default on MonthBodyComponentStyles, and moved to the month
+      // body when that style path was deprecated, so it is worth pinning.
+      await pumpMonthView(tester, DateTime(2025, 1), showWeekNumbers: true);
+
+      expect(
+        find.descendant(
+          of: find.byType(WeekNumber),
+          matching: find.byWidgetPredicate((w) => w is Align && w.alignment == Alignment.topCenter),
+        ),
+        findsWidgets,
+      );
+    });
+
+    testWidgets('a style set for the month keeps the top alignment it does not mention', (tester) async {
+      await pumpMonthView(
+        tester,
+        DateTime(2025, 1),
+        showWeekNumbers: true,
+        components: const CalendarComponents(
+          monthComponentStyles: MonthComponentStyles(
+            bodyStyles: MonthBodyComponentStyles(
+              weekNumberStyle: WeekNumberStyle(tooltip: 'Week'),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(WeekNumber),
+          matching: find.byWidgetPredicate((w) => w is Align && w.alignment == Alignment.topCenter),
+        ),
+        findsWidgets,
+      );
+    });
+
     testWidgets('applies custom week number alignment from style', (tester) async {
       const rows = 5;
       final components = const CalendarComponents(


### PR DESCRIPTION
Stacked on #415. Review that one first, or read only the last commit here. Last of the 0.25.0 stack.

The same thirteen styles were reachable through the theme and through the component containers. `multiDayOverlayStyle` had four homes: the theme, `CalendarComponents.overlayStyles`, `MultiDayHeaderComponentStyles.overlayStyles` and `MonthBodyComponentStyles.overlayStyles`.

Deprecated now, removed in 0.26.0. `CalendarComponents` keeps its builder fields: styles go to the theme, builders stay where they are.

## What made this worth checking rather than just doing

The containers were **not only duplicate slots**. They also carried per-view scoping that the theme cannot express: `WeekNumberStyle` sits on both the month body and the multi-day header with *different defaults*, and `KalenderThemeData` has one field.

Concretely, the month week number is top aligned only because `MonthBodyComponentStyles` defaults it that way, while the theme centres it. Deprecating the path as originally planned would have quietly moved it, and with no golden tests nothing would have caught it.

Since #414 made `KalenderTheme` a widget, that scoping has a replacement:

```dart
CalendarView(
  header: KalenderTheme(data: headerStyles, child: CalendarHeader()),
  body: KalenderTheme(data: bodyStyles, child: CalendarBody()),
)
```

The month body now applies its own top alignment, so the default survives the containers.

## Which turned out to fix a defect

The old default was an object, so a consumer setting *any* week number style for the month replaced it whole and silently lost the top alignment. It is now applied as a default that the consumer's style merges over, so setting a tooltip no longer moves the number.

There is a test for it, and I checked it fails against the previous behaviour rather than assuming.

## Verification

The deprecation firing was verified rather than assumed. A root `flutter analyze` cannot see it: `analysis_options.yaml` excludes `examples/**` and `deprecated_member_use_from_same_package` is off. No example uses these fields, so a probe file went into one, the warning was confirmed, and the probe was removed.

Format, analyze, 1627 tests, 47 doc snippets and all eight examples clean.