### PR TITLE
ci: check pull requests that target a branch other than main

### DIFF
--- a/.github/workflows/analyze_examples.yml
+++ b/.github/workflows/analyze_examples.yml
@@ -3,8 +3,8 @@ name: Analyze Examples
 # Only run when something that could affect the example apps changes: the package
 # they depend on, the examples themselves, the root pubspec, or this workflow.
 on:
+  # No branch filter, so a pull request stacked on another branch is checked too.
   pull_request:
-    branches: [main, main-wip]
     paths:
       - 'lib/**'
       - 'examples/**'

--- a/.github/workflows/flutter_analyze_and_test.yml
+++ b/.github/workflows/flutter_analyze_and_test.yml
@@ -6,8 +6,10 @@
 name: Analyze and Test
 
 on:
+  # No branch filter, so a pull request stacked on another branch is checked too.
+  # Filtering on [main, main-wip] meant every pull request above the base of a
+  # stack ran nothing at all.
   pull_request:
-    branches: [main, main-wip]
   push:
     branches: [main, main-wip]
 


### PR DESCRIPTION
Both workflows filtered pull requests on `branches: [main, main-wip]`, so **a pull request stacked on another pull request ran nothing at all**. [#424](https://github.com/werner-scholtz/kalender/pull/424) is stacked on [#423](https://github.com/werner-scholtz/kalender/pull/423) and reports no checks.

```diff
 on:
   pull_request:
-    branches: [main, main-wip]
   push:
     branches: [main, main-wip]
```

The `push` trigger keeps its filter, so pushes still only build the two long-lived branches, and `analyze_examples` keeps its paths filter.

`performance_profiling.yml` keeps its filter on purpose. It runs only on a pull request labelled `profile` and compares against main, which is the only comparison worth making.

### One thing to know

For a `pull_request` event GitHub reads the workflow file from the merge of head into base. So a pull request already stacked only picks this up once the change reaches its own branch or its base. Merging this first, then forward-merging main through the stack, is what turns CI on for the rest of 0.26.0.

Configuration only. No package code changes.