### PR TITLE
docs: cut the two new guide sections down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ See [MIGRATION.md](MIGRATION.md#v025x--v0260) for what to change.
 ### Features
 
 - `EventSnapStrategy.none()` leaves a dragged event where the cursor is, without needing a hand-written strategy.
-- The guides cover the release's new API: the copy contract and `withDateTimeRange` in the Events guide, the snap strategies and how to write one in the Interaction guide, and both layout strategies in the Layout guide.
 - `meta` is a direct dependency at `^1.9.0`, the version that introduced `@mustBeOverridden`. The floor is that version rather than the resolved one, so it does not narrow what a consumer can resolve.
 - `defaultMultiDayFrameGenerator` stays public, so a custom `MultiDayLayoutStrategy` can reuse the built-in row assignment and change only the order events are placed in, through the `eventComparator` the strategy itself does not expose.
 

--- a/doc/events.md
+++ b/doc/events.md
@@ -70,21 +70,7 @@ class Event extends CalendarEvent {
 
 ### The copy contract
 
-The calendar copies an event whenever it is dragged or resized. It calls `withDateTimeRange`, which you do not override:
-
-<!-- snippet: statements -->
-```dart
-final event = eventsController.byId(someId)! as Event;
-final moved = event.withDateTimeRange(
-  DateTimeRange(start: DateTime.utc(2025, 8, 12, 9), end: DateTime.utc(2025, 8, 12, 10)),
-) as Event;
-```
-
-`withDateTimeRange` calls `copyWithData`, your hook, and then puts back the state `CalendarEvent` itself holds: the `id`, the `interaction` config and the `multiDayRule`. That is why `copyWithData` lists only the fields your subclass adds. A field added to `CalendarEvent` in a later release reaches your subclass without you changing anything.
-
-Two things report a missing hook. `copyWithData` is annotated `@mustBeOverridden`, so the analyzer flags a subclass without one before you run anything, and a debug assert names the type on the first drag if the warning is ignored.
-
-`carryOver` is the part that restores the base state. Call it from a copy method of your own so those copies keep their identity too, as the example above does.
+The calendar calls `withDateTimeRange` on every drag and resize. It calls your `copyWithData`, then restores the `id`, `interaction` and `multiDayRule` that `CalendarEvent` holds, which is why `copyWithData` lists only your own fields. Call `carryOver` from a copy method of your own to get the same. A subclass with no `copyWithData` is flagged by the analyzer, since it is `@mustBeOverridden`.
 
 ### Updating events
 

--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -48,47 +48,9 @@ CalendarBody(
 
 ### Snapping strategies
 
-`eventSnapStrategy` decides where a dragged event lands. Two are built in:
+`eventSnapStrategy` decides where a dragged event lands. `EventSnapStrategy.interval()`, the default, snaps to the nearest multiple of `snapIntervalMinutes`. `EventSnapStrategy.none()` leaves the cursor position alone. `snapToTimeIndicator` and `snapToOtherEvents` apply either way.
 
-| Strategy | Behaviour |
-| --- | --- |
-| `EventSnapStrategy.interval()` | Snaps to the nearest multiple of `snapIntervalMinutes`, measured from the start of the day. The default. |
-| `EventSnapStrategy.none()` | Leaves the cursor position alone. |
-
-Write your own by extending `EventSnapStrategy`. Give the class value equality, comparing on `runtimeType` so a subclass of yours does not compare equal to it, because `CalendarSnapping` is compared with `==` to decide whether a change reaches the calendar.
-
-<!-- snippet: file -->
-```dart
-/// Snaps to the nearest quarter hour, ignoring the configured interval.
-class QuarterHourSnap extends EventSnapStrategy {
-  const QuarterHourSnap();
-
-  @override
-  InternalDateTime snap({
-    required InternalDateTime cursorDate,
-    required InternalDateTime startOfDay,
-    required int snapIntervalMinutes,
-  }) {
-    final minutes = cursorDate.difference(startOfDay).inMinutes;
-    return startOfDay.add(Duration(minutes: (minutes / 15).round() * 15));
-  }
-
-  @override
-  bool operator ==(Object other) => other.runtimeType == runtimeType;
-
-  @override
-  int get hashCode => (QuarterHourSnap).hashCode;
-}
-```
-
-<!-- snippet: continues -->
-```dart
-final body = CalendarBody(
-  snapping: const CalendarSnapping(eventSnapStrategy: QuarterHourSnap()),
-);
-```
-
-`snapToTimeIndicator` and `snapToOtherEvents` are applied separately from the strategy, so they keep working whichever one you use.
+For anything else, extend `EventSnapStrategy` and override `snap`. Compare on `runtimeType` in `==`, as [Layout](layout.md) describes for the layout strategies and for the same reason.
 
 ---
 


### PR DESCRIPTION
Trims the copy contract section in the Events guide and the snapping strategies section in the Interaction guide to a paragraph each, and drops the changelog line that announced them.

No API or behaviour change. Both sections said in twenty lines what fits in four: the copy contract needs the three member names and why the hook lists only the subclass's own fields, and snapping needs the two built-ins and a pointer to the equality pattern the Layout guide already covers.