### PR TITLE
docs: match the release notes to the repo's conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,19 @@ See [MIGRATION.md](MIGRATION.md#v025x--v0260) for what to change.
 - `HorizontalConfiguration.generateMultiDayLayoutFrame` is renamed to `multiDayLayoutStrategy` and is no longer nullable. It defaults to `MultiDayLayoutStrategy.byDuration()`, which is what `null` selected before.
 - `CalendarEvent.copyWith` is removed. A subclass overrode it and had to forward by hand every field the base class carries but takes no parameter for, which was `id` and, since 0.24.0, `multiDayRule`. Forgetting one produced a copy the calendar read as a different event, or one that lost its rule, and adding a field to the base class broke every subclass at once without a compile error. Override `copyWithData` instead and rebuild only what your subclass adds. The calendar calls `withDateTimeRange`, which applies the hook and then restores the base state through `carryOver`. A missing hook is reported by the analyzer through `@mustBeOverridden`, and by a debug assert on the first drag for anyone who ignores the warning. Your own `copyWith` is no longer an override, so it can take whatever parameters suit you. See [MIGRATION.md](MIGRATION.md#v025x--v0260).
 - `CalendarEvent.interaction` and `CalendarEvent.multiDayRule` are getters rather than fields, so `carryOver` can restore them. Reading either is unchanged. Neither was assignable before.
-- `meta` is a direct dependency at `^1.9.0`, the version that introduced `@mustBeOverridden`.
 - The seven style container classes reached through those fields are removed with them: `MonthComponentStyles`, `MonthBodyComponentStyles`, `MonthHeaderComponentStyles`, `MultiDayComponentStyles`, `MultiDayBodyComponentStyles`, `MultiDayHeaderComponentStyles` and `ScheduleComponentStyles`. Nothing public reached them once the fields were gone, so they carry no deprecation of their own. `OverlayStyles` is not one of them and stays, since `MultiDayOverlayPortalBuilder` names it.
+
+### Behavior Changes
+
+- A custom component builder is handed the theme-resolved style rather than an empty one. A builder previously received whatever the deprecated container carried, which was an empty style unless the app had set one, so `style?.textStyle ?? myFallback` reached `myFallback`. The same argument now arrives populated from the theme, so a builder written that way renders with the theme value instead of its own fallback. Read the fields you want to override rather than falling back on null. This affects `dayHeaderBuilder`, `daySeparator`, `hourLines`, `monthDayHeaderBuilder`, `monthGridBuilder`, `timeIndicator`, `timeline`, `weekDayHeaderBuilder`, `weekNumberBuilder` and `leadingDateBuilder`. See [MIGRATION.md](MIGRATION.md#v025x--v0260).
+- `MultiDayOverlayPortalBuilder` receives a populated `OverlayStyles` for the same reason, built by the new `OverlayStyles.fromContext`. That typedef takes no `BuildContext`, so it cannot resolve the theme itself.
+- `KalenderThemeData.weekNumberStyle.alignment` now reaches the month week number. It had no effect there, because the month body passed its own top alignment to the widget and a passed style wins over the theme, so the only way to change it was the deprecated `CalendarComponents` style path. The month still sits at the top when nothing asks otherwise. A calendar that set this on the theme and relied on the month ignoring it will see the month week number move. [#423](https://github.com/werner-scholtz/kalender/pull/423)
+- A custom `weekNumberBuilder` receives the same fully resolved style in the month header as in the month body. The header's spacer passed the style through unresolved, so the two disagreed. [#423](https://github.com/werner-scholtz/kalender/pull/423)
 
 ### Features
 
 - `EventSnapStrategy.none()` leaves a dragged event where the cursor is, without needing a hand-written strategy.
+- `meta` is a direct dependency at `^1.9.0`, the version that introduced `@mustBeOverridden`. The floor is that version rather than the resolved one, so it does not narrow what a consumer can resolve.
 - `defaultMultiDayFrameGenerator` stays public, so a custom `MultiDayLayoutStrategy` can reuse the built-in row assignment and change only the order events are placed in, through the `eventComparator` the strategy itself does not expose.
 
 ### Fixes
@@ -35,13 +42,6 @@ See [MIGRATION.md](MIGRATION.md#v025x--v0260) for what to change.
 - Added coverage for `multiDayOverlayPortalBuilder`, which had none: a custom portal builder is handed styles resolved from the theme, a scoped theme reaches it, and the built-in overlay still follows a scoped theme with nothing passed to it, across the `Overlay` boundary it is built into.
 - Added coverage that a `KalenderTheme` scoped to the body cannot move the month week number gutter or the multi-day timeline away from what the header reserves, that a theme above the calendar still reaches both, and that an ignored scoped value is reported once rather than on every frame.
 - Added equality coverage for the three strategy classes: two of a kind compare equal with matching hash codes, the built-ins differ from each other, a configuration built twice in a row is equal, and changing only the strategy still breaks equality.
-
-### Behavior Changes
-
-- A custom component builder is handed the theme-resolved style rather than an empty one. A builder previously received whatever the deprecated container carried, which was an empty style unless the app had set one, so `style?.textStyle ?? myFallback` reached `myFallback`. The same argument now arrives populated from the theme, so a builder written that way renders with the theme value instead of its own fallback. Read the fields you want to override rather than falling back on null. This affects `dayHeaderBuilder`, `daySeparator`, `hourLines`, `monthDayHeaderBuilder`, `monthGridBuilder`, `timeIndicator`, `timeline`, `weekDayHeaderBuilder`, `weekNumberBuilder` and `leadingDateBuilder`. See [MIGRATION.md](MIGRATION.md#v025x--v0260).
-- `MultiDayOverlayPortalBuilder` receives a populated `OverlayStyles` for the same reason, built by the new `OverlayStyles.fromContext`. That typedef takes no `BuildContext`, so it cannot resolve the theme itself.
-- `KalenderThemeData.weekNumberStyle.alignment` now reaches the month week number. It had no effect there, because the month body passed its own top alignment to the widget and a passed style wins over the theme, so the only way to change it was the deprecated `CalendarComponents` style path. The month still sits at the top when nothing asks otherwise. A calendar that set this on the theme and relied on the month ignoring it will see the month week number move. [#423](https://github.com/werner-scholtz/kalender/pull/423)
-- A custom `weekNumberBuilder` receives the same fully resolved style in the month header as in the month body. The header's spacer passed the style through unresolved, so the two disagreed. [#423](https://github.com/werner-scholtz/kalender/pull/423)
 
 ## 0.25.0
 

--- a/README.md
+++ b/README.md
@@ -156,14 +156,7 @@ The detailed guides live in [`doc/`](doc/README.md):
 - **[Timezones & Locales](doc/timezones-and-locales.md).** Events stored as UTC and displayed in any IANA location, across daylight saving changes and midnight. Day and month names from intl in the calendar's locale, right-to-left layouts, and replacing any string.
 
 > [!NOTE]
-> `weekNumberStyle` and `timelineStyle` decide how wide the calendar's gutters
-> are. Those gutters are drawn in the body and reserved again in the header, so
-> the calendar measures them once above both and a `KalenderTheme` placed inside
-> only the header or only the body cannot change them. Set either one above the
-> `CalendarView`, or on the `KalenderThemeData` registered on
-> `ThemeData.extensions`. A scoped value the calendar has to ignore is reported
-> in debug builds.
-
+> `weekNumberStyle` and `timelineStyle` decide how wide the calendar's gutters are. Those gutters are drawn in the body and reserved again in the header, so the calendar measures them once above both, and a `KalenderTheme` placed inside only the header or only the body cannot change them. Set either one above the `CalendarView`, or on the `KalenderThemeData` registered on `ThemeData.extensions`. A scoped value the calendar has to ignore is reported in debug builds.
 
 ---
 

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -291,12 +291,7 @@ it leaves null.
 4. The Material 3 defaults.
 
 > [!NOTE]
-> `weekNumberStyle` and `timelineStyle` are the exception to layer 2. They decide
-> how wide the calendar's gutters are, and each gutter is drawn in the body and
-> reserved again in the header so their day columns line up. The calendar
-> measures them once above both, so a `KalenderTheme` inside only the header or
-> only the body cannot change them. Set them above the `CalendarView` instead. A
-> scoped value the calendar has to ignore is reported in debug builds.
+> `weekNumberStyle` and `timelineStyle` are the exception to layer 2. They decide how wide the calendar's gutters are, and each gutter is drawn in the body and reserved again in the header so their day columns line up. The calendar measures them once above both, so a `KalenderTheme` inside only the header or only the body cannot change them. Set them above the `CalendarView` instead. A scoped value the calendar has to ignore is reported in debug builds.
 
 Theme changes animate: because `KalenderThemeData` is a `ThemeExtension` with `lerp`, switching themes transitions the calendar's colors along with the rest of the app. A `KalenderTheme` scope does not animate on its own, since it is a plain widget rather than part of `ThemeData`.
 


### PR DESCRIPTION
Three small things found while checking the README and the migration guide before the 0.26.0 release. No code changes.

- **Unwrapped the two notes added this release.** They were hard-wrapped at 80 characters while the README and `doc/appearance.md` run prose unwrapped (200 to 460 characters a line), so their diffs did not line up with the rest of the file.
- **`meta` moves out of `### Breaking Changes`.** Adding a dependency does not stop consumer code compiling, which is what AGENTS.md reserves that heading for. It sits under Features now, with the reason the floor is `^1.9.0` rather than the resolved version.
- **`### Behavior Changes` moves above `### Features`.** It was last, after `### Tests`. AGENTS.md names 0.23.0 as the reference for that section and it sits near the top there. The heading asks the reader to look at their screenshots, which is not a footnote after the test notes.

Verified: all 46 doc snippets compile, `dart analyze` clean.