### PR TITLE
docs: cover the new API in the guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See [MIGRATION.md](MIGRATION.md#v025x--v0260) for what to change.
 ### Features
 
 - `EventSnapStrategy.none()` leaves a dragged event where the cursor is, without needing a hand-written strategy.
+- The guides cover the release's new API: the copy contract and `withDateTimeRange` in the Events guide, the snap strategies and how to write one in the Interaction guide, and both layout strategies in the Layout guide.
 - `meta` is a direct dependency at `^1.9.0`, the version that introduced `@mustBeOverridden`. The floor is that version rather than the resolved one, so it does not narrow what a consumer can resolve.
 - `defaultMultiDayFrameGenerator` stays public, so a custom `MultiDayLayoutStrategy` can reuse the built-in row assignment and change only the order events are placed in, through the `eventComparator` the strategy itself does not expose.
 

--- a/doc/events.md
+++ b/doc/events.md
@@ -68,6 +68,24 @@ class Event extends CalendarEvent {
 > [!NOTE]
 > If you don't override `==` and `hashCode`, the calendar cannot detect changes to your custom fields and tiles will not update when those values change (e.g. via `eventsController.updateEvent(...)`). Always override both whenever you add fields to your `CalendarEvent` subclass.
 
+### The copy contract
+
+The calendar copies an event whenever it is dragged or resized. It calls `withDateTimeRange`, which you do not override:
+
+<!-- snippet: statements -->
+```dart
+final event = eventsController.byId(someId)! as Event;
+final moved = event.withDateTimeRange(
+  DateTimeRange(start: DateTime.utc(2025, 8, 12, 9), end: DateTime.utc(2025, 8, 12, 10)),
+) as Event;
+```
+
+`withDateTimeRange` calls `copyWithData`, your hook, and then puts back the state `CalendarEvent` itself holds: the `id`, the `interaction` config and the `multiDayRule`. That is why `copyWithData` lists only the fields your subclass adds. A field added to `CalendarEvent` in a later release reaches your subclass without you changing anything.
+
+Two things report a missing hook. `copyWithData` is annotated `@mustBeOverridden`, so the analyzer flags a subclass without one before you run anything, and a debug assert names the type on the first drag if the warning is ignored.
+
+`carryOver` is the part that restores the base state. Call it from a copy method of your own so those copies keep their identity too, as the example above does.
+
 ### Updating events
 
 Use `eventsController.updateEvent()` to replace an existing event with an updated copy:

--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -46,6 +46,50 @@ CalendarBody(
 )
 ```
 
+### Snapping strategies
+
+`eventSnapStrategy` decides where a dragged event lands. Two are built in:
+
+| Strategy | Behaviour |
+| --- | --- |
+| `EventSnapStrategy.interval()` | Snaps to the nearest multiple of `snapIntervalMinutes`, measured from the start of the day. The default. |
+| `EventSnapStrategy.none()` | Leaves the cursor position alone. |
+
+Write your own by extending `EventSnapStrategy`. Give the class value equality, comparing on `runtimeType` so a subclass of yours does not compare equal to it, because `CalendarSnapping` is compared with `==` to decide whether a change reaches the calendar.
+
+<!-- snippet: file -->
+```dart
+/// Snaps to the nearest quarter hour, ignoring the configured interval.
+class QuarterHourSnap extends EventSnapStrategy {
+  const QuarterHourSnap();
+
+  @override
+  InternalDateTime snap({
+    required InternalDateTime cursorDate,
+    required InternalDateTime startOfDay,
+    required int snapIntervalMinutes,
+  }) {
+    final minutes = cursorDate.difference(startOfDay).inMinutes;
+    return startOfDay.add(Duration(minutes: (minutes / 15).round() * 15));
+  }
+
+  @override
+  bool operator ==(Object other) => other.runtimeType == runtimeType;
+
+  @override
+  int get hashCode => (QuarterHourSnap).hashCode;
+}
+```
+
+<!-- snippet: continues -->
+```dart
+final body = CalendarBody(
+  snapping: const CalendarSnapping(eventSnapStrategy: QuarterHourSnap()),
+);
+```
+
+`snapToTimeIndicator` and `snapToOtherEvents` are applied separately from the strategy, so they keep working whichever one you use.
+
 ---
 
 ## Locking a single event


### PR DESCRIPTION
Re-opens #437 against `main`. Its content never reached main.

#437 was stacked on `fix/release-review-followups` (#435). #435 merged into main first, then #437 merged into `fix/release-review-followups`, which by then was no longer going anywhere. GitHub reports #437 as merged and it is, into a branch that had already been absorbed. This is the same commit, cherry-picked onto main.

Verifiable: main has 47 doc snippets and neither new section, this branch has 50 and both.

## What it adds

**`doc/events.md` never explained the copy contract in prose,** and `withDateTimeRange` appeared nowhere under `doc/` — the method the calendar calls on every drag and the one an app calls to move an event. A new "The copy contract" section covers `withDateTimeRange`, `copyWithData` and `carryOver`, plus the two ways a missing hook is reported.

**`doc/interaction.md` named only `EventSnapStrategy.interval()`.** `EventSnapStrategy.none()` is new in this release and was undocumented, and the README already advertises snapping to "your own rule" with no guide showing how. A new "Snapping strategies" section lists both built-ins and shows a worked custom strategy including the `runtimeType` comparison.

## Verification

- All 50 doc snippets compile, up from 47 on main.
- 1491 tests pass, `dart analyze` clean.