### PR TITLE
refactor!: the header and month builders take a BuildContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ See [MIGRATION.md](MIGRATION.md#v026x--v0270) for what to change.
 - Those five fields are nullable and default to `null`, which selects the package default. `MultiDayBodyComponents` gained a `buildX` method per field that applies the override or the default.
 - `builder` and `fromContext` are removed from `TimeLine`, `HourLines`, `DaySeparator` and `TimeIndicator`. Construct the widget, or call the matching `MultiDayBodyComponents.buildX`.
 - `defaultTimelineWidth` no longer takes a `TimelineStyle`. It resolves one from the context.
+- The multi-day header and month builders take a `BuildContext` as their first argument and no longer take a style: `dayHeaderBuilder`, `weekNumberBuilder`, `weekDayHeaderBuilder`, `monthDayHeaderBuilder`, `monthGridBuilder` and `monthDayCellBuilder`. Resolve the style with `KalenderTheme.of(context)`.
+- Those fields are nullable and default to `null`. `MultiDayHeaderComponents`, `MonthHeaderComponents` and `MonthBodyComponents` gained a `buildX` method per field.
+- `builder` and `fromContext` are removed from `DayHeader`, `WeekNumber`, `WeekDayHeader`, `MonthGrid`, `MonthDayHeader` and `MonthDayCell`. `MonthDayCell.shadeAdjacentMonths` stays.
 
 ### Features
 
+- The month week number gutter publishes the style it measures with, including its top alignment, to the scope it draws in. A custom `weekNumberBuilder` reads the month's value with `KalenderTheme.of(context)` where it previously had to be handed one.
 - `GutterStyles` is public, with `GutterStyles.timelineStyleOf` and `GutterStyles.weekNumberStyleOf`. A custom gutter builder can resolve the style the gutter is measured from, which a `KalenderTheme` scoped inside the calendar cannot move.
 
 ## 0.26.0

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -50,11 +50,49 @@ rather than from the theme:
 timelineWidth: (context, range) => GutterStyles.timelineStyleOf(context).width ?? 56,
 ```
 
+### The multi-day header and month builders take a `BuildContext`
+
+The same change, for the builders that draw headers, the month grid and week
+numbers.
+
+| Before | After |
+| --- | --- |
+| `dayHeaderBuilder: (date, style) =>` | `dayHeaderBuilder: (context, date) =>` |
+| `weekNumberBuilder: (range, style) =>` | `weekNumberBuilder: (context, range) =>` |
+| `weekDayHeaderBuilder: (date, style) =>` | `weekDayHeaderBuilder: (context, date) =>` |
+| `monthDayHeaderBuilder: (date, style) =>` | `monthDayHeaderBuilder: (context, date) =>` |
+| `monthGridBuilder: (style, numberOfRows) =>` | `monthGridBuilder: (context, numberOfRows) =>` |
+| `monthDayCellBuilder: (details) =>` | `monthDayCellBuilder: (context, details) =>` |
+
+A `weekNumberBuilder` in the month gutter still gets the month's own top
+alignment. The gutter publishes the style it measures with to the scope it draws
+in, so `KalenderTheme.of(context).weekNumberStyle` returns the month's value
+there and the calendar-wide value everywhere else.
+
+```dart
+// Before
+weekNumberBuilder: (range, style) => Align(
+  alignment: style?.alignment ?? Alignment.center,
+  child: Text(weekNumberOf(range)),
+),
+
+// After
+weekNumberBuilder: (context, range) {
+  final style = KalenderTheme.of(context).weekNumberStyle;
+  return Align(
+    alignment: style?.alignment ?? Alignment.center,
+    child: Text(weekNumberOf(range)),
+  );
+},
+```
+
 ### The `builder` and `fromContext` statics are removed
 
-`TimeLine`, `HourLines`, `DaySeparator` and `TimeIndicator` no longer carry them.
-Construct the widget directly, or call the matching `buildX` on
-`MultiDayBodyComponents`, which applies your override when you set one.
+`TimeLine`, `HourLines`, `DaySeparator`, `TimeIndicator`, `DayHeader`,
+`WeekNumber`, `WeekDayHeader`, `MonthGrid`, `MonthDayHeader` and `MonthDayCell`
+no longer carry them. Construct the widget directly, or call the matching
+`buildX` on the components class, which applies your override when you set one.
+`MonthDayCell.shadeAdjacentMonths` is unaffected.
 
 ```dart
 // Before

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -340,8 +340,8 @@ Pass a `CalendarComponents` object to `CalendarView` to override the default wid
   CalendarComponents(
     multiDayComponents: MultiDayComponents(
       headerComponents: MultiDayHeaderComponents(
-        dayHeaderBuilder: (date, style) => CustomWidget(),
-        weekNumberBuilder: (visibleDateTimeRange, style) => CustomWidget(),
+        dayHeaderBuilder: (context, date) => CustomWidget(),
+        weekNumberBuilder: (context, visibleDateTimeRange) => CustomWidget(),
         leftTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
         rightTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
         overlayBuilders: OverlayBuilders(
@@ -375,15 +375,15 @@ Pass a `CalendarComponents` object to `CalendarView` to override the default wid
   CalendarComponents(
     monthComponents: MonthComponents(
       headerComponents: MonthHeaderComponents(
-        weekDayHeaderBuilder: (date, style) => SizedBox(),
+        weekDayHeaderBuilder: (context, date) => SizedBox(),
       ),
       bodyComponents: MonthBodyComponents(
-        monthDayHeaderBuilder: (date, style) => SizedBox(),
+        monthDayHeaderBuilder: (context, date) => SizedBox(),
         // Custom per-cell background, or use the ready-made
         // MonthDayCell.shadeAdjacentMonths() to shade adjacent-month days.
-        monthDayCellBuilder: (details) => SizedBox(),
-        monthGridBuilder: (style, numberOfRows) => SizedBox(),
-        weekNumberBuilder: (visibleDateTimeRange, style) => SizedBox(),
+        monthDayCellBuilder: (context, details) => SizedBox(),
+        monthGridBuilder: (context, numberOfRows) => SizedBox(),
+        weekNumberBuilder: (context, visibleDateTimeRange) => SizedBox(),
         leftTriggerBuilder: (pageWidth) => SizedBox(),
         rightTriggerBuilder: (pageWidth) => SizedBox(),
         overlayBuilders: OverlayBuilders(

--- a/examples/web_demo/lib/widgets/calendar/calendar.dart
+++ b/examples/web_demo/lib/widgets/calendar/calendar.dart
@@ -187,14 +187,16 @@ class _CalendarContentState extends State<CalendarContent> {
       monthComponents: MonthComponents(
         bodyComponents: MonthBodyComponents(
           weekNumberBuilder: _buildWeekNumberText,
-          monthDayCellBuilder:
-              context.configuration.shadeAdjacentMonth ? MonthDayCell.shadeAdjacentMonths() : MonthDayCell.builder,
+          monthDayCellBuilder: context.configuration.shadeAdjacentMonth ? MonthDayCell.shadeAdjacentMonths() : null,
         ),
       ),
     );
   }
 
-  Widget _buildWeekNumberText(DateTimeRange visibleDateTimeRange, WeekNumberStyle? style) {
+  Widget _buildWeekNumberText(BuildContext context, DateTimeRange visibleDateTimeRange) {
+    // In the month gutter this resolves the calendar's own top-aligned default,
+    // which it merges into the scope the gutter is drawn in.
+    final style = KalenderTheme.of(context).weekNumberStyle;
     final internalDateTimeRange = InternalDateTimeRange(
       start: InternalDateTime.fromExternal(visibleDateTimeRange.start),
       end: InternalDateTime.fromExternal(visibleDateTimeRange.end),

--- a/lib/src/models/components/month_components.dart
+++ b/lib/src/models/components/month_components.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:kalender/src/models/components/components.dart';
 import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/widgets/components/month_day_cell.dart';
@@ -50,10 +51,12 @@ class MonthComponents {
 /// - Using these will override the respective default components.
 class MonthBodyComponents {
   /// A function that builds the month grid widget.
-  final MonthGridBuilder monthGridBuilder;
+  /// Null uses [MonthGrid].
+  final MonthGridBuilder? monthGridBuilder;
 
   /// A function that builds the month day header widget.
-  final MonthDayHeaderBuilder monthDayHeaderBuilder;
+  /// Null uses [MonthDayHeader].
+  final MonthDayHeaderBuilder? monthDayHeaderBuilder;
 
   /// Builds the day number displayed by the month day header.
   ///
@@ -63,11 +66,13 @@ class MonthBodyComponents {
   /// A function that builds the background of each day cell.
   ///
   /// Called once per cell; use it to style individual days, e.g. to gray out
-  /// days that fall outside the focused month. Defaults to an empty cell.
-  final MonthDayCellBuilder monthDayCellBuilder;
+  /// days that fall outside the focused month. Null leaves the cell empty.
+  final MonthDayCellBuilder? monthDayCellBuilder;
 
   /// A function that builds the week number widget.
-  final WeekNumberBuilder weekNumberBuilder;
+  ///
+  /// Null uses [WeekNumber].
+  final WeekNumberBuilder? weekNumberBuilder;
 
   /// A function that builds the left trigger widget.
   final HorizontalTriggerWidgetBuilder? leftTriggerBuilder;
@@ -80,15 +85,36 @@ class MonthBodyComponents {
 
   /// Creates overrides for the default components used by the [MonthBody].
   const MonthBodyComponents({
-    this.monthGridBuilder = MonthGrid.builder,
-    this.monthDayHeaderBuilder = MonthDayHeader.builder,
+    this.monthGridBuilder,
+    this.monthDayHeaderBuilder,
     this.monthDayHeaderStringBuilder,
-    this.monthDayCellBuilder = MonthDayCell.builder,
-    this.weekNumberBuilder = WeekNumber.builder,
+    this.monthDayCellBuilder,
+    this.weekNumberBuilder,
     this.leftTriggerBuilder,
     this.rightTriggerBuilder,
     this.overlayBuilders,
   });
+
+  /// Builds the month grid, with [monthGridBuilder] when set.
+  Widget buildMonthGrid(BuildContext context, int numberOfRows) {
+    return monthGridBuilder?.call(context, numberOfRows) ?? MonthGrid(numberOfRows: numberOfRows);
+  }
+
+  /// Builds a month day header, with [monthDayHeaderBuilder] when set.
+  Widget buildMonthDayHeader(BuildContext context, DateTime date) {
+    return monthDayHeaderBuilder?.call(context, date) ?? MonthDayHeader(date: date);
+  }
+
+  /// Builds a day cell background, with [monthDayCellBuilder] when set.
+  Widget buildMonthDayCell(BuildContext context, MonthDayCellDetails details) {
+    return monthDayCellBuilder?.call(context, details) ?? const MonthDayCell();
+  }
+
+  /// Builds a week number, with [weekNumberBuilder] when set.
+  Widget buildWeekNumber(BuildContext context, DateTimeRange visibleDateTimeRange) {
+    return weekNumberBuilder?.call(context, visibleDateTimeRange) ??
+        WeekNumber(visibleDateTimeRange: visibleDateTimeRange);
+  }
 
   /// Creates a copy of this with the given fields replaced.
   MonthBodyComponents copyWith({
@@ -146,7 +172,8 @@ class MonthBodyComponents {
 /// - Using these will override the respective default components.
 class MonthHeaderComponents {
   /// A function that builds the week day header widget.
-  final WeekDayHeaderBuilder weekDayHeaderBuilder;
+  /// Null uses [WeekDayHeader].
+  final WeekDayHeaderBuilder? weekDayHeaderBuilder;
 
   /// Builds the day name displayed by the week day header.
   ///
@@ -155,9 +182,14 @@ class MonthHeaderComponents {
 
   /// Creates overrides for the default components used by the [MonthHeader].
   const MonthHeaderComponents({
-    this.weekDayHeaderBuilder = WeekDayHeader.builder,
+    this.weekDayHeaderBuilder,
     this.weekDayHeaderStringBuilder,
   });
+
+  /// Builds a week day header, with [weekDayHeaderBuilder] when set.
+  Widget buildWeekDayHeader(BuildContext context, DateTime date) {
+    return weekDayHeaderBuilder?.call(context, date) ?? WeekDayHeader(date: date);
+  }
 
   /// Creates a copy of this with the given fields replaced.
   MonthHeaderComponents copyWith({

--- a/lib/src/models/components/multi_day_components.dart
+++ b/lib/src/models/components/multi_day_components.dart
@@ -55,7 +55,8 @@ class MultiDayComponents {
 /// - Using these will override the respective default components.
 class MultiDayHeaderComponents {
   /// A function that builds the day header widget.
-  final DayHeaderBuilder dayHeaderBuilder;
+  /// Null uses [DayHeader].
+  final DayHeaderBuilder? dayHeaderBuilder;
 
   /// Builds the day name displayed under the day number.
   ///
@@ -68,7 +69,8 @@ class MultiDayHeaderComponents {
   final DateStringBuilder? dayHeaderNumberStringBuilder;
 
   /// A function that builds the week number widget.
-  final WeekNumberBuilder weekNumberBuilder;
+  /// Null uses [WeekNumber].
+  final WeekNumberBuilder? weekNumberBuilder;
 
   /// A function that builds the left trigger widget.
   final HorizontalTriggerWidgetBuilder? leftTriggerBuilder;
@@ -81,14 +83,25 @@ class MultiDayHeaderComponents {
 
   /// Creates overrides for the default components used by the [MultiDayHeader].
   const MultiDayHeaderComponents({
-    this.dayHeaderBuilder = DayHeader.builder,
+    this.dayHeaderBuilder,
     this.dayHeaderStringBuilder,
     this.dayHeaderNumberStringBuilder,
-    this.weekNumberBuilder = WeekNumber.builder,
+    this.weekNumberBuilder,
     this.leftTriggerBuilder,
     this.rightTriggerBuilder,
     this.overlayBuilders,
   });
+
+  /// Builds a day header, with [dayHeaderBuilder] when set.
+  Widget buildDayHeader(BuildContext context, DateTime date) {
+    return dayHeaderBuilder?.call(context, date) ?? DayHeader(date: date);
+  }
+
+  /// Builds a week number, with [weekNumberBuilder] when set.
+  Widget buildWeekNumber(BuildContext context, DateTimeRange visibleDateTimeRange) {
+    return weekNumberBuilder?.call(context, visibleDateTimeRange) ??
+        WeekNumber(visibleDateTimeRange: visibleDateTimeRange);
+  }
 
   /// Creates a copy of this with the given fields replaced.
   MultiDayHeaderComponents copyWith({

--- a/lib/src/widgets/components/day_header.dart
+++ b/lib/src/widgets/components/day_header.dart
@@ -8,10 +8,11 @@ import 'package:kalender/src/widgets/internal_components/day_number.dart';
 /// The day header builder.
 ///
 /// The [date] is the date that the header will be displayed for.
-/// The [style] is used to style the day header.
+///
+/// Resolve the style with [KalenderTheme].
 typedef DayHeaderBuilder = Widget Function(
+  BuildContext context,
   DateTime date,
-  DayHeaderStyle? style,
 );
 
 /// The styling class for the [DayHeader].
@@ -114,15 +115,6 @@ class DayHeader extends StatelessWidget {
   /// The [date] is the date that will be displayed.
   /// The [style] is the style of the [DayHeader].
   const DayHeader({super.key, required this.date, this.style});
-
-  /// The default builder for the [DayHeader].
-  static DayHeader builder(DateTime date, DayHeaderStyle? style) => DayHeader(date: date, style: style);
-
-  static Widget fromContext(BuildContext context, InternalDateTime date) {
-    final dayHeaderBuilder = context.components.multiDayComponents.headerComponents.dayHeaderBuilder;
-    final dayHeaderStyle = KalenderTheme.of(context).dayHeaderStyle;
-    return dayHeaderBuilder.call(date.forLocation(location: context.location), dayHeaderStyle);
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/components/month_day_cell.dart
+++ b/lib/src/widgets/components/month_day_cell.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
-import 'package:kalender/src/models/providers/calendar_provider.dart';
 
 /// Builds the background of a single day cell in the month body.
 ///
@@ -14,7 +13,7 @@ import 'package:kalender/src/models/providers/calendar_provider.dart';
 /// This is a background layer and does not receive pointer events. The event
 /// and drag layers sit above it. The default builder renders nothing, leaving
 /// the cell background unchanged.
-typedef MonthDayCellBuilder = Widget Function(MonthDayCellDetails details);
+typedef MonthDayCellBuilder = Widget Function(BuildContext context, MonthDayCellDetails details);
 
 /// Details describing a single day cell, passed to a [MonthDayCellBuilder].
 class MonthDayCellDetails {
@@ -46,9 +45,6 @@ class MonthDayCellDetails {
 class MonthDayCell extends StatelessWidget {
   const MonthDayCell({super.key});
 
-  /// The default [MonthDayCellBuilder] renders nothing.
-  static Widget builder(MonthDayCellDetails details) => const MonthDayCell();
-
   /// A ready-made [MonthDayCellBuilder] that shades the leading and trailing
   /// adjacent-month days, leaving the focused month's days unchanged.
   ///
@@ -61,23 +57,7 @@ class MonthDayCell extends StatelessWidget {
   /// MonthBodyComponents(monthDayCellBuilder: MonthDayCell.shadeAdjacentMonths())
   /// ```
   static MonthDayCellBuilder shadeAdjacentMonths({Color? color}) {
-    return (details) => details.isInFocusedMonth ? const MonthDayCell() : _AdjacentMonthShade(color: color);
-  }
-
-  /// Builds the day cell for [date] using the configured [MonthDayCellBuilder].
-  static Widget fromContext(
-    BuildContext context,
-    InternalDateTime date, {
-    required bool isInFocusedMonth,
-  }) {
-    final builder = context.components.monthComponents.bodyComponents.monthDayCellBuilder;
-    return builder(
-      MonthDayCellDetails(
-        date: date.forLocation(location: context.location),
-        isToday: context.isToday(date),
-        isInFocusedMonth: isInFocusedMonth,
-      ),
-    );
+    return (context, details) => details.isInFocusedMonth ? const MonthDayCell() : _AdjacentMonthShade(color: color);
   }
 
   @override

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -8,9 +8,11 @@ import 'package:kalender/src/widgets/internal_components/day_number.dart';
 ///
 /// The [date] is a wall-clock [DateTime] in the calendar's configured location,
 /// so comparisons against `DateTime.now()` behave correctly.
+///
+/// Resolve the style with [KalenderTheme].
 typedef MonthDayHeaderBuilder = Widget Function(
+  BuildContext context,
   DateTime date,
-  MonthDayHeaderStyle? style,
 );
 
 /// The style of the [MonthDayHeader].
@@ -102,15 +104,6 @@ class MonthDayHeader extends StatelessWidget {
   final MonthDayHeaderStyle? style;
 
   const MonthDayHeader({super.key, required this.date, this.style});
-  static MonthDayHeader builder(DateTime date, MonthDayHeaderStyle? style) {
-    return MonthDayHeader(date: date, style: style);
-  }
-
-  static Widget fromContext(BuildContext context, InternalDateTime date) {
-    final dayHeader = context.components.monthComponents.bodyComponents.monthDayHeaderBuilder;
-    final style = KalenderTheme.of(context).monthDayHeaderStyle;
-    return dayHeader(date.forLocation(location: context.location), style);
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/components/month_grid.dart
+++ b/lib/src/widgets/components/month_grid.dart
@@ -2,14 +2,13 @@ import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
 
 /// The month grid builder.
 ///
-/// The [style] is used to style the month grid.
+/// Resolve the style with [KalenderTheme].
 typedef MonthGridBuilder = Widget Function(
-  MonthGridStyle? style,
+  BuildContext context,
   int numberOfRows,
 );
 
@@ -76,14 +75,6 @@ class MonthGrid extends StatelessWidget {
   final int numberOfRows;
 
   const MonthGrid({super.key, this.style, required this.numberOfRows});
-  static MonthGrid builder(MonthGridStyle? style, int numberOfRows) {
-    return MonthGrid(style: style, numberOfRows: numberOfRows);
-  }
-
-  static Widget fromContext(BuildContext context, int numberOfRows) {
-    final component = context.components.monthComponents.bodyComponents.monthGridBuilder;
-    return component.call(KalenderTheme.of(context).monthGridStyle, numberOfRows);
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/components/week_day_header.dart
+++ b/lib/src/widgets/components/week_day_header.dart
@@ -7,10 +7,11 @@ import 'package:kalender/src/theme/kalender_theme.dart';
 /// The week day header builder.
 ///
 /// The [date] is the date that the header will be displayed for.
-/// The [style] is used to style the week day header.
+///
+/// Resolve the style with [KalenderTheme].
 typedef WeekDayHeaderBuilder = Widget Function(
+  BuildContext context,
   DateTime date,
-  WeekDayHeaderStyle? style,
 );
 
 /// The [WeekDayHeaderStyle] class is used by the default [WeekDayHeader] widget.
@@ -82,9 +83,6 @@ class WeekDayHeader extends StatelessWidget {
   final WeekDayHeaderStyle? style;
 
   const WeekDayHeader({super.key, required this.date, this.style});
-  static WeekDayHeader builder(DateTime date, WeekDayHeaderStyle? style) {
-    return WeekDayHeader(date: date, style: style);
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/components/week_number.dart
+++ b/lib/src/widgets/components/week_number.dart
@@ -7,10 +7,12 @@ import 'package:kalender/src/theme/kalender_theme.dart';
 /// The week number builder.
 ///
 /// The [visibleDateTimeRange] is the range of dates that the week number will be displayed for.
-/// The [style] is used to style the week number.
+///
+/// Resolve the style with [KalenderTheme]. The month gutter merges its own
+/// defaults into that scope, so the same call returns the month's value there.
 typedef WeekNumberBuilder = Widget Function(
+  BuildContext context,
   DateTimeRange visibleDateTimeRange,
-  WeekNumberStyle? style,
 );
 
 /// The style of the [WeekNumber].
@@ -115,9 +117,6 @@ class WeekNumber extends StatelessWidget {
   final WeekNumberStyle? weekNumberStyle;
 
   const WeekNumber({super.key, required this.visibleDateTimeRange, this.weekNumberStyle});
-  static WeekNumber builder(DateTimeRange visibleDateTimeRange, WeekNumberStyle? weekNumberStyle) {
-    return WeekNumber(visibleDateTimeRange: visibleDateTimeRange, weekNumberStyle: weekNumberStyle);
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/internal_components/month_week_number_gutter.dart
+++ b/lib/src/widgets/internal_components/month_week_number_gutter.dart
@@ -38,29 +38,29 @@ class MonthWeekNumberGutter extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final style = _resolveStyle(context);
-
-    return IntrinsicWidth(
-      child: Column(
-        children: List.generate(
-          numberOfRows,
-          (index) {
-            final range = _rangeForRow(index);
-            return Expanded(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  border: Border(
-                    top: index == 0 ? dividerSide : BorderSide.none,
-                    bottom: dividerSide,
+    return KalenderTheme(
+      data: KalenderTheme.of(context).copyWith(weekNumberStyle: _resolveStyle(context)),
+      child: IntrinsicWidth(
+        child: Column(
+          children: List.generate(
+            numberOfRows,
+            (index) {
+              final range = _rangeForRow(index);
+              return Expanded(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    border: Border(
+                      top: index == 0 ? dividerSide : BorderSide.none,
+                      bottom: dividerSide,
+                    ),
+                  ),
+                  child: Builder(
+                    builder: (context) => weekNumberBuilder(context, range.forLocation(location: context.location)),
                   ),
                 ),
-                child: weekNumberBuilder(
-                  range.forLocation(location: context.location),
-                  style,
-                ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         ),
       ),
     );
@@ -86,25 +86,25 @@ class MonthWeekNumberSpacer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final style = _resolveStyle(context);
+    return KalenderTheme(
+      data: KalenderTheme.of(context).copyWith(weekNumberStyle: _resolveStyle(context)),
+      child: _WidthOnly(
+        child: IntrinsicWidth(
+          child: Stack(
+            children: List.generate(
+              numberOfRows,
+              (index) {
+                final start = visibleRange.start.add(Duration(days: index * DateTime.daysPerWeek));
+                final range = InternalDateTimeRange(
+                  start: start,
+                  end: start.add(const Duration(days: DateTime.daysPerWeek)),
+                );
 
-    return _WidthOnly(
-      child: IntrinsicWidth(
-        child: Stack(
-          children: List.generate(
-            numberOfRows,
-            (index) {
-              final start = visibleRange.start.add(Duration(days: index * DateTime.daysPerWeek));
-              final range = InternalDateTimeRange(
-                start: start,
-                end: start.add(const Duration(days: DateTime.daysPerWeek)),
-              );
-
-              return weekNumberBuilder(
-                range.forLocation(location: context.location),
-                style,
-              );
-            },
+                return Builder(
+                  builder: (context) => weekNumberBuilder(context, range.forLocation(location: context.location)),
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -59,7 +59,7 @@ class MonthBody extends StatelessWidget {
       itemBuilder: (context, index) {
         final visibleRange = pageNavigation.dateTimeRangeFromIndex(index, context.location);
         final numberOfRows = pageNavigation.numberOfRowsForRange(visibleRange);
-        final grid = MonthGrid.fromContext(context, numberOfRows);
+        final grid = monthComponents.bodyComponents.buildMonthGrid(context, numberOfRows);
 
         // The date range of each week row, shared by the content and background.
         final weekRanges = List.generate(numberOfRows, (row) {
@@ -85,7 +85,7 @@ class MonthBody extends StatelessWidget {
         // the default month view does no extra per-cell work. It is painted below
         // the grid (see the layout delegate) so cell backgrounds do not cover the
         // grid lines.
-        final hasCellBuilder = monthComponents.bodyComponents.monthDayCellBuilder != MonthDayCell.builder;
+        final hasCellBuilder = monthComponents.bodyComponents.monthDayCellBuilder != null;
         final background = hasCellBuilder
             ? _MonthDayCellBackground(
                 weekRanges: weekRanges,
@@ -107,7 +107,7 @@ class MonthBody extends StatelessWidget {
                 child: MonthWeekNumberGutter(
                   visibleRange: visibleRange,
                   numberOfRows: numberOfRows,
-                  weekNumberBuilder: monthComponents.bodyComponents.weekNumberBuilder,
+                  weekNumberBuilder: monthComponents.bodyComponents.buildWeekNumber,
                   dividerSide: dividerSide,
                 ),
               ),
@@ -153,7 +153,8 @@ class MonthWeek extends StatelessWidget {
             children: [
               WeekDayHeaders(
                 dates: internalRange.dates(),
-                dayHeaderBuilder: MonthDayHeader.fromContext,
+                dayHeaderBuilder: (context, date) => context.components.monthComponents.bodyComponents
+                    .buildMonthDayHeader(context, date.forLocation(location: context.location)),
               ),
               Expanded(
                 child: LayoutBuilder(
@@ -213,10 +214,15 @@ class _MonthDayCellBackground extends StatelessWidget {
               children: [
                 for (final date in weekRange.dates())
                   Expanded(
-                    child: MonthDayCell.fromContext(
-                      context,
-                      date,
-                      isInFocusedMonth: date.month == focusMonthStart.month && date.year == focusMonthStart.year,
+                    child: Builder(
+                      builder: (context) => context.components.monthComponents.bodyComponents.buildMonthDayCell(
+                        context,
+                        MonthDayCellDetails(
+                          date: date.forLocation(location: context.location),
+                          isToday: context.isToday(date),
+                          isInFocusedMonth: date.month == focusMonthStart.month && date.year == focusMonthStart.year,
+                        ),
+                      ),
                     ),
                   ),
               ],

--- a/lib/src/widgets/month/month_header.dart
+++ b/lib/src/widgets/month/month_header.dart
@@ -32,7 +32,6 @@ class MonthHeader extends StatelessWidget {
           return const SizedBox.shrink();
         }
         final internalVisibleRange = InternalDateTimeRange.fromDateTimeRange(visibleDateTimeRange);
-        final style = KalenderTheme.of(context).weekDayHeaderStyle;
         final showWeekNumbers = viewConfiguration.showWeekNumbers;
         final numberOfRows = viewConfiguration.pageIndexCalculator.numberOfRowsForRange(internalVisibleRange);
 
@@ -42,7 +41,7 @@ class MonthHeader extends StatelessWidget {
               MonthWeekNumberSpacer(
                 visibleRange: internalVisibleRange,
                 numberOfRows: numberOfRows,
-                weekNumberBuilder: bodyComponents.weekNumberBuilder,
+                weekNumberBuilder: bodyComponents.buildWeekNumber,
               ),
             Expanded(
               child: Row(
@@ -50,7 +49,7 @@ class MonthHeader extends StatelessWidget {
                   7,
                   (index) {
                     final date = visibleDateTimeRange.start.add(Duration(days: index));
-                    return Expanded(child: components.weekDayHeaderBuilder.call(date, style));
+                    return Expanded(child: components.buildWeekDayHeader(context, date));
                   },
                 ),
               ),

--- a/lib/src/widgets/multi_day/multi_day_header.dart
+++ b/lib/src/widgets/multi_day/multi_day_header.dart
@@ -82,7 +82,6 @@ class _SingleDayHeader extends StatelessWidget {
     final pageNavigation = viewConfiguration.pageIndexCalculator;
 
     final headerComponents = components.multiDayComponents.headerComponents;
-    final dayHeaderStyle = KalenderTheme.of(context).dayHeaderStyle;
     final dayHeaderWidget = ValueListenableBuilder(
       valueListenable: context.calendarController.internalDateTimeRange,
       builder: (context, value, child) {
@@ -90,7 +89,7 @@ class _SingleDayHeader extends StatelessWidget {
           debugPrint('Warning: The visibleDateTimeRange is null in MultiDayHeader.');
           return const SizedBox.shrink();
         }
-        return headerComponents.dayHeaderBuilder.call(value.start, dayHeaderStyle);
+        return headerComponents.buildDayHeader(context, value.start);
       },
     );
 
@@ -156,7 +155,6 @@ class _MultiDayHeader extends StatelessWidget {
     final viewConfiguration = viewController.viewConfiguration;
     final pageNavigation = viewConfiguration.pageIndexCalculator;
     final headerComponents = components.multiDayComponents.headerComponents;
-    final weekNumberStyle = KalenderTheme.of(context).weekNumberStyle;
     final weekNumberWidget = ValueListenableBuilder(
       valueListenable: context.calendarController.internalDateTimeRange,
       builder: (context, value, child) {
@@ -164,7 +162,7 @@ class _MultiDayHeader extends StatelessWidget {
           debugPrint('Warning: The visibleDateTimeRange is null in MultiDayHeader.');
           return const SizedBox.shrink();
         }
-        return headerComponents.weekNumberBuilder.call(value.forLocation(location: context.location), weekNumberStyle);
+        return headerComponents.buildWeekNumber(context, value.forLocation(location: context.location));
       },
     );
 
@@ -180,7 +178,8 @@ class _MultiDayHeader extends StatelessWidget {
             children: [
               WeekDayHeaders(
                 dates: visibleDates,
-                dayHeaderBuilder: DayHeader.fromContext,
+                dayHeaderBuilder: (context, date) => context.components.multiDayComponents.headerComponents
+                    .buildDayHeader(context, date.forLocation(location: context.location)),
               ),
               if (configuration.showTiles)
                 Stack(
@@ -236,12 +235,11 @@ class _FreeScrollHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final headerComponents = components.multiDayComponents.headerComponents;
-    final weekNumberStyle = KalenderTheme.of(context).weekNumberStyle;
     final weekNumberWidget = ValueListenableBuilder(
       valueListenable: context.calendarController.internalDateTimeRange,
       builder: (context, value, child) {
         if (value == null) return const SizedBox.shrink();
-        return headerComponents.weekNumberBuilder.call(value.forLocation(location: context.location), weekNumberStyle);
+        return headerComponents.buildWeekNumber(context, value.forLocation(location: context.location));
       },
     );
 
@@ -390,7 +388,11 @@ class _FreeScrollMultiDayBandState extends State<_FreeScrollMultiDayBand> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              WeekDayHeaders(dates: windowDates, dayHeaderBuilder: DayHeader.fromContext),
+              WeekDayHeaders(
+                dates: windowDates,
+                dayHeaderBuilder: (context, date) => context.components.multiDayComponents.headerComponents
+                    .buildDayHeader(context, date.forLocation(location: context.location)),
+              ),
               if (widget.configuration.showTiles)
                 Stack(
                   children: [

--- a/test/widgets/header_month_builder_context_test.dart
+++ b/test/widgets/header_month_builder_context_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+/// The multi-day header and month builders take a [BuildContext] and resolve
+/// their own styles from it.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  final tiles = TileComponents(tileBuilder: (event, tileRange) => const SizedBox());
+
+  Future<void> pump(
+    WidgetTester tester,
+    ViewConfiguration viewConfiguration, {
+    CalendarComponents? components,
+    KalenderThemeData? theme,
+  }) async {
+    final view = CalendarView(
+      eventsController: eventsController,
+      calendarController: calendarController,
+      viewConfiguration: viewConfiguration,
+      components: components,
+      header: CalendarHeader(multiDayTileComponents: tiles),
+      body: CalendarBody(multiDayTileComponents: tiles),
+    );
+    await pumpAndSettleWithMaterialApp(
+      tester,
+      theme == null ? view : KalenderTheme(data: theme, child: view),
+    );
+  }
+
+  final displayRange = DateTimeRange(start: DateTime(2025), end: DateTime(2025, 2));
+  final week = MultiDayViewConfiguration.week(displayRange: displayRange);
+  final month = MonthViewConfiguration.singleMonth(displayRange: displayRange);
+
+  testWidgets('a custom day header resolves its style from the theme', (tester) async {
+    await pump(
+      tester,
+      week,
+      theme: const KalenderThemeData(dayHeaderStyle: DayHeaderStyle(textStyle: TextStyle(fontSize: 42))),
+      components: CalendarComponents(
+        multiDayComponents: MultiDayComponents(
+          headerComponents: MultiDayHeaderComponents(
+            dayHeaderBuilder: (context, date) => _Probe(KalenderTheme.of(context).dayHeaderStyle?.textStyle?.fontSize),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.widgetList<_Probe>(find.byType(_Probe)).first.value, 42);
+  });
+
+  testWidgets('a custom week day header resolves its style from the theme', (tester) async {
+    await pump(
+      tester,
+      month,
+      theme: const KalenderThemeData(weekDayHeaderStyle: WeekDayHeaderStyle(textStyle: TextStyle(fontSize: 21))),
+      components: CalendarComponents(
+        monthComponents: MonthComponents(
+          headerComponents: MonthHeaderComponents(
+            weekDayHeaderBuilder: (context, date) =>
+                _Probe(KalenderTheme.of(context).weekDayHeaderStyle?.textStyle?.fontSize),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.widgetList<_Probe>(find.byType(_Probe)).first.value, 21);
+  });
+
+  testWidgets('a custom month grid builder receives the row count and a context', (tester) async {
+    await pump(
+      tester,
+      month,
+      theme: const KalenderThemeData(monthGridStyle: MonthGridStyle(thickness: 7)),
+      components: CalendarComponents(
+        monthComponents: MonthComponents(
+          bodyComponents: MonthBodyComponents(
+            monthGridBuilder: (context, numberOfRows) =>
+                _Probe(KalenderTheme.of(context).monthGridStyle?.thickness, rows: numberOfRows),
+          ),
+        ),
+      ),
+    );
+
+    final probe = tester.widgetList<_Probe>(find.byType(_Probe)).first;
+    expect(probe.value, 7);
+    expect(probe.rows, greaterThan(0));
+  });
+
+  testWidgets('the month week number builder resolves the top alignment the gutter uses', (tester) async {
+    await pump(
+      tester,
+      MonthViewConfiguration.singleMonth(displayRange: displayRange, showWeekNumbers: true),
+      components: CalendarComponents(
+        monthComponents: MonthComponents(
+          bodyComponents: MonthBodyComponents(
+            weekNumberBuilder: (context, range) =>
+                _AlignmentProbe(KalenderTheme.of(context).weekNumberStyle?.alignment),
+          ),
+        ),
+      ),
+    );
+
+    final probes = tester.widgetList<_AlignmentProbe>(find.byType(_AlignmentProbe));
+    expect(probes, isNotEmpty);
+    expect(probes.first.alignment, Alignment.topCenter);
+  });
+
+  testWidgets('null builders render the package defaults', (tester) async {
+    await pump(tester, month, components: const CalendarComponents());
+
+    expect(find.byType(MonthGrid), findsOneWidget);
+    expect(find.byType(MonthDayHeader), findsWidgets);
+    expect(find.byType(WeekDayHeader), findsWidgets);
+  });
+}
+
+/// Renders nothing. Carries a value its builder resolved from the context.
+class _Probe extends StatelessWidget {
+  const _Probe(this.value, {this.rows});
+
+  final double? value;
+  final int? rows;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+/// Renders nothing. Carries the alignment its builder resolved from the context.
+class _AlignmentProbe extends StatelessWidget {
+  const _AlignmentProbe(this.alignment);
+
+  final AlignmentGeometry? alignment;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -94,7 +94,7 @@ void main() {
       final components = CalendarComponents(
         monthComponents: MonthComponents(
           bodyComponents: MonthBodyComponents(
-            monthDayCellBuilder: (details) {
+            monthDayCellBuilder: (context, details) {
               byDate[DateTime(details.date.year, details.date.month, details.date.day)] = details;
               return const SizedBox.shrink();
             },

--- a/test/widgets/today_highlight_test.dart
+++ b/test/widgets/today_highlight_test.dart
@@ -109,9 +109,9 @@ void main() {
             components: CalendarComponents(
               monthComponents: MonthComponents(
                 bodyComponents: MonthBodyComponents(
-                  monthDayHeaderBuilder: (date, style) {
+                  monthDayHeaderBuilder: (context, date) {
                     received.add(date);
-                    return MonthDayHeader(date: date, style: style);
+                    return MonthDayHeader(date: date);
                   },
                 ),
               ),
@@ -148,9 +148,9 @@ void main() {
             components: CalendarComponents(
               monthComponents: MonthComponents(
                 bodyComponents: MonthBodyComponents(
-                  monthDayHeaderBuilder: (date, style) {
+                  monthDayHeaderBuilder: (context, date) {
                     received.add(date);
-                    return MonthDayHeader(date: date, style: style);
+                    return MonthDayHeader(date: date);
                   },
                 ),
               ),


### PR DESCRIPTION
Second of four slices of the 0.27.0 builder work. Stacked on #449.

`dayHeaderBuilder`, `weekNumberBuilder`, `weekDayHeaderBuilder`, `monthDayHeaderBuilder`, `monthGridBuilder` and `monthDayCellBuilder` take a `BuildContext` first and no longer take a style. The fields are nullable and each components class gained a `buildX` method.

The month week number needed more than a signature change. Its style is the gutter value merged with a private top-alignment default, which a builder resolving from `KalenderTheme` would not have seen. `MonthWeekNumberGutter` and `MonthWeekNumberSpacer` now publish the resolved style to the scope they draw in, the way `DefaultTextStyle.merge` does, so the default widget and a custom builder both read the month's value there and the calendar-wide value everywhere else. A test covers it.

`hasCellBuilder` in the month body compared the field against `MonthDayCell.builder` to decide whether to build the per-day background layer. It asks whether the field is null now.

`web_demo`'s `weekNumberBuilder` read `style?.alignment` and `style?.padding` from the parameter and now reads them from the context.