### PR TITLE
ci: the benchmark job publishes with a clean working tree

### DIFF
--- a/.github/workflows/performance_profiling.yml
+++ b/.github/workflows/performance_profiling.yml
@@ -46,7 +46,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      # Pinned, unlike the analyze and test workflows. This job compares numbers
+      # against the history stored on gh-pages, so an SDK that moves underneath it
+      # shows up as a performance change that no commit here caused.
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.6
+          channel: stable
 
       - name: Install Linux dependencies
         run: |
@@ -93,6 +99,14 @@ jobs:
           name: timelines-${{ github.run_number }}
           path: examples/testing/build/*.timeline.json
           retention-days: 30
+
+      # `flutter pub get` rewrites analysis_options.yaml to exclude the build and
+      # platform directories, here and in examples/testing. The publish steps below
+      # switch to gh-pages, which carries neither file, and git refuses to switch
+      # while they are modified. Every result this job produces sits in an ignored
+      # build/ directory, so restoring the tracked files discards nothing.
+      - name: Restore files the SDK rewrote
+        run: git restore .
 
       # --- Publish to the dashboard at gh-pages/dev/bench ----------------------
       # Comment-only: fail-on-alert is false, so regressions are surfaced in a PR


### PR DESCRIPTION
The benchmark job is still red on main, but not for the reason #446 fixed. Frame profiling passes now. The failure moved to the two publish steps, which were never reached before because the job died earlier.

**What happens.** `flutter pub get` prints `Upgrading analysis_options.yaml to exclude build and platform directories` and rewrites the file, once at the root and once in `examples/testing`. `github-action-benchmark` then runs `git switch gh-pages` to publish, and gh-pages carries neither file, so git refuses to move while they are modified:

```
error: Your local changes to the following files would be overwritten by checkout:
	analysis_options.yaml
	examples/testing/analysis_options.yaml
```

Nothing in the repository changed. The rewrite is newer SDK behaviour that arrived when the runner's stable Flutter rolled forward, which is why this appeared without a commit to blame.

**What changes.** The tree is restored before publishing. Every result the job produces is in an ignored `build/` directory, so restoring tracked files discards nothing it measured.

The SDK is also pinned to 3.44.6, matching `web_demo.yml` and `analyze_examples.yml`. The analyze and test workflows deliberately stay on latest stable, since that is what catches SDK breakage, but this job compares numbers against the history stored on gh-pages, so an SDK that moves underneath it reads as a performance change that no commit here caused.

Checked by reproducing locally: with both files modified, `git switch gh-pages` fails with the error above, and after `git restore .` it succeeds.

The job is skipped on pull requests, so this cannot prove itself green here. The run after merge is the check.
