### PR TITLE
fix: centre the week number label when it spans two weeks

### DIFF
--- a/lib/src/widgets/components/week_number.dart
+++ b/lib/src/widgets/components/week_number.dart
@@ -139,8 +139,12 @@ class WeekNumber extends StatelessWidget {
           tooltip: style.tooltip,
           onPressed: null,
           visualDensity: style.visualDensity ?? VisualDensity.compact,
+          // The gutter is sized by the timeline, not by this label, so a range
+          // spanning two weeks wraps. Without this the short second line sits
+          // against the leading edge.
           icon: Text(
             weekNumber,
+            textAlign: TextAlign.center,
             style: style.textStyle,
           ),
         ),

--- a/test/widgets/week_number_test.dart
+++ b/test/widgets/week_number_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:timezone/data/latest_10y.dart' as tz;
+import 'package:timezone/timezone.dart';
+
+import '../utilities.dart';
+
+/// The week number label reads `32 - 33` when the visible range crosses a week
+/// boundary. Its gutter is sized by the timeline rather than by the label, so
+/// that string wraps, and the wrapped lines have to stay centred.
+void main() {
+  group('WeekNumber label', () {
+    late CalendarController calendarController;
+    late DefaultEventsController eventsController;
+
+    setUpAll(tz.initializeTimeZones);
+
+    setUp(() {
+      calendarController = CalendarController();
+      eventsController = DefaultEventsController();
+    });
+
+    // Pinned to UTC so the dates below land in the week they read as, whichever
+    // of the six timezones CI is running under.
+    Future<void> pumpWeekNumber(WidgetTester tester, DateTimeRange range) {
+      return pumpAndSettleWithMaterialApp(
+        tester,
+        TestProvider(
+          calendarController: calendarController,
+          eventsController: eventsController,
+          tileComponents: TileComponents(tileBuilder: (event, tileRange) => const SizedBox()),
+          location: getLocation('Etc/UTC'),
+          child: WeekNumber(visibleDateTimeRange: range),
+        ),
+      );
+    }
+
+    Text labelOf(WidgetTester tester) {
+      return tester.widget<Text>(find.descendant(of: find.byType(WeekNumber), matching: find.byType(Text)));
+    }
+
+    // 4 Aug 2025 is a Monday, so this range sits inside one ISO week.
+    testWidgets('a single week renders one number', (tester) async {
+      await pumpWeekNumber(
+        tester,
+        DateTimeRange(start: DateTime.utc(2025, 8, 4), end: DateTime.utc(2025, 8, 11)),
+      );
+
+      expect(labelOf(tester).data, isNot(contains('-')));
+    });
+
+    // 6 Aug 2025 is a Wednesday, so seven days from it cross into the next week.
+    testWidgets('a range crossing a week boundary renders both numbers', (tester) async {
+      await pumpWeekNumber(
+        tester,
+        DateTimeRange(start: DateTime.utc(2025, 8, 6), end: DateTime.utc(2025, 8, 13)),
+      );
+
+      expect(labelOf(tester).data, contains('-'));
+    });
+
+    testWidgets('the label is centred, so a wrapped second line does not sit left', (tester) async {
+      await pumpWeekNumber(
+        tester,
+        DateTimeRange(start: DateTime.utc(2025, 8, 6), end: DateTime.utc(2025, 8, 13)),
+      );
+
+      expect(
+        labelOf(tester).textAlign,
+        TextAlign.center,
+        reason: 'without this the short line of a wrapped two-week label aligns to the leading edge',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Reported from the web demo: a week number reading `32 - 33` renders with its second line hard left.

Independent of the 0.26.0 stack, based on `main`.

### Cause

`week_number.dart` built the label with no `textAlign`, so it fell back to `TextAlign.start`:

```diff
   icon: Text(
     weekNumber,
+    textAlign: TextAlign.center,
     style: style.textStyle,
   ),
```

The `Align` around the chip and the `IconButton` around the icon both centre the *box*. Nothing was centring the *lines within the paragraph*, which only shows once the label wraps.

### Why it wraps, and why widening is not the fix

In the multi-day header the week number is the `leading` of `MultiDayHeaderWidget`, sized to `timelineWidth`. That width comes from the time labels so the header's day columns line up with the body's, which is what #180 and `timeline_alignment_test.dart` exist to protect. Letting the label widen the gutter would push the two out of alignment. So the label has to cope with wrapping rather than avoid it.

### Tests

New `test/widgets/week_number_test.dart`, three cases: a single week renders one number, a range crossing a week boundary renders both, and the label is centred.

Nothing covered the `end != null` branch of `InternalDateTimeRange.weekNumbers` at the widget level before this.

The location is pinned to `Etc/UTC` in the test, since the widget converts the range through `context.location` and the dates would otherwise land in a different ISO week depending on which of the six timezones CI is running under. Verified locally under UTC, `Australia/Sydney` and `America/New_York`.

### Verification

- `dart analyze` and `flutter analyze`: no issues.
- `flutter test`: 1458 pass, up 3.

### Not included

A `WeekNumberStringBuilder`, which would let an app change `32 - 33` to something shorter or localized. `string_builders.dart` has builders for the day header, the time labels and the hidden event count, and the week number was missed when 0.23.0 moved label formatting out of the style classes. It is not a drop-in: `WeekNumber` is the only label widget shared by two views, `weekNumberBuilder` exists on both `MonthBodyComponents` and `MultiDayHeaderComponents`, and `WeekNumberBuilder` has no `BuildContext` for the widget to resolve a per-view builder from. Worth doing, but it wants a decision on where the field lives.