### PR TITLE
refactor!: the schedule and overlay builders take a BuildContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ See [MIGRATION.md](MIGRATION.md#v026x--v0270) for what to change.
 - The multi-day header and month builders take a `BuildContext` as their first argument and no longer take a style: `dayHeaderBuilder`, `weekNumberBuilder`, `weekDayHeaderBuilder`, `monthDayHeaderBuilder`, `monthGridBuilder` and `monthDayCellBuilder`. Resolve the style with `KalenderTheme.of(context)`.
 - Those fields are nullable and default to `null`. `MultiDayHeaderComponents`, `MonthHeaderComponents` and `MonthBodyComponents` gained a `buildX` method per field.
 - `builder` and `fromContext` are removed from `DayHeader`, `WeekNumber`, `WeekDayHeader`, `MonthGrid`, `MonthDayHeader` and `MonthDayCell`. `MonthDayCell.shadeAdjacentMonths` stays.
+- The schedule builders take a `BuildContext` as their first argument: `leadingDateBuilder`, `scheduleTileHighlightBuilder`, `emptyItemBuilder` and `monthItemBuilder`. The first two also lost their style parameter and are nullable, and `ScheduleComponents` gained `buildLeadingDate` and `buildScheduleTileHighlight`. `ScheduleDate.builder` and `ScheduleTileHighlight.builder` are removed.
+- The overlay builders take a `BuildContext` as their first positional argument, ahead of their named parameters: `multiDayOverlayBuilder`, `multiDayOverlayPortalBuilder`, `multiDayPortalOverlayButtonBuilder` and `MultiDayOverlayEventTileBuilder`. `MultiDayOverlayBuilder` drops `style` and `MultiDayOverlayPortalBuilder` drops `overlayStyles`. Resolve either with `KalenderTheme.of(context)`, or both at once with `OverlayStyles.fromContext(context)`, which stays.
 
 ### Features
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -86,11 +86,43 @@ weekNumberBuilder: (context, range) {
 },
 ```
 
+### The schedule and overlay builders take a `BuildContext`
+
+| Before | After |
+| --- | --- |
+| `leadingDateBuilder: (date, style) =>` | `leadingDateBuilder: (context, date) =>` |
+| `scheduleTileHighlightBuilder: (date, range, style, child) =>` | `scheduleTileHighlightBuilder: (context, date, range, child) =>` |
+| `emptyItemBuilder: (tileRange) =>` | `emptyItemBuilder: (context, tileRange) =>` |
+| `monthItemBuilder: (monthRange) =>` | `monthItemBuilder: (context, monthRange) =>` |
+| `multiDayPortalOverlayButtonBuilder: (controller, rows, style) =>` | `multiDayPortalOverlayButtonBuilder: (context, controller, rows) =>` |
+
+The two overlay builders take all their arguments by name. The context goes in
+front of them as a positional argument, and the style parameter is gone:
+
+```dart
+// Before
+multiDayOverlayBuilder: ({required date, required events, ..., required style}) => MyOverlay(style: style),
+
+// After
+multiDayOverlayBuilder: (context, {required date, required events, ...}) {
+  final style = KalenderTheme.of(context).multiDayOverlayStyle;
+  return MyOverlay(style: style);
+},
+```
+
+`MultiDayOverlayPortalBuilder` loses its `overlayStyles` parameter the same way.
+`OverlayStyles` itself stays, and `OverlayStyles.fromContext(context)` resolves
+both overlay styles at once for a builder that wants the pair.
+
+The overlay is built into an `Overlay` rather than below the calendar.
+`KalenderTheme` is an `InheritedTheme`, so `KalenderTheme.of` still reaches it
+from the overlay builder's context.
+
 ### The `builder` and `fromContext` statics are removed
 
 `TimeLine`, `HourLines`, `DaySeparator`, `TimeIndicator`, `DayHeader`,
-`WeekNumber`, `WeekDayHeader`, `MonthGrid`, `MonthDayHeader` and `MonthDayCell`
-no longer carry them. Construct the widget directly, or call the matching
+`WeekNumber`, `WeekDayHeader`, `MonthGrid`, `MonthDayHeader`, `MonthDayCell`,
+`ScheduleDate` and `ScheduleTileHighlight` no longer carry them. Construct the widget directly, or call the matching
 `buildX` on the components class, which applies your override when you set one.
 `MonthDayCell.shadeAdjacentMonths` is unaffected.
 

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -346,7 +346,7 @@ Pass a `CalendarComponents` object to `CalendarView` to override the default wid
         rightTriggerBuilder: (pageWidth) => SizedBox(width: pageWidth / 20),
         overlayBuilders: OverlayBuilders(
           multiDayPortalOverlayButtonBuilder:
-              (portalController, numberOfHiddenRows, style) => SizedBox(),
+              (context, portalController, numberOfHiddenRows) => SizedBox(),
         ),
       ),
       bodyComponents: MultiDayBodyComponents(
@@ -388,7 +388,7 @@ Pass a `CalendarComponents` object to `CalendarView` to override the default wid
         rightTriggerBuilder: (pageWidth) => SizedBox(),
         overlayBuilders: OverlayBuilders(
           multiDayPortalOverlayButtonBuilder:
-              (portalController, numberOfHiddenRows, style) => SizedBox(),
+              (context, portalController, numberOfHiddenRows) => SizedBox(),
         ),
       ),
     ),
@@ -404,17 +404,17 @@ Pass a `CalendarComponents` object to `CalendarView` to override the default wid
   CalendarComponents(
     scheduleComponents: ScheduleComponents(
       // The date column shown beside the first row of each day.
-      leadingDateBuilder: (date, style) => Container(),
+      leadingDateBuilder: (context, date) => Container(),
 
       // Wraps a row to highlight it as the drop target during a drag.
-      scheduleTileHighlightBuilder: (date, dateTimeRange, style, child) =>
+      scheduleTileHighlightBuilder: (context, date, dateTimeRange, child) =>
           Container(child: child),
 
       // Optional: builder for days with no events.
-      emptyItemBuilder: (tileRange) => Container(),
+      emptyItemBuilder: (context, tileRange) => Container(),
 
       // Optional: builder for the month heading rows.
-      monthItemBuilder: (monthRange) => Container(),
+      monthItemBuilder: (context, monthRange) => Container(),
     ),
   )
   ```

--- a/lib/src/models/components/components.dart
+++ b/lib/src/models/components/components.dart
@@ -146,9 +146,8 @@ class OverlayStyles {
 
   /// The overlay styles resolved from the [KalenderTheme] of the given context.
   ///
-  /// [MultiDayOverlayPortalBuilder] takes no [BuildContext], so a custom portal
-  /// builder cannot resolve these itself and is handed them instead. The
-  /// built-in overlay widgets resolve their own, so nothing is passed to them.
+  /// A convenience for a custom overlay builder that wants both at once. Each
+  /// one is also reachable on its own through [KalenderTheme.of].
   factory OverlayStyles.fromContext(BuildContext context) {
     final theme = KalenderTheme.of(context);
     return OverlayStyles(

--- a/lib/src/models/components/schedule_components.dart
+++ b/lib/src/models/components/schedule_components.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/widgets/components/schedule_date.dart';
 import 'package:kalender/src/widgets/components/schedule_tile_highlight.dart';
@@ -6,7 +7,8 @@ import 'package:kalender/src/widgets/components/schedule_tile_highlight.dart';
 /// A class containing custom widget builders for the `ScheduleBody`.
 class ScheduleComponents {
   /// A function that builds the day header widget.
-  final ScheduleDateBuilder leadingDateBuilder;
+  /// Null uses [ScheduleDate].
+  final ScheduleDateBuilder? leadingDateBuilder;
 
   /// Builds the day name displayed above the day number.
   ///
@@ -14,7 +16,8 @@ class ScheduleComponents {
   final DateStringBuilder? leadingDateStringBuilder;
 
   /// A function that builds the highlight tile widget.
-  final ScheduleTileHighlightBuilder scheduleTileHighlightBuilder;
+  /// Null uses [ScheduleTileHighlight].
+  final ScheduleTileHighlightBuilder? scheduleTileHighlightBuilder;
 
   /// A function that builds the row for a day without events.
   ///
@@ -27,12 +30,28 @@ class ScheduleComponents {
   final MonthItemBuilder? monthItemBuilder;
 
   const ScheduleComponents({
-    this.leadingDateBuilder = ScheduleDate.builder,
+    this.leadingDateBuilder,
     this.leadingDateStringBuilder,
-    this.scheduleTileHighlightBuilder = ScheduleTileHighlight.builder,
+    this.scheduleTileHighlightBuilder,
     this.emptyItemBuilder,
     this.monthItemBuilder,
   });
+
+  /// Builds the leading date, with [leadingDateBuilder] when set.
+  Widget buildLeadingDate(BuildContext context, InternalDateTime date) {
+    return leadingDateBuilder?.call(context, date) ?? ScheduleDate(date: date);
+  }
+
+  /// Wraps [child] in the highlight, with [scheduleTileHighlightBuilder] when set.
+  Widget buildScheduleTileHighlight(
+    BuildContext context,
+    InternalDateTime date,
+    ValueNotifier<InternalDateTimeRange?> dateTimeRange,
+    Widget child,
+  ) {
+    return scheduleTileHighlightBuilder?.call(context, date, dateTimeRange, child) ??
+        ScheduleTileHighlight(date: date, dateTimeRange: dateTimeRange, child: child);
+  }
 
   /// Creates a copy of this with the given fields replaced.
   ScheduleComponents copyWith({
@@ -76,9 +95,9 @@ class ScheduleComponents {
 /// The builder for the empty item.
 ///
 /// [tileRange] is the [DateTimeRange] of the ListTile where this widget will be displayed.
-typedef EmptyItemBuilder = Widget Function(DateTimeRange tileRange);
+typedef EmptyItemBuilder = Widget Function(BuildContext context, DateTimeRange tileRange);
 
 /// The builder for the month item.
 ///
 /// [monthRange] is the [DateTimeRange] of the month.
-typedef MonthItemBuilder = Widget Function(DateTimeRange monthRange);
+typedef MonthItemBuilder = Widget Function(BuildContext context, DateTimeRange monthRange);

--- a/lib/src/widgets/components/multi_day_overlay.dart
+++ b/lib/src/widgets/components/multi_day_overlay.dart
@@ -15,6 +15,7 @@ import 'package:kalender/src/widgets/internal_components/pass_through_pointer.da
 /// The [internalRange] is the range for which the event is displayed.
 /// The [dismissOverlay] is a function that is called when the overlay needs to be dismissed.
 typedef MultiDayOverlayEventTileBuilder = MultiDayEventOverlayTile Function(
+  BuildContext context,
   CalendarEvent event,
   InternalDateTimeRange internalRange,
   VoidCallback dismissOverlay,
@@ -32,8 +33,11 @@ typedef RenderBoxCallback = RenderBox Function();
 /// The [getMultiDayEventLayoutRenderBox] is the function that returns the [RenderBox] for the `MultiDayEventLayoutWidget`.
 /// The [getOverlayPortalRenderBox] is the function that returns the [RenderBox] for the [MultiDayOverlay].
 /// The [overlayTileBuilder] is the builder for the overlay event tile.
-/// The [style] is the style for the overlay.
-typedef MultiDayOverlayBuilder = Widget Function({
+///
+/// Resolve the style with [KalenderTheme], or with [OverlayStyles.fromContext]
+/// for the overlay pair at once.
+typedef MultiDayOverlayBuilder = Widget Function(
+  BuildContext context, {
   required DateTime date,
   required List<CalendarEvent> events,
   required double tileHeight,
@@ -41,7 +45,6 @@ typedef MultiDayOverlayBuilder = Widget Function({
   required RenderBoxCallback getMultiDayEventLayoutRenderBox,
   required RenderBoxCallback getOverlayPortalRenderBox,
   required MultiDayOverlayEventTileBuilder overlayTileBuilder,
-  required MultiDayOverlayStyle? style,
 });
 
 class MultiDayOverlayStyle with Diagnosticable {
@@ -320,7 +323,7 @@ class MultiDayOverlay extends StatelessWidget {
     required this.overlayTileBuilder,
     required this.getMultiDayEventLayoutRenderBox,
     required this.getOverlayPortalRenderBox,
-    required this.style,
+    this.style,
   });
 
   /// Returns a [Key] for the overlay based on the date.
@@ -501,6 +504,7 @@ class MultiDayOverlay extends StatelessWidget {
                                         child: SizedBox(
                                           height: tileHeight,
                                           child: overlayTileBuilder(
+                                            context,
                                             event,
                                             InternalDateTimeRange.fromDateTimeRange(date.dayRange),
                                             portalController.hide,

--- a/lib/src/widgets/components/multi_day_overlay_portal.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal.dart
@@ -10,8 +10,11 @@ import 'package:kalender/kalender.dart';
 /// [tileHeight] is the height of the tile.
 /// [getMultiDayEventLayoutRenderBox] is the function that returns the [RenderBox] MultiDayEventLayoutWidget.
 /// [overlayBuilders] is the builders for the overlay event tile.
-/// [overlayStyles] is the styles for the overlay event tile.
-typedef MultiDayOverlayPortalBuilder = Widget Function({
+///
+/// Resolve the style with [KalenderTheme], or with [OverlayStyles.fromContext]
+/// for the overlay pair at once.
+typedef MultiDayOverlayPortalBuilder = Widget Function(
+  BuildContext context, {
   required DateTime date,
   required List<CalendarEvent> events,
   required int numberOfHiddenRows,
@@ -19,7 +22,6 @@ typedef MultiDayOverlayPortalBuilder = Widget Function({
   required RenderBoxCallback getMultiDayEventLayoutRenderBox,
   required MultiDayOverlayEventTileBuilder overlayTileBuilder,
   required OverlayBuilders? overlayBuilders,
-  required OverlayStyles? overlayStyles,
 });
 
 /// A widget that manages the overlay portal for a single day.
@@ -45,13 +47,6 @@ class MultiDayOverlayPortal extends StatefulWidget {
   /// The builders for the overlay.
   final OverlayBuilders? overlayBuilders;
 
-  /// The styles for the overlay widgets.
-  ///
-  /// Null leaves each overlay widget to resolve its own style from the
-  /// [KalenderTheme], which is what the built-in ones do. Pass a value only to
-  /// override the theme.
-  final OverlayStyles? overlayStyles;
-
   const MultiDayOverlayPortal({
     required this.date,
     required this.events,
@@ -60,7 +55,6 @@ class MultiDayOverlayPortal extends StatefulWidget {
     required this.getMultiDayEventLayoutRenderBox,
     required this.overlayTileBuilder,
     required this.overlayBuilders,
-    this.overlayStyles,
     super.key,
   });
 
@@ -100,6 +94,7 @@ class _MultiDayOverlayPortalState extends State<MultiDayOverlayPortal> {
       controller: _portalController,
       overlayChildBuilder: (overlayContext) {
         return widget.overlayBuilders?.multiDayOverlayBuilder?.call(
+              overlayContext,
               date: widget.date,
               events: widget.events,
               tileHeight: widget.tileHeight,
@@ -107,7 +102,6 @@ class _MultiDayOverlayPortalState extends State<MultiDayOverlayPortal> {
               overlayTileBuilder: widget.overlayTileBuilder,
               getMultiDayEventLayoutRenderBox: widget.getMultiDayEventLayoutRenderBox,
               getOverlayPortalRenderBox: getOverlayPortalRenderBox,
-              style: widget.overlayStyles?.multiDayOverlayStyle,
             ) ??
             MultiDayOverlay(
               key: MultiDayOverlay.getKey(widget.date),
@@ -118,19 +112,17 @@ class _MultiDayOverlayPortalState extends State<MultiDayOverlayPortal> {
               overlayTileBuilder: widget.overlayTileBuilder,
               getMultiDayEventLayoutRenderBox: widget.getMultiDayEventLayoutRenderBox,
               getOverlayPortalRenderBox: getOverlayPortalRenderBox,
-              style: widget.overlayStyles?.multiDayOverlayStyle,
             );
       },
       child: widget.overlayBuilders?.multiDayPortalOverlayButtonBuilder?.call(
+            context,
             _portalController,
             widget.numberOfHiddenRows,
-            widget.overlayStyles?.multiDayPortalOverlayButtonStyle,
           ) ??
           MultiDayPortalOverlayButton(
             key: MultiDayPortalOverlayButton.getKey(widget.date),
             portalController: _portalController,
             numberOfHiddenRows: widget.numberOfHiddenRows,
-            style: widget.overlayStyles?.multiDayPortalOverlayButtonStyle,
             stringBuilder: widget.overlayBuilders?.multiDayPortalOverlayButtonStringBuilder,
           ),
     );

--- a/lib/src/widgets/components/multi_day_overlay_portal_button.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal_button.dart
@@ -10,11 +10,12 @@ import 'package:kalender/src/theme/kalender_theme.dart';
 ///
 /// [portalController] is the controller for the overlay portal.
 /// [numberOfHiddenRows] is the number of events that are not displayed because of constraints.
-/// [style] is the style of the button.
+///
+/// Resolve the style with [KalenderTheme].
 typedef MultiDayPortalOverlayButtonBuilder = Widget Function(
+  BuildContext context,
   OverlayPortalController portalController,
   int numberOfHiddenRows,
-  MultiDayPortalOverlayButtonStyle? style,
 );
 
 class MultiDayPortalOverlayButtonStyle with Diagnosticable {
@@ -104,7 +105,7 @@ class MultiDayPortalOverlayButton extends StatelessWidget {
     super.key,
     required this.portalController,
     required this.numberOfHiddenRows,
-    required this.style,
+    this.style,
     this.stringBuilder,
   });
 

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -12,8 +12,8 @@ import 'package:kalender/src/widgets/internal_components/day_number.dart';
 /// The [date] is the date that the header will be displayed for.
 /// The [style] is used to style the day header.
 typedef ScheduleDateBuilder = Widget Function(
+  BuildContext context,
   InternalDateTime date,
-  ScheduleDateStyle? style,
 );
 
 /// The style of the [ScheduleDate].
@@ -90,9 +90,6 @@ class ScheduleDate extends StatelessWidget {
   /// The [date] is the date that will be displayed.
   /// The [style] is the style of the [ScheduleDate].
   const ScheduleDate({super.key, required this.date, this.style});
-  static ScheduleDate builder(InternalDateTime date, ScheduleDateStyle? style) {
-    return ScheduleDate(date: date, style: style);
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -10,7 +10,8 @@ import 'package:kalender/src/widgets/internal_components/day_number.dart';
 /// The day header builder.
 ///
 /// The [date] is the date that the header will be displayed for.
-/// The [style] is used to style the day header.
+///
+/// Resolve the style with [KalenderTheme].
 typedef ScheduleDateBuilder = Widget Function(
   BuildContext context,
   InternalDateTime date,

--- a/lib/src/widgets/components/schedule_tile_highlight.dart
+++ b/lib/src/widgets/components/schedule_tile_highlight.dart
@@ -7,12 +7,13 @@ import 'package:kalender/src/theme/kalender_theme.dart';
 ///
 /// The [date] is the date that the highlight will be applied to.
 /// The [dateTimeRange] is the range of dates that the highlight will be applied to.
-/// The [style] is the style of the highlight.
 /// The [child] is the widget that will be displayed inside the highlight.
+///
+/// Resolve the style with [KalenderTheme].
 typedef ScheduleTileHighlightBuilder = Widget Function(
+  BuildContext context,
   InternalDateTime date,
   ValueNotifier<InternalDateTimeRange?> dateTimeRange,
-  ScheduleTileHighlightStyle? style,
   Widget child,
 );
 
@@ -66,7 +67,7 @@ class ScheduleTileHighlight extends StatelessWidget {
   final ValueNotifier<InternalDateTimeRange?> dateTimeRange;
 
   /// The style of the highlight.
-  final ScheduleTileHighlightStyle style;
+  final ScheduleTileHighlightStyle? style;
 
   /// The child widget to display.
   final Widget child;
@@ -75,22 +76,9 @@ class ScheduleTileHighlight extends StatelessWidget {
     super.key,
     required this.date,
     required this.dateTimeRange,
-    required this.style,
+    this.style,
     required this.child,
   });
-  static ScheduleTileHighlight builder(
-    InternalDateTime date,
-    ValueNotifier<InternalDateTimeRange?> dateTimeRange,
-    ScheduleTileHighlightStyle? style,
-    Widget child,
-  ) {
-    return ScheduleTileHighlight(
-      date: date,
-      dateTimeRange: dateTimeRange,
-      style: style ?? const ScheduleTileHighlightStyle(),
-      child: child,
-    );
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/events_widgets/multi_day_events_widget.dart
+++ b/lib/src/widgets/events_widgets/multi_day_events_widget.dart
@@ -362,12 +362,6 @@ class _MultiDayEventLayoutWidgetState extends State<MultiDayEventLayoutWidget> {
         if (frame.totalNumberOfRows > maxNumberOfRows)
           Row(
             children: (() {
-              final overlayBuilders = widget.multiDayOverlayBuilders;
-              // The built-in overlay widgets resolve their own style. A custom
-              // builder for either takes no BuildContext, so it is handed the
-              // resolved pair, and only then is resolving it worth doing.
-              final needsStyles = overlayBuilders?.multiDayOverlayBuilder != null ||
-                  overlayBuilders?.multiDayPortalOverlayButtonBuilder != null;
               return frame.columnRowMap.entries.map((entry) {
                 final column = entry.key;
                 final row = entry.value;
@@ -376,6 +370,7 @@ class _MultiDayEventLayoutWidgetState extends State<MultiDayEventLayoutWidget> {
                 late final numberOfHiddenRows = (row + 1) - maxNumberOfRows;
 
                 late final overlayPortal = widget.multiDayOverlayBuilders?.multiDayOverlayPortalBuilder?.call(
+                      context,
                       date: date,
                       events: eventsForColumn,
                       numberOfHiddenRows: numberOfHiddenRows,
@@ -383,7 +378,6 @@ class _MultiDayEventLayoutWidgetState extends State<MultiDayEventLayoutWidget> {
                       getMultiDayEventLayoutRenderBox: getRenderBox,
                       overlayTileBuilder: _overlayEventTileBuilder,
                       overlayBuilders: widget.multiDayOverlayBuilders,
-                      overlayStyles: OverlayStyles.fromContext(context),
                     ) ??
                     MultiDayOverlayPortal(
                       key: MultiDayOverlayPortal.getKey(date),
@@ -394,10 +388,6 @@ class _MultiDayEventLayoutWidgetState extends State<MultiDayEventLayoutWidget> {
                       getMultiDayEventLayoutRenderBox: getRenderBox,
                       overlayBuilders: widget.multiDayOverlayBuilders,
                       overlayTileBuilder: _overlayEventTileBuilder,
-                      // MultiDayOverlay and MultiDayPortalOverlayButton resolve
-                      // their own, but a custom builder for either takes no
-                      // BuildContext and is handed these instead.
-                      overlayStyles: needsStyles ? OverlayStyles.fromContext(context) : null,
                     );
 
                 return Expanded(
@@ -412,6 +402,7 @@ class _MultiDayEventLayoutWidgetState extends State<MultiDayEventLayoutWidget> {
 
   /// The function that builds the overlay event tile for the event.
   MultiDayEventOverlayTile _overlayEventTileBuilder(
+    BuildContext context,
     CalendarEvent event,
     InternalDateTimeRange dateTimeRange,
     VoidCallback dismissOverlay,

--- a/lib/src/widgets/schedule/schedule_body.dart
+++ b/lib/src/widgets/schedule/schedule_body.dart
@@ -380,25 +380,24 @@ class _SchedulePositionListState extends State<SchedulePositionList> {
             final leadingWidth = widget.configuration.leadingWidth;
             Widget leadingSlot(Widget? child) => SizedBox(width: leadingWidth, child: child);
 
-            // A MonthItem row reads neither of the two below, so resolve the
-            // theme only once a row that needs it asks.
-            late final theme = KalenderTheme.of(context);
-            late final leading =
-                components.leadingDateBuilder.call(InternalDateTime.fromDateTime(date), theme.scheduleDateStyle);
-            late final highlightStyle = theme.scheduleTileHighlightStyle;
-            late final highlightBuilder = components.scheduleTileHighlightBuilder;
+            late final leading = components.buildLeadingDate(context, InternalDateTime.fromDateTime(date));
 
             if (item is MonthItem) {
               final locale = context.locale;
-              return components.monthItemBuilder?.call(InternalDateTime.fromDateTime(date).monthRange) ??
+              return components.monthItemBuilder?.call(context, InternalDateTime.fromDateTime(date).monthRange) ??
                   ListTile(title: Text(date.monthNameLocalized(locale)));
             } else if (item is EmptyItem) {
               final child = ListTile(
                 minLeadingWidth: 0,
                 leading: leadingSlot(leading),
-                title: components.emptyItemBuilder?.call(InternalDateTime.fromDateTime(date).dayRange),
+                title: components.emptyItemBuilder?.call(context, InternalDateTime.fromDateTime(date).dayRange),
               );
-              return highlightBuilder(date, viewController.highlightedDateTimeRange, highlightStyle, child);
+              return components.buildScheduleTileHighlight(
+                context,
+                date,
+                viewController.highlightedDateTimeRange,
+                child,
+              );
             } else if (item is EventItem) {
               final showDate = item.isFirst;
               final event = eventsController.byId(item.eventId)!;
@@ -416,7 +415,12 @@ class _SchedulePositionListState extends State<SchedulePositionList> {
                 ),
               );
 
-              return highlightBuilder(date, viewController.highlightedDateTimeRange, highlightStyle, child);
+              return components.buildScheduleTileHighlight(
+                context,
+                date,
+                viewController.highlightedDateTimeRange,
+                child,
+              );
             } else {
               throw Exception('Unknown item type: ${item.runtimeType}');
             }

--- a/test/widgets/overlay_portal_builder_test.dart
+++ b/test/widgets/overlay_portal_builder_test.dart
@@ -4,10 +4,9 @@ import 'package:kalender/kalender.dart';
 
 import '../utilities.dart';
 
-/// A custom [MultiDayOverlayPortalBuilder] takes no [BuildContext], so it cannot
-/// resolve the overlay styles for itself and is handed them instead. The
-/// built-in overlay widgets resolve their own, so nothing is passed down to
-/// them.
+/// Every overlay builder takes a [BuildContext] and resolves its own styles.
+/// The overlay itself is built into an [Overlay] rather than below the calendar,
+/// so its builder's context has to reach a [KalenderTheme] across that boundary.
 void main() {
   final day = DateTime.utc(2025, 1, 15);
 
@@ -53,12 +52,13 @@ void main() {
     );
   }
 
-  testWidgets('a custom portal builder receives styles resolved from the theme', (tester) async {
+  testWidgets('a custom portal builder resolves the overlay styles from its context', (tester) async {
     OverlayStyles? received;
 
     await pumpOverflowingMonth(
       tester,
-      portalBuilder: ({
+      portalBuilder: (
+        context, {
         required date,
         required events,
         required numberOfHiddenRows,
@@ -66,16 +66,14 @@ void main() {
         required getMultiDayEventLayoutRenderBox,
         required overlayTileBuilder,
         required overlayBuilders,
-        required overlayStyles,
       }) {
-        received = overlayStyles;
+        received = OverlayStyles.fromContext(context);
         return const SizedBox();
       },
     );
 
-    expect(received, isNotNull, reason: 'the builder should not have to resolve the theme itself');
     expect(
-      received!.multiDayOverlayStyle,
+      received?.multiDayOverlayStyle,
       isNotNull,
       reason: 'the Material defaults populate this even when the app sets nothing',
     );
@@ -87,7 +85,8 @@ void main() {
     await pumpOverflowingMonth(
       tester,
       scoped: const KalenderThemeData(multiDayOverlayStyle: MultiDayOverlayStyle(width: 321)),
-      portalBuilder: ({
+      portalBuilder: (
+        context, {
         required date,
         required events,
         required numberOfHiddenRows,
@@ -95,9 +94,8 @@ void main() {
         required getMultiDayEventLayoutRenderBox,
         required overlayTileBuilder,
         required overlayBuilders,
-        required overlayStyles,
       }) {
-        received = overlayStyles;
+        received = OverlayStyles.fromContext(context);
         return const SizedBox();
       },
     );
@@ -105,10 +103,7 @@ void main() {
     expect(received?.multiDayOverlayStyle?.width, equals(321));
   });
 
-  // The built-in portal resolves nothing for itself, but it hands these two
-  // builders a style, and neither typedef takes a BuildContext. Passing nothing
-  // to the portal left both permanently null.
-  testWidgets('a custom overflow button builder receives the resolved style', (tester) async {
+  testWidgets('a custom overflow button builder resolves its style from its context', (tester) async {
     MultiDayPortalOverlayButtonStyle? received;
 
     await pumpOverflowingMonth(
@@ -117,25 +112,25 @@ void main() {
         multiDayPortalOverlayButtonStyle: MultiDayPortalOverlayButtonStyle(textStyle: TextStyle(fontSize: 21)),
       ),
       overlayBuilders: OverlayBuilders(
-        multiDayPortalOverlayButtonBuilder: (controller, numberOfHiddenRows, style) {
-          received = style;
+        multiDayPortalOverlayButtonBuilder: (context, controller, numberOfHiddenRows) {
+          received = KalenderTheme.of(context).multiDayPortalOverlayButtonStyle;
           return const SizedBox();
         },
       ),
     );
 
-    expect(received, isNotNull, reason: 'the builder cannot resolve the theme itself');
-    expect(received!.textStyle?.fontSize, equals(21));
+    expect(received?.textStyle?.fontSize, equals(21));
   });
 
-  testWidgets('a custom overlay builder receives the resolved style', (tester) async {
+  testWidgets('a custom overlay builder resolves its style across the Overlay boundary', (tester) async {
     MultiDayOverlayStyle? received;
 
     await pumpOverflowingMonth(
       tester,
       scoped: const KalenderThemeData(multiDayOverlayStyle: MultiDayOverlayStyle(width: 321)),
       overlayBuilders: OverlayBuilders(
-        multiDayOverlayBuilder: ({
+        multiDayOverlayBuilder: (
+          context, {
           required date,
           required events,
           required tileHeight,
@@ -143,9 +138,8 @@ void main() {
           required overlayTileBuilder,
           required getMultiDayEventLayoutRenderBox,
           required getOverlayPortalRenderBox,
-          required style,
         }) {
-          received = style;
+          received = KalenderTheme.of(context).multiDayOverlayStyle;
           return const SizedBox();
         },
       ),

--- a/test/widgets/schedule/schedule_body_test.dart
+++ b/test/widgets/schedule/schedule_body_test.dart
@@ -247,6 +247,6 @@ void main() {
   });
 }
 
-Widget _customMonthItem(DateTimeRange monthRange) => const Text('custom month');
+Widget _customMonthItem(BuildContext context, DateTimeRange monthRange) => const Text('custom month');
 
-Widget _customEmptyItem(DateTimeRange tileRange) => const Text('custom empty');
+Widget _customEmptyItem(BuildContext context, DateTimeRange tileRange) => const Text('custom empty');


### PR DESCRIPTION
Third of four slices of the 0.27.0 builder work. Stacked on #450.

The schedule builders follow the pattern the other components already use: context first, no style, nullable fields, and a `buildX` method for the two that had a widget default.

The overlay builders take all their arguments by name, so the context goes in front of them as a positional argument. Dropping their styles removes plumbing that existed only because they had no context:

- `MultiDayOverlayPortal` no longer carries an `overlayStyles` field.
- `MultiDayEventsWidget` no longer computes whether resolving a style pair is worth doing.
- Neither one calls `OverlayStyles.fromContext` on the calendar's behalf.

`OverlayStyles` stays as a public type, and `OverlayStyles.fromContext(context)` is now what a custom overlay builder calls when it wants both styles at once.

The overlay is built into an `Overlay` rather than below the calendar. `KalenderTheme` is an `InheritedTheme`, so a custom builder resolving from the overlay context still reaches a scoped theme. `overlay_portal_builder_test.dart` was rewritten for the new contract and covers that case.