### PR TITLE
chore: release 0.26.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.26.0-dev.1
+version: 0.26.0
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
Sets the version to `0.26.0`, dropping the `-dev.1` suffix.

Promotes the pre-release to the final. The README caret range is already `^0.26.0` and the changelog section is already headed `0.26.0`, so this is the version line only.