### PR TITLE
chore: bump version to 0.26.0-dev.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A highly customizable Flutter calendar widget with Day, Multi-day, Month and Sch
 - **MIT licensed.** No commercial license to buy.
 
 > [!WARNING]
-> This package is still in development, so breaking changes land in minor releases until 1.0.0. A caret range like `^0.25.0` keeps you on 0.25.x, which is where fixes land. Every minor bump has an entry in the [migration guide](MIGRATION.md).
+> This package is still in development, so breaking changes land in minor releases until 1.0.0. A caret range like `^0.26.0` keeps you on 0.26.x, which is where fixes land. Every minor bump has an entry in the [migration guide](MIGRATION.md).
 >
 > If part of the API does not work for you, please [open an issue](https://github.com/werner-scholtz/kalender/issues).
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.25.0
+version: 0.26.0-dev.1
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
Stacked on #438. Everything needed for the 0.26.0 pre-release except the tag, which stays yours.

## What changes

- `pubspec.yaml`: `version: 0.25.0` → `0.26.0-dev.1`
- `README.md` line 42: the example caret range `^0.25.0` → `^0.26.0`

The CHANGELOG heading stays `## 0.26.0`. That matches `v0.25.0-dev.1`, which shipped with `version: 0.25.0-dev.1` against a `## 0.25.0` heading: the section documents the release, not each dev iteration.

## The publish gates

`publish.yml` checks three things on a tag push. Simulated against this branch:

| Gate | Result |
| --- | --- |
| Tag matches `v[0-9]+.[0-9]+.[0-9]+*` | `v0.26.0-dev.1` matches |
| Tag commit is an ancestor of `main` | satisfied once this merges |
| `pubspec.yaml` version equals the tag minus `v` | `0.26.0-dev.1` = `0.26.0-dev.1` |

## Verification

- `dart analyze` clean, 1491 tests pass, all 50 doc snippets compile.
- `flutter pub publish --dry-run` reports **1 warning**: `CHANGELOG.md doesn't mention current version (0.26.0-dev.1)`. Expected, and the same warning `v0.25.0-dev.1` shipped with, for the reason above.

## After merging

```bash
git tag -m v0.26.0-dev.1 v0.26.0-dev.1 && git push origin v0.26.0-dev.1
```

pub.dev never resolves a pre-release as `latest`, so `dart pub add kalender` is unaffected and people opt in with `kalender: ^0.26.0-dev.1`.