### PR TITLE
demo: scoped theme toggle for the web demo

### DIFF
--- a/examples/web_demo/lib/models/demo_configuration.dart
+++ b/examples/web_demo/lib/models/demo_configuration.dart
@@ -108,6 +108,16 @@ class DemoConfiguration extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Whether to wrap the calendar in a `KalenderTheme`, styling this one
+  /// calendar rather than every calendar in the app.
+  ValueNotifier<bool> scopedThemeNotifier = ValueNotifier(false);
+  bool get scopedTheme => scopedThemeNotifier.value;
+  set scopedTheme(bool value) {
+    if (scopedThemeNotifier.value == value) return;
+    scopedThemeNotifier.value = value;
+    notifyListeners();
+  }
+
   bool get isMobile => defaultTargetPlatform == TargetPlatform.iOS || defaultTargetPlatform == TargetPlatform.android;
 
   @override

--- a/examples/web_demo/lib/theme.dart
+++ b/examples/web_demo/lib/theme.dart
@@ -2,6 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:web_demo/utils.dart';
 
+/// A [KalenderThemeData] to scope over one calendar with a [KalenderTheme].
+///
+/// The app theme in [buildAppTheme] styles every calendar through
+/// `ThemeData.extensions`. This one is deliberately loud so it is obvious which
+/// parts of the calendar a scope reaches, including the tile that follows a
+/// drag, which is built into an `Overlay` rather than below the calendar.
+KalenderThemeData buildScopedCalendarTheme(ColorScheme colorScheme) {
+  final accent = colorScheme.tertiary;
+  return KalenderThemeData(
+    hourLinesStyle: HourLinesStyle(color: accent.withAlpha(70), thickness: 1),
+    daySeparatorStyle: DaySeparatorStyle(color: accent.withAlpha(120), width: 1),
+    monthGridStyle: MonthGridStyle(color: accent.withAlpha(120), thickness: 1),
+    timeIndicatorStyle: TimeIndicatorStyle(lineColor: accent, circleColor: accent, thickness: 2),
+    multiDayOverlayStyle: MultiDayOverlayStyle(barrierColor: accent.withAlpha(40)),
+  );
+}
+
 ThemeData buildAppTheme(Brightness brightness) {
   final colorScheme = ColorScheme.fromSeed(seedColor: const Color(0xFF6366F1), brightness: brightness);
   final lineColor = colorScheme.outlineVariant.withAlpha(60);

--- a/examples/web_demo/lib/widgets/calendar/calendar.dart
+++ b/examples/web_demo/lib/widgets/calendar/calendar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:web_demo/models/event.dart';
 import 'package:web_demo/providers.dart';
+import 'package:web_demo/theme.dart';
 import 'package:web_demo/utils.dart';
 import 'package:web_demo/widgets/configuration/configuration_panel.dart';
 import 'package:web_demo/widgets/calendar/detail_overlay.dart';
@@ -55,86 +56,90 @@ class _CalendarContentState extends State<CalendarContent> {
                   listenable: Listenable.merge([
                     context.configuration.viewConfigurationNotifier,
                     context.configuration.shadeAdjacentMonthNotifier,
+                    context.configuration.scopedThemeNotifier,
                     context.location,
                   ]),
-                  builder: (context, _) => CalendarView(
-                    location: context.location.value,
-                    locale: Localizations.localeOf(context).toLanguageTag(),
-                    calendarController: context.controller,
-                    eventsController: context.eventsController,
-                    viewConfiguration: context.configuration.viewConfiguration,
-                    components: _components(context),
-                    callbacks: _callbacks,
-                    header: Column(
-                      spacing: 4,
-                      children: [
-                        Container(
-                          decoration: BoxDecoration(
-                            color: Theme.of(context).colorScheme.surface,
-                            border: !context.configuration.showHeader
-                                ? Border(
-                                    bottom: BorderSide(
-                                      color: Theme.of(context).colorScheme.outlineVariant.withAlpha(100),
-                                    ),
-                                  )
-                                : null,
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-                            child: NavigationHeader(
-                              controller: context.controller,
-                              viewConfigurations: context.configuration.viewConfigurations,
-                              viewConfiguration: context.configuration.viewConfiguration,
-                              onToggleConfig:
-                                  canShowCustomize ? () => setState(() => _showConfig = !_showConfig) : null,
-                              configVisible: _showConfig,
+                  builder: (context, _) => _scope(
+                    context,
+                    CalendarView(
+                      location: context.location.value,
+                      locale: Localizations.localeOf(context).toLanguageTag(),
+                      calendarController: context.controller,
+                      eventsController: context.eventsController,
+                      viewConfiguration: context.configuration.viewConfiguration,
+                      components: _components(context),
+                      callbacks: _callbacks,
+                      header: Column(
+                        spacing: 4,
+                        children: [
+                          Container(
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.surface,
+                              border: !context.configuration.showHeader
+                                  ? Border(
+                                      bottom: BorderSide(
+                                        color: Theme.of(context).colorScheme.outlineVariant.withAlpha(100),
+                                      ),
+                                    )
+                                  : null,
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                              child: NavigationHeader(
+                                controller: context.controller,
+                                viewConfigurations: context.configuration.viewConfigurations,
+                                viewConfiguration: context.configuration.viewConfiguration,
+                                onToggleConfig:
+                                    canShowCustomize ? () => setState(() => _showConfig = !_showConfig) : null,
+                                configVisible: _showConfig,
+                              ),
                             ),
                           ),
-                        ),
-                        if (context.configuration.showHeader)
-                          ListenableBuilder(
-                            listenable: Listenable.merge([
-                              context.configuration.interactionHeader,
-                              context.configuration.multiDayHeaderConfigurationNotifier,
-                            ]),
-                            builder: (context, _) {
-                              return Container(
-                                padding: const EdgeInsets.only(top: 4),
-                                decoration: BoxDecoration(
-                                  border: Border(
-                                    bottom: BorderSide(
-                                      color: Theme.of(context).colorScheme.outlineVariant.withAlpha(100),
+                          if (context.configuration.showHeader)
+                            ListenableBuilder(
+                              listenable: Listenable.merge([
+                                context.configuration.interactionHeader,
+                                context.configuration.multiDayHeaderConfigurationNotifier,
+                              ]),
+                              builder: (context, _) {
+                                return Container(
+                                  padding: const EdgeInsets.only(top: 4),
+                                  decoration: BoxDecoration(
+                                    border: Border(
+                                      bottom: BorderSide(
+                                        color: Theme.of(context).colorScheme.outlineVariant.withAlpha(100),
+                                      ),
                                     ),
                                   ),
-                                ),
-                                child: CalendarHeader(
-                                  multiDayTileComponents: _multiDayTileComponents,
-                                  multiDayHeaderConfiguration: context.configuration.multiDayHeaderConfiguration,
-                                  interaction: context.configuration.interactionBody.value,
-                                ),
-                              );
-                            },
-                          ),
-                      ],
-                    ),
-                    body: ListenableBuilder(
-                      listenable: Listenable.merge([
-                        context.configuration.interactionBody,
-                        context.configuration.snapping,
-                        context.configuration.multiDayBodyConfigurationNotifier,
-                        context.configuration.monthBodyConfigurationNotifier,
-                      ]),
-                      builder: (context, _) {
-                        return CalendarBody(
-                          multiDayTileComponents: _tileComponents,
-                          monthTileComponents: _multiDayTileComponents,
-                          multiDayBodyConfiguration: context.configuration.multiDayBodyConfiguration,
-                          monthBodyConfiguration: context.configuration.monthBodyConfiguration,
-                          scheduleTileComponents: _scheduleTileComponents,
-                          interaction: context.configuration.interactionBody.value,
-                          snapping: context.configuration.snapping.value,
-                        );
-                      },
+                                  child: CalendarHeader(
+                                    multiDayTileComponents: _multiDayTileComponents,
+                                    multiDayHeaderConfiguration: context.configuration.multiDayHeaderConfiguration,
+                                    interaction: context.configuration.interactionBody.value,
+                                  ),
+                                );
+                              },
+                            ),
+                        ],
+                      ),
+                      body: ListenableBuilder(
+                        listenable: Listenable.merge([
+                          context.configuration.interactionBody,
+                          context.configuration.snapping,
+                          context.configuration.multiDayBodyConfigurationNotifier,
+                          context.configuration.monthBodyConfigurationNotifier,
+                        ]),
+                        builder: (context, _) {
+                          return CalendarBody(
+                            multiDayTileComponents: _tileComponents,
+                            monthTileComponents: _multiDayTileComponents,
+                            multiDayBodyConfiguration: context.configuration.multiDayBodyConfiguration,
+                            monthBodyConfiguration: context.configuration.monthBodyConfiguration,
+                            scheduleTileComponents: _scheduleTileComponents,
+                            interaction: context.configuration.interactionBody.value,
+                            snapping: context.configuration.snapping.value,
+                          );
+                        },
+                      ),
                     ),
                   ),
                 ),
@@ -159,6 +164,19 @@ class _CalendarContentState extends State<CalendarContent> {
           ],
         );
       },
+    );
+  }
+
+  /// Wraps the calendar in a [KalenderTheme] when the scoped theme is on.
+  ///
+  /// The app theme already registers a [KalenderThemeData] for every calendar.
+  /// This styles only what is below it, so it is what you would reach for with
+  /// two calendars in one app that need to look different.
+  Widget _scope(BuildContext context, Widget child) {
+    if (!context.configuration.scopedTheme) return child;
+    return KalenderTheme(
+      data: buildScopedCalendarTheme(Theme.of(context).colorScheme),
+      child: child,
     );
   }
 

--- a/examples/web_demo/lib/widgets/calendar/event_tiles.dart
+++ b/examples/web_demo/lib/widgets/calendar/event_tiles.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kalender/kalender.dart';
 import 'package:web_demo/models/event.dart';
 
 abstract class BaseEventTile extends StatelessWidget {
@@ -115,6 +116,10 @@ class FeedbackTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = eventColorOf(event);
+    // Read from the calendar theme rather than the event, so a scoped
+    // KalenderTheme is visible here. This widget is built into an Overlay, so
+    // it only sees a scope because KalenderTheme is an InheritedTheme.
+    final outline = KalenderTheme.of(context).daySeparatorStyle?.color;
     return AnimatedContainer(
       duration: const Duration(milliseconds: 200),
       width: dropTargetWidgetSize.width * 0.85,
@@ -122,7 +127,12 @@ class FeedbackTile extends StatelessWidget {
       decoration: BoxDecoration(
         color: resolveEventColor(context, color, 0.18),
         borderRadius: BaseEventTile.defaultBorderRadius,
-        border: Border(left: BorderSide(color: color, width: 3)),
+        border: Border(
+          left: BorderSide(color: color, width: 3),
+          top: BorderSide(color: outline ?? color, width: 2),
+          right: BorderSide(color: outline ?? color, width: 2),
+          bottom: BorderSide(color: outline ?? color, width: 2),
+        ),
         boxShadow: [
           BoxShadow(color: color.withAlpha(40), blurRadius: 12, offset: const Offset(0, 4)),
         ],

--- a/examples/web_demo/lib/widgets/configuration/configuration_panel.dart
+++ b/examples/web_demo/lib/widgets/configuration/configuration_panel.dart
@@ -61,6 +61,15 @@ class ConfigurationPanel extends StatelessWidget {
                     ],
                   ),
                 ),
+                ValueListenableBuilder<bool>(
+                  valueListenable: configuration.scopedThemeNotifier,
+                  builder: (context, value, _) => SwitchListTile.adaptive(
+                    title: const Text('Scoped theme'),
+                    subtitle: const Text('Wraps this calendar in a KalenderTheme'),
+                    value: value,
+                    onChanged: (value) => configuration.scopedTheme = value,
+                  ),
+                ),
                 ViewConfigurationEditor(viewConfiguration: configuration.viewConfiguration),
                 if (configuration.viewConfiguration is MultiDayViewConfiguration) ...[
                   MultiDayHeaderEditor(demoConfiguration: configuration),

--- a/examples/web_demo/lib/widgets/configuration/configuration_panel.dart
+++ b/examples/web_demo/lib/widgets/configuration/configuration_panel.dart
@@ -61,13 +61,19 @@ class ConfigurationPanel extends StatelessWidget {
                     ],
                   ),
                 ),
-                ValueListenableBuilder<bool>(
-                  valueListenable: configuration.scopedThemeNotifier,
-                  builder: (context, value, _) => SwitchListTile.adaptive(
-                    title: const Text('Scoped theme'),
-                    subtitle: const Text('Wraps this calendar in a KalenderTheme'),
-                    value: value,
-                    onChanged: (value) => configuration.scopedTheme = value,
+                // The other switches sit inside an ExpansionTile, which supplies
+                // the Material a ListTile paints its ink on. This one is a direct
+                // child of the panel's decorated Container, so it needs its own.
+                Material(
+                  type: MaterialType.transparency,
+                  child: ValueListenableBuilder<bool>(
+                    valueListenable: configuration.scopedThemeNotifier,
+                    builder: (context, value, _) => SwitchListTile.adaptive(
+                      title: const Text('Scoped theme'),
+                      subtitle: const Text('Wraps this calendar in a KalenderTheme'),
+                      value: value,
+                      onChanged: (value) => configuration.scopedTheme = value,
+                    ),
                   ),
                 ),
                 ViewConfigurationEditor(viewConfiguration: configuration.viewConfiguration),


### PR DESCRIPTION
The web demo installs a `KalenderThemeData` on `ThemeData.extensions`, so it exercised the theme extension but never the `KalenderTheme` widget added in 0.25.0. This adds a **Scoped theme** switch at the top of the configuration panel that wraps the calendar in one.

The scoped palette is deliberately loud, using `colorScheme.tertiary` for the hour lines, day separators, month grid, time indicator and the overflow overlay barrier, so it is obvious which parts of the calendar a scope reaches. It lives in `theme.dart` next to the app theme.

### What the toggle shows

Turning it on restyles only the calendar. Everything else in the demo keeps the app theme, which is the two-calendars-in-one-app case the widget exists for.

Dragging an event with it on is the check for the `Overlay` path. The tile that follows a drag is built into an `Overlay` and is not a descendant of the calendar, so it only sees a scope because `KalenderTheme` is an `InheritedTheme` and the drag path captures the ambient themes. To make that visible, `FeedbackTile` now takes its outline from `KalenderTheme.of(context)` rather than from the event.

**That last part changes the demo's default appearance slightly.** With the toggle off, the feedback tile gains a 2px outline in the same muted colour as the calendar's day separators, replacing an unbordered tile. It reads as consistent with the calendar chrome, but say the word and I will find another way to surface it.

The overflow overlay needed no handling. I expected it to have the same detached-tree problem and tested it: `OverlayPortal` keeps its overlay child in the element tree below the portal, so it inherits a scope the ordinary way, unlike `Draggable.feedback`.

### Verification

- `flutter analyze` clean in `examples/web_demo`.
- `flutter build web --release --wasm --base-href /kalender/` succeeds, which is what the deploy workflow runs.

### Deploying

Merging this does not redeploy the demo. `web_demo.yml` builds on a push to `main` only when the head commit message contains `web demo`, and on release tags without a pre-release suffix, so `v0.25.0-dev.1` did not trigger it either. Either merge with `web demo` in the merge commit message, or push an empty commit afterwards.