### PR TITLE
fix: the theme can set the month week number's alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.26.0
+
+### Behavior Changes
+
+- `KalenderThemeData.weekNumberStyle.alignment` now reaches the month week number. It had no effect there, because the month body passed its own top alignment to the widget and a passed style wins over the theme, so the only way to change it was the deprecated `CalendarComponents` style path. The month still sits at the top when nothing asks otherwise. A calendar that set this on the theme and relied on the month ignoring it will see the month week number move. [#423](https://github.com/werner-scholtz/kalender/pull/423)
+- A custom `weekNumberBuilder` receives the same fully resolved style in the month header as in the month body. The header's spacer passed the style through unresolved, so the two disagreed. [#423](https://github.com/werner-scholtz/kalender/pull/423)
+
 ## 0.25.0
 
 See [MIGRATION.md](MIGRATION.md#v024x--v0250) for what to change.

--- a/lib/src/models/components/month_styles.dart
+++ b/lib/src/models/components/month_styles.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:kalender/src/models/components/components.dart';
 import 'package:kalender/src/widgets/components/month_day_header.dart';
 import 'package:kalender/src/widgets/components/month_grid.dart';
@@ -60,9 +59,7 @@ class MonthBodyComponentStyles {
   const MonthBodyComponentStyles({
     this.monthGridStyle = const MonthGridStyle(),
     this.monthDayHeaderStyle = const MonthDayHeaderStyle(),
-    this.weekNumberStyle = const WeekNumberStyle(
-      alignment: Alignment.topCenter,
-    ),
+    this.weekNumberStyle = const WeekNumberStyle(),
     this.overlayStyles,
   });
 

--- a/lib/src/theme/kalender_theme.dart
+++ b/lib/src/theme/kalender_theme.dart
@@ -86,6 +86,8 @@ class KalenderThemeData extends ThemeExtension<KalenderThemeData> with Diagnosti
   /// - string builders, which use the ambient locale inside the widgets.
   /// - [TimeIndicatorStyle.circleColor], which falls back to the line color.
   /// - text styles that intentionally inherit from [DefaultTextStyle].
+  /// - [WeekNumberStyle.alignment], so a widget can tell an alignment nobody
+  ///   set from one set to centre. Each week number falls back on its own.
   static KalenderThemeData defaults(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
@@ -131,7 +133,6 @@ class KalenderThemeData extends ThemeExtension<KalenderThemeData> with Diagnosti
         visualDensity: VisualDensity.compact,
         tooltip: 'Week Number',
         padding: const EdgeInsets.symmetric(horizontal: 4),
-        alignment: Alignment.center,
       ),
       monthGridStyle: MonthGridStyle(
         color: colorScheme.surfaceContainerHighest,

--- a/lib/src/widgets/internal_components/month_week_number_gutter.dart
+++ b/lib/src/widgets/internal_components/month_week_number_gutter.dart
@@ -3,6 +3,19 @@ import 'package:flutter/rendering.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
+/// The month grid puts the week number at the top of its row rather than
+/// centring it, which is where every other week number sits.
+const _monthWeekNumberDefaults = WeekNumberStyle(alignment: Alignment.topCenter);
+
+/// The style the month week number is drawn with.
+///
+/// [KalenderThemeData.weekNumberStyle] wins over the top alignment, and [style]
+/// wins over both. Applied in the gutter and the header's spacer alike, so the
+/// two measure the same width.
+WeekNumberStyle _resolveStyle(BuildContext context, WeekNumberStyle? style) {
+  return _monthWeekNumberDefaults.merge(KalenderTheme.of(context).weekNumberStyle).merge(style);
+}
+
 class MonthWeekNumberGutter extends StatelessWidget {
   final InternalDateTimeRange visibleRange;
   final int numberOfRows;
@@ -21,6 +34,8 @@ class MonthWeekNumberGutter extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final style = _resolveStyle(context, weekNumberStyle);
+
     return IntrinsicWidth(
       child: Column(
         children: List.generate(
@@ -37,7 +52,7 @@ class MonthWeekNumberGutter extends StatelessWidget {
                 ),
                 child: weekNumberBuilder(
                   range.forLocation(location: context.location),
-                  weekNumberStyle,
+                  style,
                 ),
               ),
             );
@@ -69,6 +84,8 @@ class MonthWeekNumberSpacer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final style = _resolveStyle(context, weekNumberStyle);
+
     return _WidthOnly(
       child: IntrinsicWidth(
         child: Stack(
@@ -83,7 +100,7 @@ class MonthWeekNumberSpacer extends StatelessWidget {
 
               return weekNumberBuilder(
                 range.forLocation(location: context.location),
-                weekNumberStyle,
+                style,
               );
             },
           ),

--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -110,7 +110,7 @@ class MonthBody extends StatelessWidget {
                   visibleRange: visibleRange,
                   numberOfRows: numberOfRows,
                   weekNumberBuilder: monthComponents.bodyComponents.weekNumberBuilder,
-                  weekNumberStyle: _monthWeekNumberDefaults.merge(monthStyles.weekNumberStyle),
+                  weekNumberStyle: monthStyles.weekNumberStyle,
                   dividerSide: dividerSide,
                 ),
               ),
@@ -231,12 +231,3 @@ class _MonthDayCellBackground extends StatelessWidget {
     );
   }
 }
-
-/// The month grid puts the week number at the top of its row, where the theme
-/// leaves it centred.
-///
-/// Applied under [MonthBodyComponentStyles.weekNumberStyle], so a style set
-/// there keeps this alignment unless it sets one of its own. It is passed to
-/// the widget, so it takes precedence over [KalenderThemeData.weekNumberStyle],
-/// which cannot change the month week number's alignment.
-const _monthWeekNumberDefaults = WeekNumberStyle(alignment: Alignment.topCenter);

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -40,21 +40,25 @@ void main() {
       DateTime initialDateTime, {
       bool showWeekNumbers = false,
       CalendarComponents? components,
-    }) =>
-        pumpAndSettleWithMaterialApp(
-          tester,
-          CalendarView(
-            eventsController: eventsController,
-            calendarController: calendarController,
-            viewConfiguration: MonthViewConfiguration.singleMonth(
-              displayRange: displayRange,
-              initialDateTime: initialDateTime,
-              showWeekNumbers: showWeekNumbers,
-            ),
-            components: components,
-            body: const CalendarBody(),
-          ),
-        );
+      KalenderThemeData? theme,
+    }) {
+      final view = CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: MonthViewConfiguration.singleMonth(
+          displayRange: displayRange,
+          initialDateTime: initialDateTime,
+          showWeekNumbers: showWeekNumbers,
+        ),
+        components: components,
+        body: const CalendarBody(),
+      );
+
+      return pumpAndSettleWithMaterialApp(
+        tester,
+        theme == null ? view : KalenderTheme(data: theme, child: view),
+      );
+    }
 
     // ---------------------------------------------------------------------------
     // Row count (firstDayOfWeek = Monday / default)
@@ -263,9 +267,8 @@ void main() {
     });
 
     testWidgets('the month week number sits at the top of its row by default', (tester) async {
-      // The month grid overrides the theme's centred alignment. This used to
-      // come from a default on MonthBodyComponentStyles, and moved to the month
-      // body when that style path was deprecated, so it is worth pinning.
+      // The theme leaves alignment null, so the month's own top alignment
+      // applies. Every other week number centres itself instead.
       await pumpMonthView(tester, DateTime(2025, 1), showWeekNumbers: true);
 
       expect(
@@ -295,6 +298,52 @@ void main() {
         find.descendant(
           of: find.byType(WeekNumber),
           matching: find.byWidgetPredicate((w) => w is Align && w.alignment == Alignment.topCenter),
+        ),
+        findsWidgets,
+      );
+    });
+
+    testWidgets('the theme can move the month week number off the top', (tester) async {
+      await pumpMonthView(
+        tester,
+        DateTime(2025, 1),
+        showWeekNumbers: true,
+        theme: const KalenderThemeData(
+          weekNumberStyle: WeekNumberStyle(alignment: Alignment.bottomCenter),
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(WeekNumber),
+          matching: find.byWidgetPredicate((w) => w is Align && w.alignment == Alignment.bottomCenter),
+        ),
+        findsWidgets,
+        reason: 'KalenderThemeData.weekNumberStyle.alignment should reach the month week number',
+      );
+    });
+
+    testWidgets('a style set for the month still beats the theme', (tester) async {
+      await pumpMonthView(
+        tester,
+        DateTime(2025, 1),
+        showWeekNumbers: true,
+        theme: const KalenderThemeData(
+          weekNumberStyle: WeekNumberStyle(alignment: Alignment.bottomCenter),
+        ),
+        components: const CalendarComponents(
+          monthComponentStyles: MonthComponentStyles(
+            bodyStyles: MonthBodyComponentStyles(
+              weekNumberStyle: WeekNumberStyle(alignment: Alignment.centerLeft),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(WeekNumber),
+          matching: find.byWidgetPredicate((w) => w is Align && w.alignment == Alignment.centerLeft),
         ),
         findsWidgets,
       );


### PR DESCRIPTION
First of five for 0.26.0, and the base of the stack. Non-breaking on its own.

### The problem

`KalenderThemeData.weekNumberStyle.alignment` has no effect in the month body. The only thing that can change it is `CalendarComponents.monthComponentStyles.bodyStyles.weekNumberStyle`, which 0.25.0 deprecated for removal in 0.26.0. Removing it would leave the alignment unreachable, so this has to be settled before the removal lands.

### Three things kept the theme out, not one

The first pass at scoping this found one obstacle. There were three, and missing either of the other two would have left the fix silently ineffective.

1. **`KalenderThemeData.defaults` set `alignment: Alignment.center` unconditionally.** A widget reading the theme therefore cannot tell an alignment nobody set from one deliberately set to centre.
2. **`MonthBodyComponentStyles.weekNumberStyle` is non-nullable** and its constructor defaults to `WeekNumberStyle(alignment: Alignment.topCenter)` (`month_styles.dart:62`). `MonthComponentStyles.bodyStyles` in turn defaults to `const MonthBodyComponentStyles()`, so that `topCenter` is present whether or not the app ever touched the container. No theme value inserted anywhere in the merge chain could win against it.
3. **The month body applied a second `topCenter` of its own** on top of that.

### What changed

The theme default goes, since `WeekNumber.build` already falls back to `Alignment.center` at the point of use (`week_number.dart:134`), so nothing centred moves. The container's redundant default goes with it.

The month's top alignment moves into `MonthWeekNumberGutter` and `MonthWeekNumberSpacer`, which is where it is actually needed. Both now resolve the same way: the top alignment underneath, the theme over it, the passed style over both.

```dart
WeekNumberStyle _resolveStyle(BuildContext context, WeekNumberStyle? style) {
  return _monthWeekNumberDefaults.merge(KalenderTheme.of(context).weekNumberStyle).merge(style);
}
```

That also settles a difference between the two widgets. The gutter received the body's merged default and the header's spacer received the raw container style, so a custom `weekNumberBuilder` saw a different style depending on which called it. Both now receive the fully resolved one.

`month_header.dart` needed no change as a result, since the resolution moved below it.

### Behavior

Nothing renders differently unless the app set an alignment on the theme, which previously did nothing in the month body. A `### Behavior Changes` entry covers it.

One consequence worth flagging for the removal that follows: after the deprecated container goes, `KalenderThemeData.weekNumberStyle` is the only route to this alignment and it feeds both the month gutter and the multi-day header, so an app will no longer be able to set the two apart. The MIGRATION entry belongs with that PR rather than this one, where the full picture lands.

### Verification

- `dart analyze` and `flutter analyze`: no issues.
- `flutter test`: 1457 pass, up from 1455. Two added.
- Every example analyzed directly, since `analysis_options.yaml` excludes `examples/**`: all eight clean.

The three existing alignment tests in `month_body_test.dart` pass unchanged, which is the check that nothing centred moved. Two were added: the theme can now move the month week number off the top, and a style set on the container still beats the theme. The stale comment on the first of the three is corrected, since it described the theme as centring the month week number, which it no longer does.
