### PR TITLE
chore: comment_references is enabled

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -32,6 +32,7 @@ linter:
     type_literal_in_constant_pattern: true
     directives_ordering: true
     prefer_const_constructors: true
+    comment_references: true
 
 formatter:
   page_width: 120

--- a/lib/src/models/calendar_events/calendar_event.dart
+++ b/lib/src/models/calendar_events/calendar_event.dart
@@ -2,8 +2,8 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart' show EventInteraction;
-import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/calendar_events/multi_day_rule.dart';
+import 'package:kalender/src/models/view_configurations/view_configuration.dart';
 import 'package:meta/meta.dart';
 
 /// Base class for events displayed in the calendar.

--- a/lib/src/models/components/components.dart
+++ b/lib/src/models/components/components.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kalender/src/calendar_view.dart';
 import 'package:kalender/src/models/components/month_components.dart';
 import 'package:kalender/src/models/components/multi_day_components.dart';
 import 'package:kalender/src/models/components/schedule_components.dart';

--- a/lib/src/models/components/multi_day_components.dart
+++ b/lib/src/models/components/multi_day_components.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:kalender/src/models/components/components.dart';
 import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/widgets/components/day_header.dart';

--- a/lib/src/models/components/string_builders.dart
+++ b/lib/src/models/components/string_builders.dart
@@ -25,7 +25,7 @@ extension CalendarLocale on BuildContext {
   /// The locale of the enclosing calendar, as passed to `CalendarView.locale`.
   ///
   /// This is the locale the calendar formats its own dates and times with, which
-  /// is not necessarily the app's locale. Pass it to `intl`'s [DateFormat] or
-  /// [NumberFormat], or to the localized extensions on [DateTime].
+  /// is not necessarily the app's locale. Pass it to `intl`'s `DateFormat` or
+  /// `NumberFormat`, or to the localized extensions on [DateTime].
   dynamic get calendarLocale => LocaleProvider.of(this);
 }

--- a/lib/src/models/components/tile_components.dart
+++ b/lib/src/models/components/tile_components.dart
@@ -153,7 +153,7 @@ class ScheduleTileComponents extends TileComponents {
 /// [event] is the event that the tile will be built for.
 ///
 /// [tileRange] is the wall-clock [DateTimeRange] of the view the tile will be displayed in.
-/// The values are local [DateTime]s (or [TZDateTime]s when a timezone location is set).
+/// The values are local [DateTime]s (or `TZDateTime`s when a timezone location is set).
 typedef TileBuilder = Widget Function(
   CalendarEvent event,
   DateTimeRange tileRange,

--- a/lib/src/models/controllers/events_controller.dart
+++ b/lib/src/models/controllers/events_controller.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/calendar_events/calendar_event.dart';
 import 'package:kalender/src/models/calendar_events/multi_day_rule.dart';
+import 'package:kalender/src/models/controllers/events_controller/default_events_controller.dart';
+import 'package:kalender/src/models/view_configurations/view_configuration.dart';
 
 /// The [EventsController] is used to manage [CalendarEvent]s.
 ///

--- a/lib/src/models/mixins/drag_target_utils.dart
+++ b/lib/src/models/mixins/drag_target_utils.dart
@@ -194,6 +194,12 @@ mixin DragTargetUtilities<T extends StatefulWidget> on State<T> {
   /// Reschedule an event.
   CalendarEvent? createEvent(InternalDateTime cursorDateTime) => newEvent ??= controller.newEvent;
 
+  /// Resolves the latest version of the [event] from the [EventsController],
+  /// falling back to the provided instance if not found.
+  CalendarEvent _resolveEvent(CalendarEvent event) {
+    return eventsController.byId(event.id) ?? event;
+  }
+
   /// Processes the [DragTargetDetails] and handle different types of detail data (reschedule, resize, create, other).
   ///
   /// [onCreate] - handle the [Create] type.
@@ -202,12 +208,6 @@ mixin DragTargetUtilities<T extends StatefulWidget> on State<T> {
   /// [onOther] - handle other types.
   ///
   /// Each handler function returns a value of type [K], which is the result of handling the data.
-  /// Resolves the latest version of the [event] from the [EventsController],
-  /// falling back to the provided instance if not found.
-  CalendarEvent _resolveEvent(CalendarEvent event) {
-    return eventsController.byId(event.id) ?? event;
-  }
-
   static K handleDragDetails<K extends Object?, T extends Object?>(
     DragTargetDetails<Object?> details, {
     required K Function(int controllerId) onCreate,

--- a/lib/src/models/providers/calendar_provider.dart
+++ b/lib/src/models/providers/calendar_provider.dart
@@ -62,7 +62,7 @@ class LocaleProvider extends InheritedWidget {
   /// Creates a [LocaleProvider] with the specified locale.
   const LocaleProvider({super.key, required this.locale, required super.child});
 
-  /// Gets the [LocaleProvider] of type [T] from the context.
+  /// Gets the [LocaleProvider] from the context.
   static dynamic of(BuildContext context) {
     final result = context.dependOnInheritedWidgetOfExactType<LocaleProvider>();
     assert(result != null, 'No LocaleProvider found.');
@@ -173,7 +173,7 @@ class Snapping extends InheritedNotifier<ValueNotifier<CalendarSnapping>> {
 class HeightPerMinute extends InheritedNotifier<ValueNotifier<double>> {
   const HeightPerMinute({super.key, required super.notifier, required super.child});
 
-  /// Gets the [HeightPerMinute] of type [T] from the context.
+  /// Gets the [HeightPerMinute] from the context.
   static double of(BuildContext context) {
     final result = context.dependOnInheritedWidgetOfExactType<HeightPerMinute>();
     assert(result != null, 'No HeightPerMinuteProvider found.');

--- a/lib/src/models/view_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_view_configuration.dart
@@ -6,6 +6,9 @@ import 'package:kalender/src/models/navigation_triggers.dart';
 import 'package:kalender/src/models/view_configurations/page_index_calculator.dart';
 import 'package:kalender/src/models/view_configurations/view_configuration.dart';
 import 'package:kalender/src/models/view_transition.dart';
+import 'package:kalender/src/widgets/month/month_body.dart';
+import 'package:kalender/src/widgets/multi_day/multi_day_body.dart';
+import 'package:kalender/src/widgets/multi_day/multi_day_header.dart';
 
 enum MultiDayViewType {
   singleDay,

--- a/lib/src/models/view_configurations/view_configuration.dart
+++ b/lib/src/models/view_configurations/view_configuration.dart
@@ -6,6 +6,9 @@ import 'package:kalender/src/models/navigation_triggers.dart';
 import 'package:kalender/src/models/view_configurations/page_index_calculator.dart';
 import 'package:kalender/src/models/view_configurations/schedule_view_configuration.dart';
 import 'package:kalender/src/models/view_transition.dart';
+import 'package:kalender/src/widgets/components/day_header.dart';
+import 'package:kalender/src/widgets/components/month_day_header.dart';
+import 'package:kalender/src/widgets/components/schedule_date.dart';
 
 export 'package:kalender/kalender_extensions.dart';
 

--- a/lib/src/widgets/components/multi_day_overlay_portal_button.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:kalender/src/models/components/components.dart';
 import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';

--- a/lib/src/widgets/internal_components/day_number.dart
+++ b/lib/src/widgets/internal_components/day_number.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 /// date, and the multi-day overlay.
 ///
 /// It is never interactive. It is a label that happens to be drawn like a
-/// button, so [onPressed] is always null and the highlight has to set the
+/// button, so `onPressed` is always null and the highlight has to set the
 /// disabled colors to stay tonal.
 class DayNumber extends StatelessWidget {
   const DayNumber({

--- a/lib/src/widgets/internal_components/expandable_page_view.dart
+++ b/lib/src/widgets/internal_components/expandable_page_view.dart
@@ -153,7 +153,7 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
 /// Reports its child's size after layout using a custom [RenderProxyBox].
 ///
 /// Unlike approaches that read size via [GlobalKey] in a post-frame callback,
-/// this reads the child's size directly in [performLayout] — the only point in
+/// this reads the child's size directly in `performLayout` — the only point in
 /// the pipeline where the render object is guaranteed to have a valid size.
 class _SizeReporter extends SingleChildRenderObjectWidget {
   final ValueChanged<Size> onSizeChanged;

--- a/lib/src/widgets/multi_day/multi_day_header.dart
+++ b/lib/src/widgets/multi_day/multi_day_header.dart
@@ -267,7 +267,7 @@ class _FreeScrollHeader extends StatelessWidget {
 ///
 /// Only the visible window is rendered, so the strip stays small regardless of
 /// how large the display range is. The horizontal position is derived from
-/// [MultiDayViewController.pageOffset] and applied synchronously in [build], so
+/// [MultiDayViewController.pageOffset] and applied synchronously in `build`, so
 /// re-anchoring the window and its offset compensation happen on the same frame
 /// (no visible jump).
 class _FreeScrollMultiDayBand extends StatefulWidget {

--- a/test/interactions/drag_target_edge_cases_test.dart
+++ b/test/interactions/drag_target_edge_cases_test.dart
@@ -12,7 +12,7 @@ import '../utilities.dart';
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Jan 6, 2025 is a Monday, so a week-view initialized here shows
-/// Monday Jan 6 → Sunday Jan 12 in [visibleDates], giving deterministic
+/// Monday Jan 6 → Sunday Jan 12 in `visibleDates`, giving deterministic
 /// date assertions in all cursor-position tests.
 final _weekInitialDate = DateTime(2025, 1, 6);
 


### PR DESCRIPTION
Groundwork for the 0.27.0 builder stack, on `main` so the stack is checked by it.

Dangling dartdoc references were invisible here: the analyzer did not check them and neither did CI, so a `[name]` pointing at nothing rendered as plain text and nobody noticed. Enabling the lint turned up 31.

Most were a type referenced without an import, which the reference now has. Six named nothing that exists and are demoted to code spans: `DateFormat` and `NumberFormat`, `TZDateTime`, `IconButton`'s `onPressed`, `RenderBox`'s `performLayout`, and a `State`'s `build`.

Two were real defects:

- `LocaleProvider.of` and `HeightPerMinute.of` were both documented as returning "of type `[T]`". Neither is generic and neither ever was.
- `handleDragDetails` had lost its documentation. A `_resolveEvent` method was added between the doc comment and the method it describes, so eight lines about the handler callbacks and the `K` return type became part of `_resolveEvent`'s doc while `handleDragDetails` was left undocumented. The block is back on the method it documents.

`flutter analyze` exits non-zero on infos and CI runs it bare, so this is enforced rather than advisory.