### PR TITLE
chore: release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,31 @@ See [MIGRATION.md](MIGRATION.md#v024x--v0250) for what to change.
 
 ### Breaking Changes
 
-- `CalendarEvent.isMultiDayEvent` is removed. It was deprecated in 0.24.0, which named this release. Use `spansMultipleDays(location:, defaultRule:)`. See [MIGRATION.md](MIGRATION.md#v024x--v0250).
+- `CalendarEvent.isMultiDayEvent` is removed. It was deprecated in 0.24.0, which named this release. Use `spansMultipleDays(location:, defaultRule:)`. See [MIGRATION.md](MIGRATION.md#v024x--v0250). [#410](https://github.com/werner-scholtz/kalender/pull/410)
 
 ### Features
 
-- `KalenderTheme` is a widget, so a theme can be applied to part of the tree instead of the whole app. Wrap a calendar in `KalenderTheme(data: ..., child: ...)` and two calendars in one app can look different. The nearest one wins when they nest, and fields it leaves out still come from the `KalenderThemeData` registered on `ThemeData.extensions`, which keeps working as before. It is an `InheritedTheme`, so the theme also reaches the tile that follows a drag, which is built into an `Overlay` rather than below the calendar.
-- The style classes and `KalenderThemeData` are `Diagnosticable`, so their resolved values appear in the Flutter devtools inspector and in `toString()` instead of a bare instance hash. Fields left unset are omitted rather than printed as null.
+- `KalenderTheme` is a widget, so a theme can be applied to part of the tree instead of the whole app. Wrap a calendar in `KalenderTheme(data: ..., child: ...)` and two calendars in one app can look different. The nearest one wins when they nest, and fields it leaves out still come from the `KalenderThemeData` registered on `ThemeData.extensions`, which keeps working as before. It is an `InheritedTheme`, so the theme also reaches the tile that follows a drag, which is built into an `Overlay` rather than below the calendar. [#414](https://github.com/werner-scholtz/kalender/pull/414)
+- The style classes and `KalenderThemeData` are `Diagnosticable`, so their resolved values appear in the Flutter devtools inspector and in `toString()` instead of a bare instance hash. Fields left unset are omitted rather than printed as null. [#412](https://github.com/werner-scholtz/kalender/pull/412)
 
 ### Deprecations
 
-- The style fields on `CalendarComponents` are deprecated and are removed in 0.26.0. Use `KalenderThemeData` for the whole app, or a `KalenderTheme` to scope one calendar. The same thirteen styles were reachable both ways, and `multiDayOverlayStyle` had four different homes. `CalendarComponents` keeps its builder fields. See [MIGRATION.md](MIGRATION.md#v024x--v0250).
+- The style fields on `CalendarComponents` are deprecated and are removed in 0.26.0. Use `KalenderThemeData` for the whole app, or a `KalenderTheme` to scope one calendar. The same thirteen styles were reachable both ways, and `multiDayOverlayStyle` had four different homes. `CalendarComponents` keeps its builder fields. See [MIGRATION.md](MIGRATION.md#v024x--v0250). [#416](https://github.com/werner-scholtz/kalender/pull/416)
 
 ### Fixes
 
-- Styling the month view's week number no longer moves it to the middle of its row. The top alignment came from a default on `MonthBodyComponentStyles`, so setting any week number style there replaced it. The month body now applies that alignment itself, and anything you set merges over it.
-- `CalendarComponents`, the containers reached through it, `TileComponents` and `ScheduleTileComponents` compare by value, and `CalendarComponents` can be `const`. The inherited widgets carrying them reported a change on every rebuild because they compared by identity, and now report one only when something differs.
-- `CalendarComponents` and the containers reached through it gain `copyWith`.
+- Styling the month view's week number no longer moves it to the middle of its row. The top alignment came from a default on `MonthBodyComponentStyles`, so setting any week number style there replaced it. The month body now applies that alignment under your style, and keeps it unless you set an alignment of your own. In the month view a `KalenderThemeData` cannot change this alignment, because the style the month body passes to the widget takes precedence over the theme. The rest of `WeekNumberStyle` resolves from the theme as usual. [#416](https://github.com/werner-scholtz/kalender/pull/416) [#419](https://github.com/werner-scholtz/kalender/pull/419)
+- `CalendarComponents`, the containers reached through it, `TileComponents` and `ScheduleTileComponents` compare by value, and `CalendarComponents` can be `const`. The inherited widgets carrying them reported a change on every rebuild because they compared by identity, and now report one only when something differs. [#409](https://github.com/werner-scholtz/kalender/pull/409)
+- `CalendarComponents` and the containers reached through it gain `copyWith`. [#409](https://github.com/werner-scholtz/kalender/pull/409)
+
+### Tests
+
+- Added coverage for the scoped `KalenderTheme`: it applies below itself, takes precedence over the extension, and fills in from it field by field. The nearest scope wins when they nest, two calendars in one app can be themed differently, changing the data notifies dependents where an equal value does not, and `wrap` carries the theme into a tree built outside the calendar. [#414](https://github.com/werner-scholtz/kalender/pull/414)
+- Added `Diagnosticable` coverage for every style class: a style reports the fields it sets and omits the ones it does not, and the theme reports the styles it carries. [#412](https://github.com/werner-scholtz/kalender/pull/412)
+- Added equality coverage for `CalendarComponents`, the containers reached through it and `TileComponents`: each field breaks equality when it differs, a builder held as a top-level function stays equal across instances, and one written as a closure does not. [#409](https://github.com/werner-scholtz/kalender/pull/409)
+- Added coverage that the month week number sits at the top of its row by default, and that a style set for the month keeps that alignment when it does not mention one. [#416](https://github.com/werner-scholtz/kalender/pull/416)
+- Added the `KalenderThemeData` coverage no test reached: `hashCode`, the fields `==` compares after the third, and one `copyWith` fallback. [#408](https://github.com/werner-scholtz/kalender/pull/408)
+- Added coverage that the time indicator follows the day while the app runs: it moves to the next column when the day rolls over, a rebuild every 30 seconds does not stop the day being noticed, a full day passing moves it off a page it no longer belongs to, and resuming the app corrects it after time passed. [#413](https://github.com/werner-scholtz/kalender/pull/413)
 
 ## 0.24.0
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A highly customizable Flutter calendar widget with Day, Multi-day, Month and Sch
 - **MIT licensed.** No commercial license to buy.
 
 > [!WARNING]
-> This package is still in development, so breaking changes land in minor releases until 1.0.0. A caret range like `^0.24.0` keeps you on 0.24.x, which is where fixes land. Every minor bump has an entry in the [migration guide](MIGRATION.md).
+> This package is still in development, so breaking changes land in minor releases until 1.0.0. A caret range like `^0.25.0` keeps you on 0.25.x, which is where fixes land. Every minor bump has an entry in the [migration guide](MIGRATION.md).
 >
 > If part of the API does not work for you, please [open an issue](https://github.com/werner-scholtz/kalender/issues).
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.25.0-dev.1
+version: 0.25.0
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
Prepares the 0.25.0 release. Merging this makes `v0.25.0` taggable; the tag is what publishes.

### Version

`pubspec.yaml` goes from `0.25.0-dev.1` to `0.25.0`. `publish.yml` refuses a tag whose version does not match it exactly, so this has to land before tagging.

The README's suggested caret range moves to `^0.25.0`, matching what it did for 0.24.0.

### Changelog

Every entry gains its PR link. The 0.25.0 section had none, where every release back to 0.19.0 has them.

A `### Tests` section is added for the coverage that landed with the theming work: the scoped theme, the `Diagnosticable` styles, the component equality, the month week number alignment, the `KalenderThemeData` gaps and the time indicator day rollover.

The week number entry is corrected. It said the month body applies the top alignment "and anything you set merges over it". That holds for a style set on `MonthBodyComponentStyles`, but not for the theme, which is the path this release points people at. `month_body.dart` passes the merged style to the widget, and `WeekNumber` resolves it as `theme.merge(passed)`, so the passed alignment always wins. `KalenderThemeData.weekNumberStyle.alignment` therefore cannot move the month week number. Its other fields resolve from the theme as usual. The doc comment on `_monthWeekNumberDefaults` already said this correctly.

### One thing to decide before 0.26.0

That alignment is only reachable through `CalendarComponents.monthComponentStyles`, which this release deprecates for removal in 0.26.0. Unless the month body stops injecting the default or the alignment moves elsewhere, it becomes unreachable then. Recorded here rather than changed, since it is a design call and not a release blocker.

### Verification

- `dart format` clean, `flutter analyze` clean.
- 1455 tests pass.
- `dart run tool/analyze_doc_snippets.dart`: 46 snippets from 10 files compile.
- `flutter pub publish --dry-run`: 0 warnings. The archive is 175 KB and excludes `ROADMAP.md`, `AGENTS.md`, `examples/`, `test/` and `benchmark/` as intended.

### Not in this PR

The web demo fix is on #420, since that is where the defect is. Its `analyze-examples (web_demo)` job was failing at the Test step: the new "Scoped theme" switch sat directly in the configuration panel's decorated `Container` with no `Material` between them, which trips a `ListTile` assert. The other switches in the panel are inside an `ExpansionTile`, which supplies one. Pushed as a fix on that branch, and its tests and analyze now pass locally.

Both want to be on main before the tag, so the demo the tag rebuilds matches the published package.
