### PR TITLE
chore: pre-release 0.25.0-dev.1

### DIFF
--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -110,7 +110,7 @@ class MonthBody extends StatelessWidget {
                   visibleRange: visibleRange,
                   numberOfRows: numberOfRows,
                   weekNumberBuilder: monthComponents.bodyComponents.weekNumberBuilder,
-                  weekNumberStyle: monthWeekNumberDefaults.merge(monthStyles.weekNumberStyle),
+                  weekNumberStyle: _monthWeekNumberDefaults.merge(monthStyles.weekNumberStyle),
                   dividerSide: dividerSide,
                 ),
               ),
@@ -235,6 +235,8 @@ class _MonthDayCellBackground extends StatelessWidget {
 /// The month grid puts the week number at the top of its row, where the theme
 /// leaves it centred.
 ///
-/// Applied as a default rather than an override, so anything set on the theme
-/// or through a [KalenderTheme] still wins.
-const monthWeekNumberDefaults = WeekNumberStyle(alignment: Alignment.topCenter);
+/// Applied under [MonthBodyComponentStyles.weekNumberStyle], so a style set
+/// there keeps this alignment unless it sets one of its own. It is passed to
+/// the widget, so it takes precedence over [KalenderThemeData.weekNumberStyle],
+/// which cannot change the month week number's alignment.
+const _monthWeekNumberDefaults = WeekNumberStyle(alignment: Alignment.topCenter);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.24.0
+version: 0.25.0-dev.1
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
Bumps the version to `0.25.0-dev.1` so the theming work in 0.25.0 can be checked on pub.dev before the real release.

Also carries one fix from the pre-release review.

### Keep the month week number default out of the public API

`monthWeekNumberDefaults` was added when the container styles were deprecated. It lives in `month_body.dart`, which `kalender.dart` exports, so it became a public top-level name that nothing outside that file uses. Confirmed by compiling a reference to it against the package, and confirmed gone the same way. Renaming it now costs nothing, since it has never been in a release.

Its doc comment also had the resolution order backwards. It said anything set on the theme still wins. The style is passed to the widget, and the widget merges the passed style over the theme, so it takes precedence instead. Checked against the rendered `Align`: with a `KalenderTheme` setting `weekNumberStyle.alignment` to `bottomCenter`, the month body still renders `topCenter`. The comment now states that.

That limitation is not new and nothing here changes it, but it needs an answer before 0.26.0 removes `MonthBodyComponentStyles`. The deprecation points users at `KalenderThemeData`, and for this one field that will not work: `KalenderThemeData.defaults` sets `alignment: Alignment.center` explicitly, so there is no way to distinguish an unset alignment from a chosen one, and the month body's `topCenter` always wins. Today the container is still there to reach it. After 0.26.0 the alignment becomes unreachable. The cause is that one `weekNumberStyle` on the theme serves two views that want different defaults, which is what the per-view containers were for.

### Verification

- 1455 tests pass.
- `flutter analyze` clean.
- `dart format --set-exit-if-changed lib test tool benchmark` clean.
- All eight examples analyze clean.
- `flutter pub publish --dry-run` warns only that the changelog does not mention `0.25.0-dev.1`. That warning clears in CI, where the link-pinning step rewrites the changelog's relative `MIGRATION.md` links to `blob/v0.25.0-dev.1/` URLs and commits them, leaving the dry run warning-free. Verified by running the pinning step locally.

The changelog keeps its `## 0.25.0` heading with no dev entry, matching all seven 0.24.0 pre-releases.

### After merging

Tag `v0.25.0-dev.1` on the merge commit. The publish workflow refuses a tag that is not on `main`.