### PR TITLE
fix: close three equality gaps on the view configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See [MIGRATION.md](MIGRATION.md#v025x--v0260) for what to change.
 
 - A custom builder receives the theme-resolved style rather than an empty one. Previously a builder was handed whatever the deprecated container carried, which was an empty style unless the app had set one, so a custom builder had no way to see the theme. `OverlayStyles.fromContext` resolves the overlay pair for `MultiDayOverlayPortalBuilder`, which takes no `BuildContext` of its own.
 
+### Fixes
+
+- `MultiDayBodyConfiguration.keepPagesAlive` takes part in `==` and `hashCode`. It is declared on that class rather than the `VerticalConfiguration` base, and the inherited equality did not reach it, so changing only that value did not reach the calendar.
+- `MonthBodyConfiguration` and `MultiDayHeaderConfiguration` no longer compare equal to each other. Both extend `HorizontalConfiguration` and add no equality of their own, and its `==` tested only `other is HorizontalConfiguration` with no runtime type check. The same applied to `VerticalConfiguration`.
+- `MultiDayViewConfiguration.nowCallback` is included in `hashCode`, where it already took part in `==`. Unequal objects may share a hash, so nothing was broken, but the other two configurations include it.
+
 ### Behavior Changes
 
 - `KalenderThemeData.weekNumberStyle.alignment` now reaches the month week number. It had no effect there, because the month body passed its own top alignment to the widget and a passed style wins over the theme, so the only way to change it was the deprecated `CalendarComponents` style path. The month still sits at the top when nothing asks otherwise. A calendar that set this on the theme and relied on the month ignoring it will see the month week number move. [#423](https://github.com/werner-scholtz/kalender/pull/423)

--- a/lib/src/models/view_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_view_configuration.dart
@@ -337,6 +337,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
       name,
       initialDateTime,
       dateTransition,
+      nowCallback,
       scrollTransition,
       zoomTransition,
       timeOfDayRange,
@@ -416,6 +417,14 @@ class MultiDayBodyConfiguration extends VerticalConfiguration {
       keepPagesAlive: keepPagesAlive ?? this.keepPagesAlive,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    return super == other && other is MultiDayBodyConfiguration && other.keepPagesAlive == keepPagesAlive;
+  }
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, keepPagesAlive);
 }
 
 /// The configuration used by the [MultiDayHeader] and [MonthBody].

--- a/lib/src/models/view_configurations/view_configuration.dart
+++ b/lib/src/models/view_configurations/view_configuration.dart
@@ -151,6 +151,10 @@ abstract class VerticalConfiguration {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
+    // Subclasses add fields but not all of them override this, so without a
+    // runtime type check two different configuration types compare equal.
+    if (other.runtimeType != runtimeType) return false;
+
     return other is VerticalConfiguration &&
         other.showMultiDayEvents == showMultiDayEvents &&
         other.horizontalPadding == horizontalPadding &&
@@ -230,6 +234,11 @@ abstract class HorizontalConfiguration {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
+
+    // MonthBodyConfiguration and MultiDayHeaderConfiguration both extend this
+    // and add no equality of their own, so without a runtime type check they
+    // compare equal to each other.
+    if (other.runtimeType != runtimeType) return false;
 
     return other is HorizontalConfiguration &&
         other.tileHeight == tileHeight &&

--- a/test/configuration/base_configuration_equality_test.dart
+++ b/test/configuration/base_configuration_equality_test.dart
@@ -3,8 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender.dart';
 
 /// Exercises the `==` / `hashCode` defined on the abstract [VerticalConfiguration]
-/// and [HorizontalConfiguration] base classes, through concrete subclasses that
-/// do not override them ([MultiDayBodyConfiguration] / [MultiDayHeaderConfiguration]).
+/// and [HorizontalConfiguration] base classes, through the concrete subclasses
+/// that reach them ([MultiDayBodyConfiguration] / [MultiDayHeaderConfiguration]),
+/// and the runtime type check that keeps two subclasses of one base apart.
 void main() {
   // ─── VerticalConfiguration (via MultiDayBodyConfiguration) ───────────────────
 
@@ -39,6 +40,15 @@ void main() {
       );
       expect(a, isNot(equals(b)));
     });
+
+    // keepPagesAlive is declared on MultiDayBodyConfiguration rather than the
+    // base, and the inherited equality did not reach it.
+    test('differing keepPagesAlive breaks equality', () {
+      const a = MultiDayBodyConfiguration();
+      const b = MultiDayBodyConfiguration(keepPagesAlive: true);
+      expect(a, isNot(equals(b)));
+      expect(a.hashCode, isNot(equals(b.hashCode)));
+    });
   });
 
   // ─── HorizontalConfiguration (via MultiDayHeaderConfiguration) ───────────────
@@ -65,6 +75,26 @@ void main() {
       const b = MultiDayHeaderConfiguration(allowSingleDayEvents: true);
       expect(a, isNot(equals(b)));
       expect(a.hashCode, isNot(equals(b.hashCode)));
+    });
+  });
+
+  // ─── Two subclasses of one base are not each other ───────────────────────────
+
+  group('Configuration types stay distinct', () {
+    // MonthBodyConfiguration and MultiDayHeaderConfiguration both extend
+    // HorizontalConfiguration and add no equality of their own, so with only an
+    // `other is HorizontalConfiguration` test they compared equal.
+    test('MonthBodyConfiguration is not a MultiDayHeaderConfiguration', () {
+      const month = MonthBodyConfiguration();
+      const header = MultiDayHeaderConfiguration();
+      expect(month, isNot(equals(header)));
+      expect(header, isNot(equals(month)));
+    });
+
+    test('each still equals its own type', () {
+      expect(const MonthBodyConfiguration(), equals(const MonthBodyConfiguration()));
+      expect(const MultiDayHeaderConfiguration(), equals(const MultiDayHeaderConfiguration()));
+      expect(const MultiDayBodyConfiguration(), equals(const MultiDayBodyConfiguration()));
     });
   });
 }

--- a/test/widgets/view_configuration_identity_test.dart
+++ b/test/widgets/view_configuration_identity_test.dart
@@ -84,6 +84,12 @@ void main() {
     test('nowCallback', () {
       expect(week(), isNot(equals(weekWith(nowCallback: _stubNow))));
     });
+
+    // nowCallback was in `==` but not in `hashCode`, which is legal but a sign
+    // the field was missed when the others were added.
+    test('nowCallback also reaches hashCode', () {
+      expect(week().hashCode, isNot(equals(weekWith(nowCallback: _stubNow).hashCode)));
+    });
   });
 
   group('fields that deliberately do not break equality', () {


### PR DESCRIPTION
Third of five for 0.26.0. **Stacked on [#424](https://github.com/werner-scholtz/kalender/pull/424), so merge that first.**

Non-breaking. All three were found while checking [#380](https://github.com/werner-scholtz/kalender/issues/380), and none is a function field, so they land before the conversions rather than tangled up with them.

### `MultiDayBodyConfiguration.keepPagesAlive` was not compared

It is declared on that class rather than on the `VerticalConfiguration` base, and the inherited `==` did not reach it. Changing only that value never reached the calendar. `multi_day_body.dart` reads it, so the effect was real rather than latent.

### Two configuration types compared equal to each other

`MonthBodyConfiguration` and `MultiDayHeaderConfiguration` both extend `HorizontalConfiguration` and add no fields or equality of their own. Its `==` tested only `other is HorizontalConfiguration`:

```diff
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
 
     return other is HorizontalConfiguration &&
```

`VerticalConfiguration` had the same shape and gets the same fix.

### `nowCallback` was in `==` but not in `hashCode`

Not a bug. Unequal objects are allowed to share a hash, so nothing misbehaved. It is included because the month and schedule configurations include it and this one was missed.

### Verification

- `dart analyze` and `flutter analyze`: no issues.
- `flutter test`: 1455 pass, up 4.
- Four tests added: `keepPagesAlive` breaks equality and hash, the two types stay distinct while each still equals its own type, and `nowCallback` reaches `hashCode`.

No `### Breaking Changes` entry, since nothing stops compiling. Three `### Fixes` entries.