### PR TITLE
fix: a week view honours numberOfDays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,13 +274,11 @@ before tagging it:
   `MultiDayBodyConfiguration` in favour of `VerticalConfiguration`. Find them
   with `grep -rn "TODO" lib/`. They are `//` comments so they do not render as
   prose in the API reference, but each one is a decision still owed.
-- **Deprecations past their window.** The style fields on `CalendarComponents`
-  are removed in 0.26.0, which their shipped deprecation message names. The seven
-  style container classes those fields reached go in the same release, with no
-  deprecation of their own, since nothing public reaches them once the fields are
-  gone. `OverlayStyles` is not one of them and stays, since
-  `MultiDayOverlayPortalBuilder` names it. See
-  [Verifying a removal](#verifying-a-removal).
+- **Deprecations past their window.** `TimeOfDayRange.isAllDay` is removed in
+  0.27.0, which its 0.26.0 deprecation message names. `coversWholeDay` replaces
+  it, and it is the only `@Deprecated` left in `lib/`. The style fields on
+  `CalendarComponents` and the seven style container classes they reached were
+  removed in 0.26.0. See [Verifying a removal](#verifying-a-removal).
 - **Function fields compared with `==`.** `ViewConfiguration.nowCallback` is the
   one left. It takes part in equality, so a closure written inline is a new
   function every build and defeats the caching the comparison exists to enable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,59 +1,57 @@
-## 0.27.0
-
-### Features
-
-- `CalendarEvent.isAllDay` states that an event occupies whole days rather than a span of time. True places it in the multi-day header lane whatever its duration and consults no `MultiDayRule`, which is the case no rule could express: an hour-long event inside one calendar day needed an override of `spansMultipleDays` before. False, the default, leaves the decision where it was, so nothing changes for an event that does not set it. The date range is untouched, and the flag is carried across drags and resizes by `carryOver` like `id` and `multiDayRule`. It joins `layoutEquals` and `hashCode`, since it decides which lane the tile renders in.
-
-### Deprecations
-
-- `TimeOfDayRange.isAllDay` is renamed to `coversWholeDay` and will be removed in 0.28.0. It reports whether the range runs from 00:00 to 23:59, which is about the hours the body lays out rather than about an event, and the old name is wanted for `CalendarEvent.isAllDay`. `TimeOfDayRange.allDay()` is unchanged.
-
 ## 0.26.0
 
 See [MIGRATION.md](MIGRATION.md#v025x--v0260) for what to change.
 
 ### Breaking Changes
 
-- The style fields on `CalendarComponents` are removed, as their 0.25.0 deprecation message named. `monthComponentStyles`, `multiDayComponentStyles`, `scheduleComponentStyles` and `overlayStyles` are gone from the constructor, `copyWith`, `==` and `hashCode`. Use `KalenderThemeData` for the whole app, or wrap a calendar in `KalenderTheme` to scope it. `CalendarComponents` keeps its builder fields. See [MIGRATION.md](MIGRATION.md#v025x--v0260).
-- `eventLayoutStrategy`, `generateMultiDayLayoutFrame` and `eventSnapStrategy` are classes rather than function typedefs. Each has value equality and named factories for the built-ins: `EventLayoutStrategy.overlap()` and `.sideBySide()`, `MultiDayLayoutStrategy.byDuration()`, and `EventSnapStrategy.interval()`. A configuration holding one of these written as an inline closure was a new value on every build, so the calendar read every rebuild as a change, and for the multi-day frame that cleared the layout frame cache and regenerated every row. A function cannot be deprecated into a class, so these change without a window. See [MIGRATION.md](MIGRATION.md#v025x--v0260). [#380](https://github.com/werner-scholtz/kalender/issues/380)
-- `HorizontalConfiguration.generateMultiDayLayoutFrame` is renamed to `multiDayLayoutStrategy` and is no longer nullable. It defaults to `MultiDayLayoutStrategy.byDuration()`, which is what `null` selected before.
-- `CalendarEvent.copyWith` is removed. A subclass overrode it and had to forward by hand every field the base class carries but takes no parameter for, which was `id` and, since 0.24.0, `multiDayRule`. Forgetting one produced a copy the calendar read as a different event, or one that lost its rule, and adding a field to the base class broke every subclass at once without a compile error. Override `copyWithData` instead and rebuild only what your subclass adds. The calendar calls `withDateTimeRange`, which applies the hook and then restores the base state through `carryOver`. A missing hook is reported by the analyzer through `@mustBeOverridden`, and by a debug assert on the first drag for anyone who ignores the warning. Your own `copyWith` is no longer an override, so it can take whatever parameters suit you. See [MIGRATION.md](MIGRATION.md#v025x--v0260).
-- `CalendarEvent.interaction` and `CalendarEvent.multiDayRule` are getters rather than fields, so `carryOver` can restore them. Reading either is unchanged. Neither was assignable before.
-- `HourLines.fromContext` no longer takes a `style` argument. It resolved the style from the theme and discarded whatever was passed, so the argument silently did nothing, but removing it stops a call that named it from compiling. `timelineStyle` is unaffected. See [MIGRATION.md](MIGRATION.md#v025x--v0260).
-- The seven style container classes reached through those fields are removed with them: `MonthComponentStyles`, `MonthBodyComponentStyles`, `MonthHeaderComponentStyles`, `MultiDayComponentStyles`, `MultiDayBodyComponentStyles`, `MultiDayHeaderComponentStyles` and `ScheduleComponentStyles`. Nothing public reached them once the fields were gone, so they carry no deprecation of their own. `OverlayStyles` is not one of them and stays, since `MultiDayOverlayPortalBuilder` names it.
+- The style fields on `CalendarComponents` are removed, as their 0.25.0 deprecation named: `monthComponentStyles`, `multiDayComponentStyles`, `scheduleComponentStyles` and `overlayStyles`, along with their constructor and `copyWith` parameters and their places in `==` and `hashCode`. Use `KalenderThemeData`, or `KalenderTheme` to scope it to one calendar. The builder fields stay.
+- The seven style container classes those fields reached go with them: `MonthComponentStyles`, `MonthBodyComponentStyles`, `MonthHeaderComponentStyles`, `MultiDayComponentStyles`, `MultiDayBodyComponentStyles`, `MultiDayHeaderComponentStyles` and `ScheduleComponentStyles`. `OverlayStyles` stays, since `MultiDayOverlayPortalBuilder` names it.
+- `eventLayoutStrategy`, `generateMultiDayLayoutFrame` and `eventSnapStrategy` are classes rather than function typedefs, each with value equality and named factories for the built-ins: `EventLayoutStrategy.overlap()` and `.sideBySide()`, `MultiDayLayoutStrategy.byDuration()`, and `EventSnapStrategy.interval()`. A function cannot be deprecated into a class, so there is no window. [#380](https://github.com/werner-scholtz/kalender/issues/380)
+- `HorizontalConfiguration.generateMultiDayLayoutFrame` is renamed to `multiDayLayoutStrategy` and is no longer nullable. It defaults to `MultiDayLayoutStrategy.byDuration()`, which `null` selected before.
+- `CalendarEvent.copyWith` is removed. Override `copyWithData` instead and rebuild only what your subclass adds. The calendar calls `withDateTimeRange`, which applies that hook and then restores `id`, `interaction`, `multiDayRule` and `isAllDay` through `carryOver`. A missing hook is reported by `@mustBeOverridden` at analysis time and by a debug assert on the first drag. Your own `copyWith` is no longer an override, so it can take whatever parameters suit you.
+- `CalendarEvent.interaction` and `CalendarEvent.multiDayRule` are getters rather than fields. Reading either is unchanged, and neither was assignable before.
+- `HourLines.fromContext` no longer takes a `style` argument. It resolved the style from the theme and discarded what was passed. `timelineStyle` is unaffected.
 
 ### Behavior Changes
 
-- A custom component builder is handed the theme-resolved style rather than an empty one. A builder previously received whatever the deprecated container carried, which was an empty style unless the app had set one, so `style?.textStyle ?? myFallback` reached `myFallback`. The same argument now arrives populated from the theme, so a builder written that way renders with the theme value instead of its own fallback. Read the fields you want to override rather than falling back on null. This affects `dayHeaderBuilder`, `daySeparator`, `hourLines`, `monthDayHeaderBuilder`, `monthGridBuilder`, `timeIndicator`, `timeline`, `weekDayHeaderBuilder`, `weekNumberBuilder` and `leadingDateBuilder`. See [MIGRATION.md](MIGRATION.md#v025x--v0260).
-- `MultiDayOverlayPortalBuilder` receives a populated `OverlayStyles` for the same reason, built by the new `OverlayStyles.fromContext`. That typedef takes no `BuildContext`, so it cannot resolve the theme itself.
-- `KalenderThemeData.weekNumberStyle.alignment` now reaches the month week number. It had no effect there, because the month body passed its own top alignment to the widget and a passed style wins over the theme, so the only way to change it was the deprecated `CalendarComponents` style path. The month still sits at the top when nothing asks otherwise. A calendar that set this on the theme and relied on the month ignoring it will see the month week number move. [#423](https://github.com/werner-scholtz/kalender/pull/423)
-- A custom `weekNumberBuilder` receives the same fully resolved style in the month header as in the month body. The header's spacer passed the style through unresolved, so the two disagreed. [#423](https://github.com/werner-scholtz/kalender/pull/423)
+- A custom component builder receives the theme-resolved style rather than an empty one, so `style?.textStyle ?? myFallback` reaches the theme value where it used to reach the fallback. Read the fields you want to override rather than falling back on null. This affects `dayHeaderBuilder`, `daySeparator`, `hourLines`, `monthDayHeaderBuilder`, `monthGridBuilder`, `timeIndicator`, `timeline`, `weekDayHeaderBuilder`, `weekNumberBuilder` and `leadingDateBuilder`.
+- `MultiDayOverlayPortalBuilder` receives a populated `OverlayStyles`, built by the new `OverlayStyles.fromContext`.
+- `KalenderThemeData.weekNumberStyle.alignment` reaches the month week number, which ignored it before. The month still sits at the top by default, so only a calendar that set a non-default alignment moves. [#423](https://github.com/werner-scholtz/kalender/pull/423)
+- A custom `weekNumberBuilder` receives the same resolved style in the month header as in the month body. [#423](https://github.com/werner-scholtz/kalender/pull/423)
 
 ### Features
 
-- `EventSnapStrategy.none()` leaves a dragged event where the cursor is, without needing a hand-written strategy.
-- `meta` is a direct dependency at `^1.9.0`, the version that introduced `@mustBeOverridden`. The floor is that version rather than the resolved one, so it does not narrow what a consumer can resolve.
-- `defaultMultiDayFrameGenerator` stays public, so a custom `MultiDayLayoutStrategy` can reuse the built-in row assignment and change only the order events are placed in, through the `eventComparator` the strategy itself does not expose.
+- `CalendarEvent.isAllDay` places an event in the multi-day header lane whatever its duration, with no `MultiDayRule` consulted. It defaults to false, leaves the date range untouched, is carried across drags and resizes by `carryOver`, and takes part in `layoutEquals` and `hashCode`.
+- `PageIndexCalculator` and its subclasses are exported. `ViewConfiguration.pageIndexCalculator` returns the type, which an app had no way to name. [#444](https://github.com/werner-scholtz/kalender/issues/444)
+- `EventSnapStrategy.none()` leaves a dragged event where the cursor is.
+- `defaultMultiDayFrameGenerator` stays public, so a custom `MultiDayLayoutStrategy` can reuse the built-in row assignment and change only the order events are placed in.
+- `meta` is a direct dependency at `^1.9.0`, the version that introduced `@mustBeOverridden`.
+
+### Deprecations
+
+- `TimeOfDayRange.isAllDay` is renamed to `coversWholeDay` and will be removed in 0.27.0. It reports whether the range runs from 00:00 to 23:59, and the old name is wanted for `CalendarEvent.isAllDay`. `TimeOfDayRange.allDay()` is unchanged.
 
 ### Fixes
 
-- The month week number gutter and the multi-day timeline are measured once above both the header and the body, so the two halves cannot be given different widths. This covers all six readers: the drawn gutter, the header's spacer, the drag target's spacer, and the labels inside the gutter, which are laid out with the style the box was measured from. Each is drawn in the body and reserved again in the header, and both used to resolve their style from their own position in the tree. A `KalenderTheme` scoped to only one half moved one and left the other behind, which shifted every day column out of line with its header. A scoped `weekNumberStyle` or `timelineStyle` that the calendar has to ignore is now reported in debug builds.
-- The week number label is centred when the visible range crosses a week boundary. The gutter is sized by the timeline rather than by the label, so `32 - 33` wraps, and the short second line sat against the leading edge. [#427](https://github.com/werner-scholtz/kalender/pull/427)
-- A custom `multiDayOverlayBuilder` or `multiDayPortalOverlayButtonBuilder` receives the style resolved from the theme. Neither typedef takes a `BuildContext`, so neither can resolve it itself.
-- The overlay styles are resolved once, where a custom overlay builder needs them, rather than at four call sites in the header and the month body. The pair used to be built eagerly on every header and month week build, carried through three widgets, and merged at the end with the identical value the built-in overlay widgets resolve for themselves. Nothing is passed to those now, and a custom builder is handed the pair only when a column actually overflows. `MultiDayOverlayPortal.overlayStyles` is optional, where null leaves each overlay widget to resolve its own.
-- The Material defaults are built once per `ThemeData` rather than on every theme lookup. `KalenderTheme.of` runs on nearly every widget build and rebuilt thirteen style objects each time, which the month view did twice per day cell and the schedule view once per row. The cache is keyed weakly on the theme, so an entry is collected with the theme it belongs to.
-- A schedule row resolves the theme only when it reads one of the two styles that need it. A month separator row reads neither and paid for a full resolution regardless.
-- `MultiDayBodyConfiguration.keepPagesAlive` takes part in `==` and `hashCode`. It is declared on that class rather than the `VerticalConfiguration` base, and the inherited equality did not reach it, so changing only that value did not reach the calendar.
-- `MonthBodyConfiguration` and `MultiDayHeaderConfiguration` no longer compare equal to each other. Both extend `HorizontalConfiguration` and add no equality of their own, and its `==` tested only `other is HorizontalConfiguration` with no runtime type check. The same applied to `VerticalConfiguration`.
-- `MultiDayViewConfiguration.nowCallback` is included in `hashCode`, where it already took part in `==`. Unequal objects may share a hash, so nothing was broken, but the other two configurations include it.
+- `MultiDayViewConfiguration.week` and `.workWeek` honour `numberOfDays`. Both built their page index calculator with a hardcoded 7 and 5, so the body laid out `numberOfDays` columns under a header showing a full week, and every column sat out of line with its header. Both take 1 through 7, which shortens the page and leaves the weekly pagination alone. `copyWith` carries the value, where it reset it to the default before. [#444](https://github.com/werner-scholtz/kalender/issues/444)
+- The month week number gutter and the multi-day timeline are measured once above both the header and the body, so the two halves cannot be given different widths. A `KalenderTheme` scoped to one half moved it and left the other behind, which put every day column out of line with its header. A scoped `weekNumberStyle` or `timelineStyle` the calendar has to ignore is now reported in debug builds.
+- The week number label is centred when the visible range crosses a week boundary. The gutter is sized by the timeline rather than by the label, so `32 - 33` wraps and the short second line sat against the leading edge. [#427](https://github.com/werner-scholtz/kalender/pull/427)
+- A custom `multiDayOverlayBuilder` or `multiDayPortalOverlayButtonBuilder` receives the style resolved from the theme.
+- The overlay styles are resolved once, where a custom overlay builder needs them, rather than at four call sites in the header and the month body. `MultiDayOverlayPortal.overlayStyles` is optional, where null leaves each overlay widget to resolve its own.
+- The Material defaults are built once per `ThemeData` rather than on every `KalenderTheme.of` call, which runs on nearly every widget build. The cache is keyed weakly on the theme.
+- A schedule row resolves the theme only when it reads one of the two styles that need it.
+- `MultiDayBodyConfiguration.keepPagesAlive` takes part in `==` and `hashCode`, so changing only that value reaches the calendar.
+- `MonthBodyConfiguration` and `MultiDayHeaderConfiguration` no longer compare equal to each other, and the same for the two `VerticalConfiguration` subclasses. The base `==` tested only `other is HorizontalConfiguration` with no runtime type check.
+- `MultiDayViewConfiguration.nowCallback` is included in `hashCode`, where it already took part in `==`.
 
 ### Tests
 
-- Added coverage for the copy contract: a moved event keeps the identity, interaction config and rule its subclass never mentions, the copy is the subclass's own type, a subclass with no hook is named by the assert, a `copyWith` of the subclass's own keeps the base state through `carryOver`, and the events controller still finds a dragged event by its id.
-- Added coverage for `multiDayOverlayPortalBuilder`, which had none: a custom portal builder is handed styles resolved from the theme, a scoped theme reaches it, and the built-in overlay still follows a scoped theme with nothing passed to it, across the `Overlay` boundary it is built into.
-- Added coverage that a `KalenderTheme` scoped to the body cannot move the month week number gutter or the multi-day timeline away from what the header reserves, that a theme above the calendar still reaches both, and that an ignored scoped value is reported once rather than on every frame.
-- Added coverage that the drag target's gutter spacer matches the drawn gutter and that the timeline labels fit the box measured for them, both under a body-scoped theme, and that a custom overlay builder and a custom overflow button builder each receive the resolved style.
-- Added equality coverage for the three strategy classes: two of a kind compare equal with matching hash codes, the built-ins differ from each other, a subclass of a built-in is not equal to it, a configuration built twice in a row is equal, and changing only the strategy still breaks equality.
+- Added coverage for the copy contract: a moved event keeps the identity, interaction and rule its subclass never mentions, the copy is the subclass's own type, a subclass with no hook is named by the assert, and the events controller still finds a dragged event by its id.
+- Added coverage for `multiDayOverlayPortalBuilder`, which had none, across the `Overlay` boundary it is built into.
+- Added coverage that a `KalenderTheme` scoped to the body cannot move the month week number gutter or the multi-day timeline away from what the header reserves, and that an ignored scoped value is reported once rather than on every frame.
+- Added coverage that the drag target's gutter spacer matches the drawn gutter and that the timeline labels fit the box measured for them.
+- Added equality coverage for the three strategy classes.
+- Added coverage for a shortened week: the page length, that the pagination stays weekly, that `copyWith` carries the value, and that the header renders that many day headers.
 
 ## 0.25.0
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,9 +48,9 @@ One unrelated removal rides along, because 0.24.0 promised it here. **`CalendarE
 
 ### 0.26.0, the styles and the copy contract
 
-Three items, all breaking. The first is contractual: the deprecation message shipped in 0.25.0 names this release by number, so it is the one item here that has a deadline rather than an argument.
+Three breaking items, plus the all-day flag and one fix that arrived while the release was still open. The first is contractual: the deprecation message shipped in 0.25.0 names this release by number, so it is the one item here that has a deadline rather than an argument.
 
-The all-day flag and the `spansMultipleDays` shortener moved to 0.27.0. They add public API and teach a new concept, which does not belong in the same migration guide as the two largest removals the package has done. 0.24.0 shipped ten breaking changes and the section above already calls that worth not repeating.
+The all-day flag was scoped out to 0.27.0, on the argument that new public API does not belong in the same migration guide as the two largest removals the package has done. It came back. Only `0.26.0-dev.1` ever reached pub.dev, so the release was still open when the flag merged, and nothing about it is breaking, so it costs the migration guide nothing.
 
 **1. The deprecated style fields on `CalendarComponents` are removed.** Four fields, along with their constructor and `copyWith` parameters and their places in `==` and `hashCode`. Larger than the deprecation implied: 25 read sites across 17 files, most of them the `fromContext` helpers on the component widgets. The seven container classes reached through those fields go with them, which empties `month_styles.dart`, `multi_day_styles.dart` and `schedule_styles.dart`. Only the fields carry a deprecation, so the classes are removed without a window of their own. Once the fields are gone nothing public reaches them, so a window would protect a type annotation and nothing else.
 
@@ -74,11 +74,7 @@ The all-day flag and the `spansMultipleDays` shortener moved to 0.27.0. They add
 
   Two equality gaps turned up while checking, both unrelated to function fields and neither breaking. `MultiDayBodyConfiguration.keepPagesAlive` is not covered by the equality it inherits, and the body and header configuration base classes test only `other is X` with no runtime type check, so two different configuration types with matching fields can compare equal.
 
-### 0.27.0, the event model
-
-Scoped for 0.26.0 and moved out to keep that release to one migration. Not blocked by anything except the copy contract above.
-
-**Whether an event is all-day becomes something you can state.** The calendar inferred it from duration through `MultiDayRule`, and the per-event rule override doubled as the way to force it, which that field's own documentation admitted when it described an event "all-day by nature rather than by duration". That never worked for the case it named: an event under 24 hours inside one calendar day satisfies neither built-in rule, so forcing it meant overriding `spansMultipleDays`.
+**4. Whether an event is all-day becomes something you can state.** The calendar inferred it from duration through `MultiDayRule`, and the per-event rule override doubled as the way to force it, which that field's own documentation admitted when it described an event "all-day by nature rather than by duration". That never worked for the case it named: an event under 24 hours inside one calendar day satisfies neither built-in rule, so forcing it meant overriding `spansMultipleDays`.
 
   `CalendarEvent.isAllDay` states it. A plain `bool` defaulting to false, so nothing changes for an event that does not set it. True means the multi-day header lane whatever the duration, with no rule consulted. A nullable tri-state was rejected: "not all-day" and "no opinion" want the same answer, since an event spanning several days has to stay in the header either way. The date range is untouched, and `carryOver` carries the flag across drags like `id` and `multiDayRule`, so it is not a third field to forward by hand.
 
@@ -86,11 +82,19 @@ Scoped for 0.26.0 and moved out to keep that release to one migration. Not block
 
   The ICS example needed more than first recorded. RFC 5545 encodes all-day as a date-valued `DTSTART`, but the `isAllDayEvent` getter on `enough_icalendar` reads a proprietary Microsoft property instead, so the standard signal is read off the value type of the property. The example discarded it at parse time and exported an all-day event as a timed one. It now maps to `isAllDay` and writes `VALUE=DATE` back out, a date-valued `DTSTART` with no `DTEND` lasts one day rather than one hour, and `sample.ics` carries one.
 
-A second item, a shorter way to call `spansMultipleDays`, is dropped. Every verbose call site is inside the package, and the shortest form needs a `BuildContext` that two of the eight sites do not have. Making `defaultRule` optional is the only shape that reads shorter everywhere, and omitting it would silently substitute the package default for the calendar's own rule, which compiles and renders wrong. What is left is an internal tidy-up with no public API in it.
+  A shorter way to call `spansMultipleDays` was scoped alongside the flag and is dropped. Every verbose call site is inside the package, and the shortest form needs a `BuildContext` that two of the eight sites do not have. Making `defaultRule` optional is the only shape that reads shorter everywhere, and omitting it would silently substitute the package default for the calendar's own rule, which compiles and renders wrong. What is left is an internal tidy-up with no public API in it.
 
-### 0.28.0, the builders take a context
+**5. A week view honours `numberOfDays`.** [#444](https://github.com/werner-scholtz/kalender/issues/444). `MultiDayViewConfiguration.week` and `.workWeek` both took the parameter and built their page index calculator with a hardcoded 7 and 5, so the body laid out `numberOfDays` columns under a header showing the hardcoded count, and every column sat out of line with its header. `WeekIndexCalculator` already carries `daysToDisplay`, which shortens the page and leaves the weekly pagination alone, so the fix is to pass the value in. `copyWith` dropped it too.
+
+  `PageIndexCalculator` is exported with it, the second half of the same issue. `ViewConfiguration.pageIndexCalculator` returns the type, so it was already public with no way for an app to name it.
+
+  What this does not do is let an app pick arbitrary visible days. See [#90](https://github.com/werner-scholtz/kalender/issues/90) below.
+
+### 0.27.0, the builders take a context
 
 One break, across the widest customisation surface the package has. It gets a release of its own rather than riding along with model changes, and it happens before 1.0.0 because a freeze would put it behind a 2.0.0.
+
+`TimeOfDayRange.isAllDay` is removed here, as its 0.26.0 deprecation message names. `coversWholeDay` replaces it.
 
 **Every builder typedef takes a `BuildContext`.** Fourteen of the fifteen builder typedefs that carry a style take none, so a custom builder cannot call `KalenderTheme.of` and resolve anything for itself. The package has to resolve on its behalf and pass the result in, which is the only reason a style parameter sits on those signatures at all.
 
@@ -151,10 +155,16 @@ Selection is the thread through the middle three. There is no `selectedDate` on 
 
 | Issue | Shape |
 |---|---|
-| [#90](https://github.com/werner-scholtz/kalender/issues/90) hide and show weekends | A view configuration option. Changes which dates a page carries, so it reaches the date arithmetic rather than only the layout. |
+| [#90](https://github.com/werner-scholtz/kalender/issues/90) hide and show weekends | A set of visible weekdays on the view configuration. Changes which dates a page carries, so it reaches the date arithmetic rather than only the layout. Scoped below. |
 | [#98](https://github.com/werner-scholtz/kalender/issues/98) named and uneditable time regions | A second thing the calendar draws besides events, that events sit on top of. The largest new model here. |
 | [#259](https://github.com/werner-scholtz/kalender/issues/259) drag to create over a locked event | A drag starting on an unmodifiable event should fall through to creation instead of doing nothing. Mostly behavior. |
 | [#280](https://github.com/werner-scholtz/kalender/issues/280) animated transitions between views | Opt-in, default off, reduced-motion aware, wrapping the controller swap in `CalendarView`. |
+
+**Arbitrary visible weekdays, [#90](https://github.com/werner-scholtz/kalender/issues/90), needs the page to stop being one date range.** 0.26.0 covers the contiguous case with `numberOfDays` on `week` and `workWeek`, which is what the reporter of [#444](https://github.com/werner-scholtz/kalender/issues/444) asked for. Every contiguous span starting on `firstDayOfWeek` is expressible that way, so what a set of weekdays adds is the non-contiguous case, Monday, Wednesday and Friday, and a span that starts somewhere other than `firstDayOfWeek`.
+
+That is not a parameter. A page is a contiguous `DateTimeRange` throughout the package, and a day's index within that range is what maps to pixels. Six places do that arithmetic: `event_tile_utils.dart` turns a drag position into a date by dividing by the column count and indexing the range's dates, the multi-day event widget and both layout strategies place a header tile by its first and last day index, the day separator count and the time indicator both derive from the column count, and the free-scroll band is built on day index equalling pixel offset. Each needs a column-to-date mapping instead. `CalendarController.visibleDateTimeRange` and the `onPageChanged` callback are a single range, which a gapped page makes untrue, and both are public. The events controller fetches by range, so hidden-day events arrive and have to be dropped per column. An app asking for Monday to Saturday most likely wants the month grid at six columns too, which reaches the month body, the week number gutter and the row-count logic in `MonthIndexCalculator`.
+
+One design question comes first: does a hidden day vanish, leaving six columns, or is it skipped, leaving a page that still spans seven calendar days with six drawn? The two are the same for Monday to Saturday and differ for Monday, Wednesday and Friday, and the answer decides what `visibleDateTimeRange` reports. Adding the set later costs no deprecation, since `numberOfDays` can be derived from its length.
 
 Multi-column days, so several calendars can sit side by side within one day, is not filed yet and belongs in the first group.
 

--- a/doc/views.md
+++ b/doc/views.md
@@ -41,8 +41,8 @@ Displays one or more days with time on the vertical axis.
 | Constructor                                             | Description                                    |
 | -------------------------------------------------------- | ---------------------------------------------- |
 | `MultiDayViewConfiguration.singleDay()`                  | Single day                                     |
-| `MultiDayViewConfiguration.week()`                       | Full 7-day week                                |
-| `MultiDayViewConfiguration.workWeek()`                   | Monday to Friday                               |
+| `MultiDayViewConfiguration.week()`                       | A week, 7 days by default                      |
+| `MultiDayViewConfiguration.workWeek()`                   | Monday to Friday, 5 days by default            |
 | `MultiDayViewConfiguration.custom(numberOfDays: n)`      | Custom number of days                          |
 | `MultiDayViewConfiguration.freeScroll(numberOfDays: n)`  | Scrolls freely across days, without page snaps |
 
@@ -52,6 +52,7 @@ These views also control which hours exist, where the day opens vertically, and 
 - `initialTimeOfDay`: the time at the top of the viewport on first render. Defaults to midnight, so set it to the hour your users actually start at or the calendar opens on empty overnight hours. The offset is measured from `timeOfDayRange.start`, so keep this value inside the range.
 - `initialHeightPerMinute`: the starting zoom, in logical pixels per minute. Defaults to `0.7`, giving a 42 pixel hour. Change it later through the controller, see [Zoom](interaction.md#zoom).
 - `firstDayOfWeek`: which day a week starts on, as `DateTime.monday` through `DateTime.sunday`. Defaults to `DateTime.monday`. Applies to `week`, `singleDay` and `custom`. `workWeek` and `freeScroll` fix it themselves.
+- `numberOfDays`: how many days a page shows. `week` and `workWeek` take 1 through 7 and drop days off the end of the page without changing the pagination, so `week(numberOfDays: 6)` shows Monday to Saturday and still turns a week at a time. `custom` and `freeScroll` require it and page by it, so they take any number. `singleDay` fixes it at 1.
 
 <!-- snippet: expression -->
 ```dart

--- a/lib/kalender.dart
+++ b/lib/kalender.dart
@@ -32,6 +32,7 @@ export 'package:kalender/src/models/navigation_triggers.dart';
 export 'package:kalender/src/models/time_of_day_range.dart';
 export 'package:kalender/src/models/view_configurations/month_view_configuration.dart';
 export 'package:kalender/src/models/view_configurations/multi_day_view_configuration.dart';
+export 'package:kalender/src/models/view_configurations/page_index_calculator.dart';
 export 'package:kalender/src/models/view_configurations/schedule_view_configuration.dart';
 
 export 'package:kalender/src/models/controllers/events_controller/default_event_store.dart';

--- a/lib/src/models/time_of_day_range.dart
+++ b/lib/src/models/time_of_day_range.dart
@@ -44,7 +44,7 @@ class TimeOfDayRange {
   /// Whether this range runs from 00:00 to 23:59.
   bool get coversWholeDay => start.hour == 0 && end.hour == 23 && end.minute == 59;
 
-  @Deprecated('Use coversWholeDay. Will be removed in 0.28.0.')
+  @Deprecated('Use coversWholeDay. Will be removed in 0.27.0.')
   bool get isAllDay => coversWholeDay;
 
   /// Returns a [Duration] representing the time difference between the [start] and [end].

--- a/lib/src/models/view_configurations/month_view_configuration.dart
+++ b/lib/src/models/view_configurations/month_view_configuration.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:kalender/kalender.dart';
-import 'package:kalender/src/models/view_configurations/page_index_calculator.dart';
 
 class MonthViewConfiguration extends ViewConfiguration {
   @override

--- a/lib/src/models/view_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_view_configuration.dart
@@ -104,6 +104,12 @@ class MultiDayViewConfiguration extends ViewConfiguration {
         pageIndexCalculator = PageIndexCalculator.singleDay(displayRange ?? kDefaultRange());
 
   /// Creates a [MultiDayViewConfiguration] for a week.
+  ///
+  /// [numberOfDays] shortens the page without changing the pagination, so 6 with
+  /// a [firstDayOfWeek] of [DateTime.monday] shows Monday to Saturday and still
+  /// turns the page a week at a time. It must be between 1 and 7. Use
+  /// [MultiDayViewConfiguration.custom] for a page of any other length, which
+  /// pages by [numberOfDays] rather than by the week.
   MultiDayViewConfiguration.week({
     super.name = 'Week',
     super.initialDateTime,
@@ -121,14 +127,23 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     this.scrollResolver,
     this.zoomTransition = ZoomTransition.preserve,
     this.zoomResolver,
-  })  : timeOfDayRange = timeOfDayRange ?? TimeOfDayRange.allDay(),
+  })  : assert(
+          numberOfDays >= 1 && numberOfDays <= DateTime.daysPerWeek,
+          'numberOfDays must be between 1 and 7 for a week view.\n'
+          'Use MultiDayViewConfiguration.custom for a page of any other length.',
+        ),
+        timeOfDayRange = timeOfDayRange ?? TimeOfDayRange.allDay(),
         type = MultiDayViewType.week,
         pageIndexCalculator = PageIndexCalculator.week(
           displayRange ?? kDefaultRange(),
           firstDayOfWeek,
+          daysToDisplay: numberOfDays,
         );
 
   /// Creates a [MultiDayViewConfiguration] for a work week.
+  ///
+  /// [numberOfDays] shortens the page without changing the pagination, which
+  /// starts every page on a Monday. It must be between 1 and 7.
   MultiDayViewConfiguration.workWeek({
     super.name = 'Work Week',
     super.initialDateTime,
@@ -145,10 +160,18 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     this.scrollResolver,
     this.zoomTransition = ZoomTransition.preserve,
     this.zoomResolver,
-  })  : timeOfDayRange = timeOfDayRange ?? TimeOfDayRange.allDay(),
+  })  : assert(
+          numberOfDays >= 1 && numberOfDays <= DateTime.daysPerWeek,
+          'numberOfDays must be between 1 and 7 for a work week view.\n'
+          'Use MultiDayViewConfiguration.custom for a page of any other length.',
+        ),
+        timeOfDayRange = timeOfDayRange ?? TimeOfDayRange.allDay(),
         firstDayOfWeek = defaultFirstDayOfWeek,
         type = MultiDayViewType.workWeek,
-        pageIndexCalculator = PageIndexCalculator.workWeek(displayRange ?? kDefaultRange());
+        pageIndexCalculator = PageIndexCalculator.workWeek(
+          displayRange ?? kDefaultRange(),
+          daysToDisplay: numberOfDays,
+        );
 
   /// Creates a [MultiDayViewConfiguration] for a custom number of days.
   MultiDayViewConfiguration.custom({
@@ -252,6 +275,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
           timeOfDayRange: timeOfDayRange0,
           displayRange: displayRange0,
           firstDayOfWeek: firstDayOfWeek0,
+          numberOfDays: numberOfDays ?? this.numberOfDays,
           initialTimeOfDay: initialTimeOfDay0,
           scrollTransition: scrollTransition0,
           scrollResolver: scrollResolver0,
@@ -267,6 +291,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
           nowCallback: nowCallback0,
           timeOfDayRange: timeOfDayRange0,
           displayRange: displayRange0,
+          numberOfDays: numberOfDays ?? this.numberOfDays,
           initialTimeOfDay: initialTimeOfDay0,
           scrollTransition: scrollTransition0,
           scrollResolver: scrollResolver0,

--- a/lib/src/models/view_configurations/page_index_calculator.dart
+++ b/lib/src/models/view_configurations/page_index_calculator.dart
@@ -38,13 +38,30 @@ abstract class PageIndexCalculator {
   }
 
   /// Creates a [PageIndexCalculator] for a week [MultiDayViewConfiguration.week].
-  factory PageIndexCalculator.week(DateTimeRange dateTimeRange, int firstDayOfWeek) {
-    return WeekIndexCalculator.week(dateTimeRange: dateTimeRange, firstDayOfWeek: firstDayOfWeek);
+  ///
+  /// [daysToDisplay] shortens the page without changing the weekly pagination,
+  /// so 6 shows Monday to Saturday on a week that still turns every 7 days.
+  factory PageIndexCalculator.week(
+    DateTimeRange dateTimeRange,
+    int firstDayOfWeek, {
+    int daysToDisplay = DateTime.daysPerWeek,
+  }) {
+    return WeekIndexCalculator(
+      dateTimeRange: dateTimeRange,
+      firstDayOfWeek: firstDayOfWeek,
+      daysToDisplay: daysToDisplay,
+    );
   }
 
   /// Creates a [PageIndexCalculator] for a work week [MultiDayViewConfiguration.workWeek].
-  factory PageIndexCalculator.workWeek(DateTimeRange dateTimeRange) {
-    return WeekIndexCalculator.workWeek(dateTimeRange: dateTimeRange);
+  ///
+  /// [daysToDisplay] shortens the page without changing the weekly pagination.
+  factory PageIndexCalculator.workWeek(DateTimeRange dateTimeRange, {int daysToDisplay = 5}) {
+    return WeekIndexCalculator(
+      dateTimeRange: dateTimeRange,
+      firstDayOfWeek: DateTime.monday,
+      daysToDisplay: daysToDisplay,
+    );
   }
 
   /// Creates a [PageIndexCalculator] for a custom [MultiDayViewConfiguration.custom].
@@ -155,10 +172,19 @@ class WeekIndexCalculator extends PageIndexCalculator {
   final int firstDayOfWeek;
 
   /// The number of days to display in a week view. Usually 7.
+  ///
+  /// Fewer than 7 shortens the page and leaves the pagination alone, so the page
+  /// still turns every 7 days from [firstDayOfWeek]. More than 7 would make
+  /// consecutive pages overlap.
   final int daysToDisplay;
 
   /// Creates a [WeekIndexCalculator] with the given [dateTimeRange], [firstDayOfWeek], and [daysToDisplay].
-  WeekIndexCalculator({required super.dateTimeRange, required this.firstDayOfWeek, required this.daysToDisplay});
+  WeekIndexCalculator({required super.dateTimeRange, required this.firstDayOfWeek, required this.daysToDisplay})
+      : assert(
+          daysToDisplay >= 1 && daysToDisplay <= DateTime.daysPerWeek,
+          'daysToDisplay must be between 1 and 7, because a week view pages by whole weeks.\n'
+          'Use CustomIndexCalculator for a page that is longer than a week.',
+        );
 
   /// Creates a [WeekIndexCalculator] for a standard week view.
   WeekIndexCalculator.week({

--- a/lib/src/models/view_configurations/schedule_view_configuration.dart
+++ b/lib/src/models/view_configurations/schedule_view_configuration.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
-import 'package:kalender/src/models/view_configurations/page_index_calculator.dart';
 
 /// The type of the schedule view.
 enum ScheduleViewType {

--- a/lib/src/widgets/multi_day/multi_day_body.dart
+++ b/lib/src/widgets/multi_day/multi_day_body.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/models/providers/gutter_styles.dart';
-import 'package:kalender/src/models/view_configurations/page_index_calculator.dart';
 import 'package:kalender/src/widgets/drag_targets/vertical_drag_target.dart';
 import 'package:kalender/src/widgets/draggable/day_draggable.dart';
 import 'package:kalender/src/widgets/events_widgets/day_events_widget.dart';

--- a/test/configuration/week_number_of_days_test.dart
+++ b/test/configuration/week_number_of_days_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/internal_components/week_day_headers.dart' show WeekDayHeaders;
+
+import '../utilities.dart';
+
+/// A week view shortened with [MultiDayViewConfiguration.week]'s `numberOfDays`.
+///
+/// The body divides its width by `numberOfDays` while the header renders the
+/// dates of the page, so the two only line up if the page is that many days
+/// long. Covers issue #444.
+void main() {
+  final displayRange = DateTimeRange(start: DateTime(2025), end: DateTime(2026));
+
+  // Monday 14 April 2025.
+  final monday = DateTime(2025, 4, 14);
+
+  group('MultiDayViewConfiguration.week', () {
+    test('a page is numberOfDays long and still turns a week at a time', () {
+      final configuration = MultiDayViewConfiguration.week(
+        displayRange: displayRange,
+        firstDayOfWeek: DateTime.monday,
+        numberOfDays: 6,
+      );
+
+      final calculator = configuration.pageIndexCalculator;
+      final index = calculator.indexFromDate(monday, null);
+      final page = calculator.dateTimeRangeFromIndex(index, null);
+      final next = calculator.dateTimeRangeFromIndex(index + 1, null);
+
+      expect(page.dates().length, 6, reason: 'Monday to Saturday');
+      expect(page.start.weekday, DateTime.monday);
+      expect(page.end.difference(page.start), const Duration(days: 6));
+      expect(next.start.difference(page.start), const Duration(days: 7), reason: 'pagination stays weekly');
+    });
+
+    test('the default is still a full week', () {
+      final configuration = MultiDayViewConfiguration.week(displayRange: displayRange);
+      final calculator = configuration.pageIndexCalculator;
+      final page = calculator.dateTimeRangeFromIndex(calculator.indexFromDate(monday, null), null);
+      expect(configuration.numberOfDays, DateTime.daysPerWeek);
+      expect(page.dates().length, DateTime.daysPerWeek);
+    });
+
+    test('copyWith keeps numberOfDays and replaces it', () {
+      final configuration = MultiDayViewConfiguration.week(displayRange: displayRange, numberOfDays: 6);
+
+      expect(configuration.copyWith(name: 'Renamed').numberOfDays, 6);
+
+      final replaced = configuration.copyWith(numberOfDays: 4);
+      expect(replaced.numberOfDays, 4);
+      final page = replaced.pageIndexCalculator.dateTimeRangeFromIndex(
+        replaced.pageIndexCalculator.indexFromDate(monday, null),
+        null,
+      );
+      expect(page.dates().length, 4);
+    });
+
+    test('numberOfDays outside 1 to 7 is rejected', () {
+      expect(
+        () => MultiDayViewConfiguration.week(displayRange: displayRange, numberOfDays: 8),
+        throwsAssertionError,
+        reason: 'pages would overlap',
+      );
+      expect(
+        () => MultiDayViewConfiguration.week(displayRange: displayRange, numberOfDays: 0),
+        throwsAssertionError,
+      );
+    });
+  });
+
+  group('MultiDayViewConfiguration.workWeek', () {
+    test('a page is numberOfDays long', () {
+      final configuration = MultiDayViewConfiguration.workWeek(displayRange: displayRange, numberOfDays: 4);
+      final calculator = configuration.pageIndexCalculator;
+      final page = calculator.dateTimeRangeFromIndex(calculator.indexFromDate(monday, null), null);
+
+      expect(page.dates().length, 4);
+      expect(page.start.weekday, DateTime.monday);
+    });
+
+    test('the default is still five days', () {
+      final configuration = MultiDayViewConfiguration.workWeek(displayRange: displayRange);
+      final calculator = configuration.pageIndexCalculator;
+      final page = calculator.dateTimeRangeFromIndex(calculator.indexFromDate(monday, null), null);
+      expect(page.dates().length, 5);
+    });
+
+    test('copyWith keeps numberOfDays', () {
+      final configuration = MultiDayViewConfiguration.workWeek(displayRange: displayRange, numberOfDays: 4);
+      expect(configuration.copyWith(name: 'Renamed').numberOfDays, 4);
+    });
+  });
+
+  group('WeekIndexCalculator', () {
+    test('daysToDisplay outside 1 to 7 is rejected', () {
+      expect(
+        () => WeekIndexCalculator(
+          dateTimeRange: displayRange,
+          firstDayOfWeek: DateTime.monday,
+          daysToDisplay: 8,
+        ),
+        throwsAssertionError,
+      );
+    });
+  });
+
+  group('the header follows numberOfDays', () {
+    Future<void> pumpWeek(WidgetTester tester, int numberOfDays) {
+      return pumpAndSettleWithMaterialApp(
+        tester,
+        CalendarView(
+          eventsController: DefaultEventsController(),
+          calendarController: CalendarController(),
+          viewConfiguration: MultiDayViewConfiguration.week(
+            displayRange: displayRange,
+            initialDateTime: monday,
+            firstDayOfWeek: DateTime.monday,
+            numberOfDays: numberOfDays,
+          ),
+          header: const CalendarHeader(),
+          body: const CalendarBody(),
+        ),
+      );
+    }
+
+    testWidgets('six days render six day headers', (tester) async {
+      await pumpWeek(tester, 6);
+
+      final headers = tester.widgetList<WeekDayHeaders>(find.byType(WeekDayHeaders));
+      expect(headers, isNotEmpty);
+      for (final header in headers) {
+        expect(header.dates.length, 6);
+        expect(header.dates.first.weekday, DateTime.monday);
+        expect(header.dates.last.weekday, DateTime.saturday);
+      }
+    });
+
+    testWidgets('the default renders seven', (tester) async {
+      await pumpWeek(tester, 7);
+
+      final headers = tester.widgetList<WeekDayHeaders>(find.byType(WeekDayHeaders));
+      expect(headers, isNotEmpty);
+      for (final header in headers) {
+        expect(header.dates.length, DateTime.daysPerWeek);
+      }
+    });
+  });
+}

--- a/test/models/page_index_calculator_test.dart
+++ b/test/models/page_index_calculator_test.dart
@@ -169,6 +169,44 @@ void main() {
       });
     });
 
+    group('WeekIndexCalculator with six days for $location', () {
+      late WeekIndexCalculator calculator;
+      setUpAll(() {
+        calculator = WeekIndexCalculator(
+          dateTimeRange: range,
+          firstDayOfWeek: DateTime.monday,
+          daysToDisplay: 6,
+        );
+      });
+
+      test('a page ends after six days', () {
+        expect(
+          calculator.dateTimeRangeFromIndex(0, location),
+          InternalDateTimeRange(start: InternalDateTime(2019, 12, 30), end: InternalDateTime(2020, 1, 5)),
+        );
+        expect(
+          calculator.dateTimeRangeFromIndex(1, location),
+          InternalDateTimeRange(start: InternalDateTime(2020, 1, 6), end: InternalDateTime(2020, 1, 12)),
+        );
+      });
+
+      test('pagination is unchanged', () {
+        expect(calculator.indexFromDate(TZDateTime(location, 2020, 1, 6), location), 1);
+        expect(calculator.indexFromDate(TZDateTime(location, 2020, 3, 2), location), 9);
+        expect(calculator.numberOfPages(location), 53);
+        expect(
+          calculator.internalRange(location),
+          InternalDateTimeRange(start: InternalDateTime(2019, 12, 30), end: InternalDateTime(2021, 1, 4)),
+        );
+      });
+
+      test('the day the page drops is still reachable', () {
+        // Sunday 5 January 2020 is not displayed, but asking for it must land on
+        // the page that starts the week it belongs to.
+        expect(calculator.indexFromDate(TZDateTime(location, 2020, 1, 5), location), 0);
+      });
+    });
+
     group('CustomIndexCalculator for $location', () {
       late CustomIndexCalculator calculator;
       setUpAll(() {


### PR DESCRIPTION
Closes #444, both halves of it.

**A week view honours `numberOfDays`.** `MultiDayViewConfiguration.week` and `.workWeek` both take the parameter and both built their page index calculator with a hardcoded 7 and 5. The body divides its width by `numberOfDays` while the header renders the dates of the page, so any other value put every day column out of line with its header. `WeekIndexCalculator` already carries `daysToDisplay`, which shortens the page and leaves the weekly pagination alone, and that is how `workWeek` gets Monday to Friday, so the fix is to pass the value in. Both accept 1 through 7, since above that consecutive pages would overlap. `copyWith` dropped the value in both branches as well.

**`PageIndexCalculator` is exported.** `ViewConfiguration.pageIndexCalculator` returns the type, so it was already part of the public API with no way for an app to name it. The types its members use are already exported.

The changelog's 0.26.0 section absorbs the all-day entries from 0.27.0. Only `0.26.0-dev.1` reached pub.dev, so the release was still open when #443 merged, and an archive tagged 0.26.0 would otherwise carry features its changelog puts in the next release. `TimeOfDayRange.isAllDay` now says it is removed in 0.27.0, and the roadmap's builders release renumbers from 0.28.0 to 0.27.0. The 0.26.0 section is also condensed: each entry says what changed, with the upgrade steps left to MIGRATION.md instead of repeated per entry.

Arbitrary visible weekdays, the non-contiguous case, is scoped onto the roadmap under #90 rather than built here. Every contiguous span starting on `firstDayOfWeek` is expressible with `numberOfDays`, so what a weekday set adds is Monday/Wednesday/Friday and spans that start elsewhere. That needs a page to stop being a single date range, which reaches the drag targets, both event widgets, the layout strategies, the free-scroll band, and the public `visibleDateTimeRange`.
