### PR TITLE
fix: the review findings on the style removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ See [MIGRATION.md](MIGRATION.md#v025x--v0260) for what to change.
 
 - `EventSnapStrategy.none()` leaves a dragged event where the cursor is, without needing a hand-written strategy.
 - `defaultMultiDayFrameGenerator` stays public, so a custom `MultiDayLayoutStrategy` can reuse the built-in row assignment and change only the order events are placed in, through the `eventComparator` the strategy itself does not expose.
-- A custom builder receives the theme-resolved style rather than an empty one. Previously a builder was handed whatever the deprecated container carried, which was an empty style unless the app had set one, so a custom builder had no way to see the theme. `OverlayStyles.fromContext` resolves the overlay pair for `MultiDayOverlayPortalBuilder`, which takes no `BuildContext` of its own.
 
 ### Fixes
 
+- The week number label is centred when the visible range crosses a week boundary. The gutter is sized by the timeline rather than by the label, so `32 - 33` wraps, and the short second line sat against the leading edge. [#427](https://github.com/werner-scholtz/kalender/pull/427)
+- `HourLines.fromContext` no longer takes a `style` argument. It resolved the style from the theme and discarded whatever was passed, so the argument silently did nothing. `timelineStyle` is unaffected.
 - `MultiDayBodyConfiguration.keepPagesAlive` takes part in `==` and `hashCode`. It is declared on that class rather than the `VerticalConfiguration` base, and the inherited equality did not reach it, so changing only that value did not reach the calendar.
 - `MonthBodyConfiguration` and `MultiDayHeaderConfiguration` no longer compare equal to each other. Both extend `HorizontalConfiguration` and add no equality of their own, and its `==` tested only `other is HorizontalConfiguration` with no runtime type check. The same applied to `VerticalConfiguration`.
 - `MultiDayViewConfiguration.nowCallback` is included in `hashCode`, where it already took part in `==`. Unequal objects may share a hash, so nothing was broken, but the other two configurations include it.
@@ -27,6 +28,8 @@ See [MIGRATION.md](MIGRATION.md#v025x--v0260) for what to change.
 
 ### Behavior Changes
 
+- A custom component builder is handed the theme-resolved style rather than an empty one. A builder previously received whatever the deprecated container carried, which was an empty style unless the app had set one, so `style?.textStyle ?? myFallback` reached `myFallback`. The same argument now arrives populated from the theme, so a builder written that way renders with the theme value instead of its own fallback. Read the fields you want to override rather than falling back on null. This affects `dayHeaderBuilder`, `daySeparator`, `hourLines`, `monthDayHeaderBuilder`, `monthGridBuilder`, `timeIndicator`, `timeline`, `weekDayHeaderBuilder`, `weekNumberBuilder` and `leadingDateBuilder`. See [MIGRATION.md](MIGRATION.md#v025x--v0260).
+- `MultiDayOverlayPortalBuilder` receives a populated `OverlayStyles` for the same reason, built by the new `OverlayStyles.fromContext`. That typedef takes no `BuildContext`, so it cannot resolve the theme itself.
 - `KalenderThemeData.weekNumberStyle.alignment` now reaches the month week number. It had no effect there, because the month body passed its own top alignment to the widget and a passed style wins over the theme, so the only way to change it was the deprecated `CalendarComponents` style path. The month still sits at the top when nothing asks otherwise. A calendar that set this on the theme and relied on the month ignoring it will see the month week number move. [#423](https://github.com/werner-scholtz/kalender/pull/423)
 - A custom `weekNumberBuilder` receives the same fully resolved style in the month header as in the month body. The header's spacer passed the style through unresolved, so the two disagreed. [#423](https://github.com/werner-scholtz/kalender/pull/423)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ See [MIGRATION.md](MIGRATION.md#v025x--v0260) for what to change.
 
 ### Fixes
 
+- The month week number gutter and the multi-day timeline are measured once above both the header and the body, so the two halves cannot be given different widths. Each is drawn in the body and reserved again in the header, and both used to resolve their style from their own position in the tree. A `KalenderTheme` scoped to only one half moved one and left the other behind, which shifted every day column out of line with its header. A scoped `weekNumberStyle` or `timelineStyle` that the calendar has to ignore is now reported in debug builds.
 - The week number label is centred when the visible range crosses a week boundary. The gutter is sized by the timeline rather than by the label, so `32 - 33` wraps, and the short second line sat against the leading edge. [#427](https://github.com/werner-scholtz/kalender/pull/427)
+- The Material defaults are built once per `ThemeData` rather than on every theme lookup. `KalenderTheme.of` runs on nearly every widget build and rebuilt thirteen style objects each time, which the month view did twice per day cell and the schedule view once per row. The cache is keyed weakly on the theme, so an entry is collected with the theme it belongs to.
+- A schedule row resolves the theme only when it reads one of the two styles that need it. A month separator row reads neither and paid for a full resolution regardless.
 - `HourLines.fromContext` no longer takes a `style` argument. It resolved the style from the theme and discarded whatever was passed, so the argument silently did nothing. `timelineStyle` is unaffected.
 - `MultiDayBodyConfiguration.keepPagesAlive` takes part in `==` and `hashCode`. It is declared on that class rather than the `VerticalConfiguration` base, and the inherited equality did not reach it, so changing only that value did not reach the calendar.
 - `MonthBodyConfiguration` and `MultiDayHeaderConfiguration` no longer compare equal to each other. Both extend `HorizontalConfiguration` and add no equality of their own, and its `==` tested only `other is HorizontalConfiguration` with no runtime type check. The same applied to `VerticalConfiguration`.
@@ -24,6 +27,7 @@ See [MIGRATION.md](MIGRATION.md#v025x--v0260) for what to change.
 
 ### Tests
 
+- Added coverage that a `KalenderTheme` scoped to the body cannot move the month week number gutter or the multi-day timeline away from what the header reserves, that a theme above the calendar still reaches both, and that an ignored scoped value is reported once rather than on every frame.
 - Added equality coverage for the three strategy classes: two of a kind compare equal with matching hash codes, the built-ins differ from each other, a configuration built twice in a row is equal, and changing only the strategy still breaks equality.
 
 ### Behavior Changes

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,6 +48,8 @@ CalendarView(
 )
 ```
 
+`weekNumberStyle` and `timelineStyle` are the exception. They size the gutters that both halves have to agree on, so the calendar resolves them above the header and the body and a scope inside either one does not reach them. Set those two above the `CalendarView`. A scoped value the calendar ignores is reported in debug builds.
+
 ### Custom component builders receive a resolved style
 
 Nothing to change unless a builder falls back on the style argument being null.
@@ -76,6 +78,8 @@ This applies to `dayHeaderBuilder`, `daySeparator`, `hourLines`, `monthDayHeader
 Nothing to change unless you set `KalenderThemeData.weekNumberStyle.alignment`. That had no effect in the month view before and now applies, so the month week number may move. It still sits at the top when the theme sets no alignment.
 
 The theme field feeds both the month gutter and the multi-day header, so the two can no longer be given different alignments. `MonthBodyComponentStyles` was the only way to set them apart and it is gone.
+
+Set it above the `CalendarView` rather than on a `KalenderTheme` scoped to the header or the body. `weekNumberStyle` sizes the month gutter, which the header reserves space for, so it is resolved once above both.
 
 ### The three strategy fields become classes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,6 +48,29 @@ CalendarView(
 )
 ```
 
+### Custom component builders receive a resolved style
+
+Nothing to change unless a builder falls back on the style argument being null.
+
+A builder used to be handed whatever the deprecated container carried, which was an empty style unless the app had set one. It is now handed the style resolved from the theme, so the fallback below never runs:
+
+```dart
+- weekNumberBuilder: (range, style) => MyWeekNumber(textStyle: style?.textStyle ?? myBoldStyle)
++ weekNumberBuilder: (range, style) => MyWeekNumber(textStyle: myBoldStyle)
+```
+
+Override the fields you want rather than falling back on null, or merge your own over what you are given:
+
+```dart
+weekNumberBuilder: (range, style) => MyWeekNumber(
+  textStyle: myBoldStyle.merge(style?.textStyle),
+)
+```
+
+This applies to `dayHeaderBuilder`, `daySeparator`, `hourLines`, `monthDayHeaderBuilder`, `monthGridBuilder`, `timeIndicator`, `timeline`, `weekDayHeaderBuilder`, `weekNumberBuilder` and `leadingDateBuilder`, and to the `OverlayStyles` a `MultiDayOverlayPortalBuilder` receives.
+
+`HourLines.fromContext` loses its `style` argument in the same pass. It resolved the style from the theme and discarded whatever was passed, so it silently did nothing. Delete the argument.
+
 ### The month week number's alignment moves to the theme
 
 Nothing to change unless you set `KalenderThemeData.weekNumberStyle.alignment`. That had no effect in the month view before and now applies, so the month week number may move. It still sits at the top when the theme sets no alignment.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ The detailed guides live in [`doc/`](doc/README.md):
 - **[Layout](doc/layout.md).** Where tiles are placed and sized, and how overlapping events share a column. Only needed for a custom layout strategy, such as one lane per person.
 - **[Timezones & Locales](doc/timezones-and-locales.md).** Events stored as UTC and displayed in any IANA location, across daylight saving changes and midnight. Day and month names from intl in the calendar's locale, right-to-left layouts, and replacing any string.
 
+> [!NOTE]
+> `weekNumberStyle` and `timelineStyle` decide how wide the calendar's gutters
+> are. Those gutters are drawn in the body and reserved again in the header, so
+> the calendar measures them once above both and a `KalenderTheme` placed inside
+> only the header or only the body cannot change them. Set either one above the
+> `CalendarView`, or on the `KalenderThemeData` registered on
+> `ThemeData.extensions`. A scoped value the calendar has to ignore is reported
+> in debug builds.
+
+
 ---
 
 ## Contributing

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -290,6 +290,14 @@ it leaves null.
 3. The `KalenderThemeData` registered on `ThemeData.extensions`.
 4. The Material 3 defaults.
 
+> [!NOTE]
+> `weekNumberStyle` and `timelineStyle` are the exception to layer 2. They decide
+> how wide the calendar's gutters are, and each gutter is drawn in the body and
+> reserved again in the header so their day columns line up. The calendar
+> measures them once above both, so a `KalenderTheme` inside only the header or
+> only the body cannot change them. Set them above the `CalendarView` instead. A
+> scoped value the calendar has to ignore is reported in debug builds.
+
 Theme changes animate: because `KalenderThemeData` is a `ThemeExtension` with `lerp`, switching themes transitions the calendar's colors along with the rest of the app. A `KalenderTheme` scope does not animate on its own, since it is a plain widget rather than part of `ThemeData`.
 
 ### The overflow overlay

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -285,7 +285,7 @@ your calendar, so an ordinary inherited widget would not reach them.
 Four layers, most specific first. Each one fills in the fields the layer above
 it leaves null.
 
-1. A style passed to a single calendar through `CalendarComponents` (see [Appearance](#appearance--custom-components)).
+1. A style passed directly to a widget, which is how a custom builder styles the widget it returns (see [Appearance](#appearance--custom-components)).
 2. The nearest `KalenderTheme` above the calendar.
 3. The `KalenderThemeData` registered on `ThemeData.extensions`.
 4. The Material 3 defaults.
@@ -318,14 +318,13 @@ KalenderThemeData(
 
 Pass a `CalendarComponents` object to `CalendarView` to override the default widget builders.
 
-> [!WARNING]
-> The style fields on `CalendarComponents` are deprecated and are removed in
-> 0.26.0. Use `KalenderThemeData` for the whole app, or wrap a calendar in a
-> [`KalenderTheme`](#theming-part-of-the-app) to style one of them. That is the
-> same set of styles reached one way instead of four.
+> [!NOTE]
+> `CalendarComponents` carries builders only. Styles live on `KalenderThemeData`:
+> register one on `ThemeData.extensions` for the whole app, or wrap a calendar in
+> a [`KalenderTheme`](#theming-part-of-the-app) to style one of them.
 >
-> `CalendarComponents` keeps its builder fields. Styles move to the theme,
-> builders stay here.
+> A custom builder is handed the resolved style for the widget it replaces, so it
+> can pass that straight through or override the fields it cares about.
 
 <details>
   <summary>MultiDayComponents</summary>

--- a/lib/src/calendar_view.dart
+++ b/lib/src/calendar_view.dart
@@ -23,10 +23,8 @@ class CalendarView extends StatefulWidget {
   /// - [MonthComponents]
   /// - [ScheduleComponents]
   ///
-  /// Styles:
-  /// - [MultiDayComponentStyles]
-  /// - [MonthComponentStyles],
-  /// - [ScheduleComponentStyles]
+  /// Styles live on [KalenderThemeData] rather than here. Register one on
+  /// [ThemeData.extensions], or wrap a calendar in a [KalenderTheme] to scope it.
   final CalendarComponents? components;
 
   /// The header widget that will be displayed above the body.

--- a/lib/src/calendar_view.dart
+++ b/lib/src/calendar_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/layout_delegates/calendar_layout_delegate.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
+import 'package:kalender/src/models/providers/gutter_styles.dart';
 
 class CalendarView extends StatefulWidget {
   /// The [EventsController] that will be used to populate the events in the calendar view.
@@ -286,6 +287,10 @@ class CalendarViewState extends State<CalendarView> {
     final bodyId = widget.body == null ? null : CalendarLayoutDelegate.body;
     final headerId = widget.header == null ? null : CalendarLayoutDelegate.header;
 
+    // Resolved here rather than where each gutter is drawn, so the header and
+    // the body cannot be given different widths. See [GutterStyles].
+    final kalenderTheme = KalenderTheme.of(context);
+
     return LocationProvider(
       notifier: _location,
       child: LocaleProvider(
@@ -294,24 +299,28 @@ class CalendarViewState extends State<CalendarView> {
           callbacks: widget.callbacks,
           child: Components(
             components: widget.components ?? const CalendarComponents(),
-            child: EventsControllerProvider(
-              eventsController: widget.eventsController,
-              child: CalendarControllerProvider(
-                notifier: widget.calendarController,
-                child: CustomMultiChildLayout(
-                  delegate: CalendarLayoutDelegate(headerId, bodyId),
-                  children: [
-                    if (bodyId != null)
-                      LayoutId(
-                        id: bodyId,
-                        child: widget.body!,
-                      ),
-                    if (headerId != null)
-                      LayoutId(
-                        id: headerId,
-                        child: widget.header!,
-                      ),
-                  ],
+            child: GutterStyles(
+              weekNumberStyle: kalenderTheme.weekNumberStyle,
+              timelineStyle: kalenderTheme.timelineStyle,
+              child: EventsControllerProvider(
+                eventsController: widget.eventsController,
+                child: CalendarControllerProvider(
+                  notifier: widget.calendarController,
+                  child: CustomMultiChildLayout(
+                    delegate: CalendarLayoutDelegate(headerId, bodyId),
+                    children: [
+                      if (bodyId != null)
+                        LayoutId(
+                          id: bodyId,
+                          child: widget.body!,
+                        ),
+                      if (headerId != null)
+                        LayoutId(
+                          id: headerId,
+                          child: widget.header!,
+                        ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/src/models/providers/gutter_styles.dart
+++ b/lib/src/models/providers/gutter_styles.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:kalender/kalender.dart';
+
+/// The styles that decide how wide the calendar's gutters are.
+///
+/// The month week number column and the multi-day timeline are each measured
+/// twice: once where they are drawn in the body, and once as an invisible spacer
+/// in the header that reserves the same width so the day columns of the two line
+/// up. [CalendarView] resolves these once above both, so a [KalenderTheme]
+/// placed inside the header or the body cannot move one without the other.
+///
+/// A scoped theme that sets one of these is reported by
+/// [debugCheckGutterStyleReaches] rather than silently ignored.
+class GutterStyles extends InheritedWidget {
+  /// The week number style the month gutter and its header spacer measure with.
+  final WeekNumberStyle? weekNumberStyle;
+
+  /// The timeline style the multi-day body and its header measure with.
+  final TimelineStyle? timelineStyle;
+
+  /// Creates a [GutterStyles] with the given resolved styles.
+  const GutterStyles({
+    super.key,
+    required this.weekNumberStyle,
+    required this.timelineStyle,
+    required super.child,
+  });
+
+  /// Gets the [GutterStyles] from the context.
+  static GutterStyles of(BuildContext context) {
+    final result = context.dependOnInheritedWidgetOfExactType<GutterStyles>();
+    assert(result != null, 'No GutterStyles found.');
+    return result!;
+  }
+
+  @override
+  bool updateShouldNotify(covariant GutterStyles oldWidget) {
+    return weekNumberStyle != oldWidget.weekNumberStyle || timelineStyle != oldWidget.timelineStyle;
+  }
+}
+
+/// The mismatches already reported, so each is named once rather than on every
+/// frame that rebuilds the gutter.
+final Set<String> _reported = <String>{};
+
+/// Resets the record of reported mismatches. For tests.
+@visibleForTesting
+void debugResetGutterStyleWarnings() => _reported.clear();
+
+/// Reports a [field] that a [KalenderTheme] below the calendar sets and the
+/// shared gutter measurement ignores.
+///
+/// Always returns true, so it can be called from an `assert`. Pass both values
+/// from outside the assert: reading an inherited widget inside one would make
+/// the widget depend on it in debug builds and not in release builds.
+bool debugCheckGutterStyleReaches({
+  required String field,
+  required Object? shared,
+  required Object? scoped,
+}) {
+  if (shared == scoped) return true;
+  if (!_reported.add('$field:$shared:$scoped')) return true;
+
+  debugPrint(
+    'kalender: a KalenderTheme below the CalendarView sets $field, which is ignored.\n'
+    'The gutter it sizes is drawn in the body and reserved again in the header, so '
+    'the calendar measures it once above both. A theme scoped to only one of them '
+    'would move the two apart.\n'
+    'Set $field on a KalenderTheme above the CalendarView, or on the '
+    'KalenderThemeData registered on ThemeData.extensions.',
+  );
+  return true;
+}

--- a/lib/src/theme/kalender_theme.dart
+++ b/lib/src/theme/kalender_theme.dart
@@ -4,10 +4,13 @@ import 'package:kalender/kalender.dart';
 
 /// The calendar's visual theme, following the same layering as Flutter's own component themes.
 ///
-/// Styling is resolved in three layers, most specific first:
-/// 1. A style passed directly to a widget or through the component style containers.
-/// 2. A [KalenderThemeData] registered as a [ThemeExtension] on the app's [ThemeData].
-/// 3. Material 3 defaults derived from the ambient [Theme], see [KalenderThemeData.defaults].
+/// Styling is resolved in four layers, most specific first. Each fills in the
+/// fields the layer above it leaves null:
+/// 1. A style passed directly to a widget, which is how a custom builder styles
+///    the widget it returns.
+/// 2. The nearest [KalenderTheme] above the calendar.
+/// 3. A [KalenderThemeData] registered as a [ThemeExtension] on the app's [ThemeData].
+/// 4. Material 3 defaults derived from the ambient [Theme], see [KalenderThemeData.defaults].
 ///
 /// To theme every calendar in the app:
 ///

--- a/lib/src/theme/kalender_theme.dart
+++ b/lib/src/theme/kalender_theme.dart
@@ -2,6 +2,18 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 
+/// The Material defaults for a [ThemeData], built once.
+///
+/// [KalenderThemeData.defaults] constructs thirteen style objects, and the
+/// calendar resolves the theme on nearly every widget build. An [Expando] holds
+/// its keys weakly, so an entry is collected with the theme it belongs to.
+final _defaultsCache = Expando<KalenderThemeData>('kalender defaults');
+
+/// The defaults merged with the [ThemeExtension] registered on the same
+/// [ThemeData]. Both inputs come from the theme, so one entry serves every
+/// lookup that finds no scoped [KalenderTheme].
+final _extendedCache = Expando<KalenderThemeData>('kalender defaults + extension');
+
 /// The calendar's visual theme, following the same layering as Flutter's own component themes.
 ///
 /// Styling is resolved in four layers, most specific first. Each fills in the
@@ -91,8 +103,15 @@ class KalenderThemeData extends ThemeExtension<KalenderThemeData> with Diagnosti
   /// - text styles that intentionally inherit from [DefaultTextStyle].
   /// - [WeekNumberStyle.alignment], so a widget can tell an alignment nobody
   ///   set from one set to centre. Each week number falls back on its own.
-  static KalenderThemeData defaults(BuildContext context) {
-    final theme = Theme.of(context);
+  static KalenderThemeData defaults(BuildContext context) => _defaultsFor(Theme.of(context));
+
+  static KalenderThemeData _defaultsFor(ThemeData theme) {
+    final cached = _defaultsCache[theme];
+    if (cached != null) return cached;
+    return _defaultsCache[theme] = _buildDefaults(theme);
+  }
+
+  static KalenderThemeData _buildDefaults(ThemeData theme) {
     final colorScheme = theme.colorScheme;
     final textTheme = theme.textTheme;
 
@@ -364,10 +383,14 @@ class KalenderTheme extends InheritedTheme {
   ///
   /// A style passed directly to a widget still takes precedence over all three.
   static KalenderThemeData of(BuildContext context) {
-    final defaults = KalenderThemeData.defaults(context);
-    final extension = Theme.of(context).extension<KalenderThemeData>();
+    final theme = Theme.of(context);
+    var base = _extendedCache[theme];
+    if (base == null) {
+      base = KalenderThemeData._defaultsFor(theme).merge(theme.extension<KalenderThemeData>());
+      _extendedCache[theme] = base;
+    }
     final inherited = context.dependOnInheritedWidgetOfExactType<KalenderTheme>()?.data;
-    return defaults.merge(extension).merge(inherited);
+    return base.merge(inherited);
   }
 
   @override

--- a/lib/src/widgets/components/hour_lines.dart
+++ b/lib/src/widgets/components/hour_lines.dart
@@ -140,7 +140,6 @@ class HourLines extends StatelessWidget with TimeLineUtils {
   static Widget fromContext(
     BuildContext context,
     TimeOfDayRange timeOfDayRange, {
-    HourLinesStyle? style,
     TimelineStyle? timelineStyle,
   }) {
     final hourLinesStyle = KalenderTheme.of(context).hourLinesStyle;

--- a/lib/src/widgets/internal_components/month_week_number_gutter.dart
+++ b/lib/src/widgets/internal_components/month_week_number_gutter.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
+import 'package:kalender/src/models/providers/gutter_styles.dart';
 
 /// The month grid puts the week number at the top of its row rather than
 /// centring it, which is where every other week number sits.
@@ -9,10 +10,16 @@ const _monthWeekNumberDefaults = WeekNumberStyle(alignment: Alignment.topCenter)
 
 /// The style the month week number is drawn with.
 ///
-/// [KalenderThemeData.weekNumberStyle] wins over the top alignment. Applied in
-/// the gutter and the header's spacer alike, so the two measure the same width.
+/// [KalenderThemeData.weekNumberStyle] wins over the top alignment. It comes from
+/// [GutterStyles], resolved above both the header and the body, so the gutter and
+/// the header's spacer always measure the same width.
 WeekNumberStyle _resolveStyle(BuildContext context) {
-  return _monthWeekNumberDefaults.merge(KalenderTheme.of(context).weekNumberStyle);
+  final shared = GutterStyles.of(context).weekNumberStyle;
+  // Read outside the assert so the widget depends on the theme in release builds
+  // too, then compared inside it so the warning costs nothing when shipped.
+  final scoped = KalenderTheme.of(context).weekNumberStyle;
+  assert(debugCheckGutterStyleReaches(field: 'weekNumberStyle', shared: shared, scoped: scoped));
+  return _monthWeekNumberDefaults.merge(shared);
 }
 
 class MonthWeekNumberGutter extends StatelessWidget {

--- a/lib/src/widgets/internal_components/multi_day_header_layout.dart
+++ b/lib/src/widgets/internal_components/multi_day_header_layout.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
+import 'package:kalender/src/models/providers/gutter_styles.dart';
 
 /// The widget used for the MultiDayHeader.
 ///
@@ -36,7 +37,10 @@ class MultiDayHeaderWidget extends StatelessWidget {
     } else {
       final calendarComponents = context.components;
       final bodyComponents = calendarComponents.multiDayComponents.bodyComponents;
-      final timelineStyle = KalenderTheme.of(context).timelineStyle ?? const TimelineStyle();
+      final sharedStyle = GutterStyles.of(context).timelineStyle;
+      final scopedStyle = KalenderTheme.of(context).timelineStyle;
+      assert(debugCheckGutterStyleReaches(field: 'timelineStyle', shared: sharedStyle, scoped: scopedStyle));
+      final timelineStyle = sharedStyle ?? const TimelineStyle();
       timelineWidth = bodyComponents.timelineWidth(context, TimeOfDayRange.allDay(), timelineStyle);
     }
 

--- a/lib/src/widgets/multi_day/multi_day_body.dart
+++ b/lib/src/widgets/multi_day/multi_day_body.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
+import 'package:kalender/src/models/providers/gutter_styles.dart';
 import 'package:kalender/src/models/view_configurations/page_index_calculator.dart';
 import 'package:kalender/src/widgets/drag_targets/vertical_drag_target.dart';
 import 'package:kalender/src/widgets/draggable/day_draggable.dart';
@@ -64,7 +65,10 @@ class MultiDayBody extends StatelessWidget {
     // The single source of truth for the timeline gutter width, shared with the
     // header and drag overlay so their day columns stay aligned.
     final bodyComponents = context.components.multiDayComponents.bodyComponents;
-    final timelineStyle = KalenderTheme.of(context).timelineStyle ?? const TimelineStyle();
+    final sharedStyle = GutterStyles.of(context).timelineStyle;
+    final scopedStyle = KalenderTheme.of(context).timelineStyle;
+    assert(debugCheckGutterStyleReaches(field: 'timelineStyle', shared: sharedStyle, scoped: scopedStyle));
+    final timelineStyle = sharedStyle ?? const TimelineStyle();
     final timelineWidth = bodyComponents.timelineWidth(context, timeOfDayRange, timelineStyle);
 
     return Stack(

--- a/lib/src/widgets/schedule/schedule_body.dart
+++ b/lib/src/widgets/schedule/schedule_body.dart
@@ -380,7 +380,9 @@ class _SchedulePositionListState extends State<SchedulePositionList> {
             final leadingWidth = widget.configuration.leadingWidth;
             Widget leadingSlot(Widget? child) => SizedBox(width: leadingWidth, child: child);
 
-            final theme = KalenderTheme.of(context);
+            // A MonthItem row reads neither of the two below, so resolve the
+            // theme only once a row that needs it asks.
+            late final theme = KalenderTheme.of(context);
             late final leading =
                 components.leadingDateBuilder.call(InternalDateTime.fromDateTime(date), theme.scheduleDateStyle);
             late final highlightStyle = theme.scheduleTileHighlightStyle;

--- a/test/widgets/gutter_style_scope_test.dart
+++ b/test/widgets/gutter_style_scope_test.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/models/providers/gutter_styles.dart';
+import 'package:kalender/src/widgets/internal_components/expandable_page_view.dart' show ExpandablePageView;
+import 'package:kalender/src/widgets/internal_components/month_week_number_gutter.dart';
+
+import '../utilities.dart';
+
+/// The month week number column and the multi-day timeline are each drawn in the
+/// body and reserved again in the header. Both used to resolve their style from
+/// their own position in the tree, so a `KalenderTheme` scoped to one half moved
+/// it and left the other behind. [CalendarView] now resolves both above the two,
+/// and reports a scoped value it has to ignore.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+  late List<String> warnings;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+    debugResetGutterStyleWarnings();
+    warnings = [];
+  });
+
+  tearDown(() {
+    calendarController.dispose();
+    eventsController.dispose();
+  });
+
+  /// Collects what the calendar reports while [body] runs.
+  ///
+  /// [debugPrint] is restored before returning, because the test framework
+  /// checks that foundation debug variables are unset when the body ends.
+  Future<void> capturingWarnings(Future<void> Function() body) async {
+    final original = debugPrint;
+    debugPrint = (message, {wrapWidth}) {
+      if (message != null) warnings.add(message);
+    };
+    try {
+      await body();
+    } finally {
+      debugPrint = original;
+    }
+  }
+
+  final tiles = TileComponents(tileBuilder: (event, tileRange) => const SizedBox());
+
+  /// A calendar whose body is scoped to [bodyTheme] while the header is not,
+  /// which is the shape the migration guide recommends for per-view styling.
+  Widget splitTheme(ViewConfiguration configuration, KalenderThemeData bodyTheme) {
+    return CalendarView(
+      eventsController: eventsController,
+      calendarController: calendarController,
+      viewConfiguration: configuration,
+      header: CalendarHeader(multiDayTileComponents: tiles),
+      body: KalenderTheme(data: bodyTheme, child: CalendarBody(multiDayTileComponents: tiles)),
+    );
+  }
+
+  group('month week number gutter', () {
+    MonthViewConfiguration month() => MonthViewConfiguration.singleMonth(
+          displayRange: year2025DisplayRange,
+          initialDateTime: DateTime(2025, 8),
+          showWeekNumbers: true,
+        );
+
+    double gutterWidth(WidgetTester tester) => tester.getSize(find.byType(MonthWeekNumberGutter)).width;
+    double spacerWidth(WidgetTester tester) => tester.getSize(find.byType(MonthWeekNumberSpacer)).width;
+
+    testWidgets('the gutter and the header spacer measure alike by default', (tester) async {
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        CalendarView(
+          eventsController: eventsController,
+          calendarController: calendarController,
+          viewConfiguration: month(),
+          header: const CalendarHeader(),
+          body: const CalendarBody(),
+        ),
+      );
+
+      expect(gutterWidth(tester), moreOrLessEquals(spacerWidth(tester), epsilon: 0.5));
+    });
+
+    testWidgets('a body-scoped week number style cannot move one without the other', (tester) async {
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        splitTheme(
+          month(),
+          const KalenderThemeData(weekNumberStyle: WeekNumberStyle(padding: EdgeInsets.symmetric(horizontal: 40))),
+        ),
+      );
+
+      expect(
+        gutterWidth(tester),
+        moreOrLessEquals(spacerWidth(tester), epsilon: 0.5),
+        reason: 'the width is resolved above both, so a scope inside the body cannot widen only the gutter',
+      );
+    });
+
+    testWidgets('the ignored scoped style is reported', (tester) async {
+      await capturingWarnings(() async {
+        await pumpAndSettleWithMaterialApp(
+          tester,
+          splitTheme(
+            month(),
+            const KalenderThemeData(weekNumberStyle: WeekNumberStyle(padding: EdgeInsets.symmetric(horizontal: 40))),
+          ),
+        );
+      });
+
+      expect(warnings.where((w) => w.contains('weekNumberStyle')), isNotEmpty);
+      expect(warnings.first, contains('is ignored'));
+      expect(warnings.first, contains('above the CalendarView'));
+    });
+
+    testWidgets('a theme above the calendar reaches the gutter and stays silent', (tester) async {
+      await capturingWarnings(() async {
+        await pumpAndSettleWithMaterialApp(
+          tester,
+          KalenderTheme(
+            data: const KalenderThemeData(
+              weekNumberStyle: WeekNumberStyle(padding: EdgeInsets.symmetric(horizontal: 40)),
+            ),
+            child: CalendarView(
+              eventsController: eventsController,
+              calendarController: calendarController,
+              viewConfiguration: month(),
+              header: const CalendarHeader(),
+              body: const CalendarBody(),
+            ),
+          ),
+        );
+      });
+
+      expect(gutterWidth(tester), moreOrLessEquals(spacerWidth(tester), epsilon: 0.5));
+      expect(gutterWidth(tester), greaterThan(80), reason: 'the 40px horizontal padding should apply');
+      expect(warnings, isEmpty, reason: 'nothing is ignored when the theme sits above both halves');
+    });
+
+    testWidgets('the report names the field once, not once per frame', (tester) async {
+      final view = splitTheme(
+        month(),
+        const KalenderThemeData(weekNumberStyle: WeekNumberStyle(padding: EdgeInsets.symmetric(horizontal: 40))),
+      );
+      await capturingWarnings(() async {
+        await pumpAndSettleWithMaterialApp(tester, view);
+      });
+      final afterFirst = warnings.length;
+
+      await capturingWarnings(() async {
+        await tester.pump();
+        await tester.pumpAndSettle();
+      });
+
+      expect(warnings.length, equals(afterFirst));
+    });
+  });
+
+  group('multi-day timeline gutter', () {
+    MultiDayViewConfiguration week() => MultiDayViewConfiguration.week(
+          displayRange: year2025DisplayRange,
+          initialDateTime: DateTime(2025, 1, 13),
+        );
+
+    testWidgets('a body-scoped timeline style keeps the columns aligned', (tester) async {
+      await pumpAndSettleWithMaterialApp(
+        tester,
+        splitTheme(
+          week(),
+          const KalenderThemeData(timelineStyle: TimelineStyle(width: 140)),
+        ),
+      );
+
+      final bodyDayArea = tester.getRect(find.byType(HourLines));
+      final headerDayArea = tester.getRect(find.byType(ExpandablePageView));
+      expect(headerDayArea.left, moreOrLessEquals(bodyDayArea.left, epsilon: 0.5));
+      expect(headerDayArea.right, moreOrLessEquals(bodyDayArea.right, epsilon: 0.5));
+    });
+
+    testWidgets('the ignored scoped style is reported', (tester) async {
+      await capturingWarnings(() async {
+        await pumpAndSettleWithMaterialApp(
+          tester,
+          splitTheme(
+            week(),
+            const KalenderThemeData(timelineStyle: TimelineStyle(width: 140)),
+          ),
+        );
+      });
+
+      expect(warnings.where((w) => w.contains('timelineStyle')), isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #429. Fixes the actionable findings from the review of `v0.25.0..main`.

## One real bug

`HourLines.fromContext` declared a `style` argument and discarded it:

```dart
static Widget fromContext(context, timeOfDayRange, {HourLinesStyle? style, TimelineStyle? timelineStyle}) {
  final hourLinesStyle = KalenderTheme.of(context).hourLinesStyle;  // style never read
  ...
}
```

The adjacent `timelineStyle` *is* forwarded, so the two looked interchangeable while only one worked. Passing `style:` produced no analyzer warning and no runtime signal.

Removed rather than honoured. Every sibling helper (`DaySeparator.fromContext`, `DayHeader.fromContext`) takes no style argument, the only in-package call site passes neither, and AGENTS.md prefers a compile error to a member that silently does nothing.

## Three pieces of stale documentation

All three describe the style containers this release deletes.

- **`doc/appearance.md`** ships in the pub archive and renders on pub.dev. It listed `CalendarComponents` as resolution layer 1 and carried a `[!WARNING]` box saying the fields "are deprecated and are removed in 0.26.0" — the release it would ship in.
- **`CalendarView.components`** still listed the three deleted container types under a "Styles:" heading. This produced three `unresolved doc reference` warnings under `dart doc` where v0.25.0 produced none. Now 0 warnings, 0 errors.
- **`KalenderTheme`'s class doc** described layer 1 as "passed directly to a widget or through the component style containers", and listed three layers where there are four — the scoped `KalenderTheme` was missing.

## Two changelog corrections

**The builder style change moves from `### Features` to `### Behavior Changes`,** with a MIGRATION.md entry. It changes what an unchanged app renders, which AGENTS.md reserves that heading for. A builder written as `style?.textStyle ?? myBoldStyle` used to reach `myBoldStyle`, because the container handed it an empty style. It now receives the theme value, so the fallback never runs and the widget renders in the theme's weight. Ten builders are affected.

**The week number centring fix had no entry at all.** #427 touched only `week_number.dart` and a new test, so nothing recorded that a two-week label moves from leading-edge aligned to centred.

## Verification

- `dart analyze` clean, `dart format` clean, `dart doc` clean (was 3 warnings).
- 1476 tests pass.
- All 46 doc snippets compile.

## Deliberately not fixed here

The review's header/body theme split finding, and the two theme-resolution efficiency findings. Both need a decision rather than a patch, and are described in the discussion on the parent PR.
