### PR TITLE
chore: bump version to 0.26.0-dev.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A highly customizable Flutter calendar widget with Day, Multi-day, Month and Sch
 - **MIT licensed.** No commercial license to buy.
 
 > [!WARNING]
-> This package is still in development, so breaking changes land in minor releases until 1.0.0. A caret range like `^0.25.0` keeps you on 0.25.x, which is where fixes land. Every minor bump has an entry in the [migration guide](MIGRATION.md).
+> This package is still in development, so breaking changes land in minor releases until 1.0.0. A caret range like `^0.26.0` keeps you on 0.26.x, which is where fixes land. Every minor bump has an entry in the [migration guide](MIGRATION.md).
 >
 > If part of the API does not work for you, please [open an issue](https://github.com/werner-scholtz/kalender/issues).
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.25.0
+version: 0.26.0-dev.1
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
Sets the package version to `0.26.0-dev.1` and updates the caret range the README uses as an example to `^0.26.0`.

This is the pre-release of the 0.26.0 work. pub.dev never resolves a pre-release as `latest`, so an existing `^0.25.0` range is unaffected and people opt in with `kalender: ^0.26.0-dev.1`.

Re-opens #439, whose commit landed on an already-absorbed branch rather than main.
