### PR TITLE
chore: prepare 0.27.0-dev.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,8 +273,10 @@ before tagging it:
   including `CreateEventGesture` to `EventInteractionGesture`, the `renderBox`
   parameter on `OnEventTapped` and `OnEventTappedWithDetail`, and
   `MultiDayBodyConfiguration` in favour of `VerticalConfiguration`. Find them
-  with `grep -rn "TODO" lib/`. They are `//` comments so they do not render as
-  prose in the API reference, but each one is a decision still owed.
+  with `grep -rn "TODO" lib/`. Each one is a decision still owed. Keep them as
+  `//` comments: a `///` one renders as prose in the API reference, which is how
+  `FreeScrollFunctions` shipped with a TODO as its entire published
+  documentation. `grep -rn "/// TODO" lib/` is the check.
 - **Deprecations past their window.** None. `lib/` carries no `@Deprecated` at
   all: `TimeOfDayRange.isAllDay` was removed in 0.27.0 as its 0.26.0 message
   named, and the `CalendarComponents` style fields with the seven containers they

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,10 +32,10 @@ if (timeOfDayRange.coversWholeDay) { ... }
 
 `TimeOfDayRange.allDay()` is a different member and is unaffected.
 
-### The multi-day body builders take a `BuildContext`
+### Every builder takes a `BuildContext`
 
-Each one dropped its style parameter and gained a context as its first argument.
-Resolve the style yourself from the context.
+Each builder gained a context as its first argument. The fifteen that carried a
+style lost it, and resolve one from the context instead.
 
 | Before | After |
 | --- | --- |
@@ -44,6 +44,24 @@ Resolve the style yourself from the context.
 | `timelineWidth: (context, range, style) =>` | `timelineWidth: (context, range) =>` |
 | `daySeparator: (style) =>` | `daySeparator: (context) =>` |
 | `timeIndicator: (range, heightPerMinute, style, location) =>` | `timeIndicator: (context, range, heightPerMinute, location) =>` |
+| `dayHeaderBuilder: (date, style) =>` | `dayHeaderBuilder: (context, date) =>` |
+| `weekNumberBuilder: (range, style) =>` | `weekNumberBuilder: (context, range) =>` |
+| `weekDayHeaderBuilder: (date, style) =>` | `weekDayHeaderBuilder: (context, date) =>` |
+| `monthDayHeaderBuilder: (date, style) =>` | `monthDayHeaderBuilder: (context, date) =>` |
+| `monthGridBuilder: (style, numberOfRows) =>` | `monthGridBuilder: (context, numberOfRows) =>` |
+| `monthDayCellBuilder: (details) =>` | `monthDayCellBuilder: (context, details) =>` |
+| `leadingDateBuilder: (date, style) =>` | `leadingDateBuilder: (context, date) =>` |
+| `scheduleTileHighlightBuilder: (date, range, style, child) =>` | `scheduleTileHighlightBuilder: (context, date, range, child) =>` |
+| `emptyItemBuilder: (tileRange) =>` | `emptyItemBuilder: (context, tileRange) =>` |
+| `monthItemBuilder: (monthRange) =>` | `monthItemBuilder: (context, monthRange) =>` |
+| `multiDayPortalOverlayButtonBuilder: (controller, rows, style) =>` | `multiDayPortalOverlayButtonBuilder: (context, controller, rows) =>` |
+| `tileBuilder: (event, tileRange) =>` | `tileBuilder: (context, event, tileRange) =>` |
+| `overlayTileBuilder: (event, tileRange) =>` | `overlayTileBuilder: (context, event, tileRange) =>` |
+| `tileWhenDraggingBuilder: (event) =>` | `tileWhenDraggingBuilder: (context, event) =>` |
+| `feedbackTileBuilder: (event, size) =>` | `feedbackTileBuilder: (context, event, size) =>` |
+| `dropTargetTile: (event) =>` | `dropTargetTile: (context, event) =>` |
+| `leftTriggerBuilder: (pageWidth) =>` | `leftTriggerBuilder: (context, pageWidth) =>` |
+| `topTriggerBuilder: (viewPortHeight) =>` | `topTriggerBuilder: (context, viewPortHeight) =>` |
 
 A builder that read the style it was passed reads it from the context instead:
 
@@ -58,32 +76,33 @@ daySeparator: (context) {
 },
 ```
 
-The timeline is the exception. Its style decides the gutter width, which the body,
-the header and the drag overlay all measure from, so it comes from `GutterStyles`
-rather than from the theme:
+A builder written as a named function or a static takes the context the same way:
+
+```dart
+// Before
+static EventTile builder(CalendarEvent event, DateTimeRange tileRange) => EventTile(event: event);
+
+// After
+static EventTile builder(BuildContext context, CalendarEvent event, DateTimeRange tileRange) =>
+    EventTile(event: event);
+```
+
+Four cases need more than the signature change.
+
+#### The timeline resolves from `GutterStyles`, not the theme
+
+Its style decides the gutter width, which the body, the header and the drag
+overlay all measure from. A theme scoped inside the calendar cannot move it.
 
 ```dart
 timelineWidth: (context, range) => GutterStyles.timelineStyleOf(context).width ?? 56,
 ```
 
-### The multi-day header and month builders take a `BuildContext`
+#### The month week number keeps its top alignment
 
-The same change, for the builders that draw headers, the month grid and week
-numbers.
-
-| Before | After |
-| --- | --- |
-| `dayHeaderBuilder: (date, style) =>` | `dayHeaderBuilder: (context, date) =>` |
-| `weekNumberBuilder: (range, style) =>` | `weekNumberBuilder: (context, range) =>` |
-| `weekDayHeaderBuilder: (date, style) =>` | `weekDayHeaderBuilder: (context, date) =>` |
-| `monthDayHeaderBuilder: (date, style) =>` | `monthDayHeaderBuilder: (context, date) =>` |
-| `monthGridBuilder: (style, numberOfRows) =>` | `monthGridBuilder: (context, numberOfRows) =>` |
-| `monthDayCellBuilder: (details) =>` | `monthDayCellBuilder: (context, details) =>` |
-
-A `weekNumberBuilder` in the month gutter still gets the month's own top
-alignment. The gutter publishes the style it measures with to the scope it draws
-in, so `KalenderTheme.of(context).weekNumberStyle` returns the month's value
-there and the calendar-wide value everywhere else.
+The gutter publishes the style it measures with to the scope it draws in, so
+`KalenderTheme.of(context).weekNumberStyle` returns the month's value there and
+the calendar-wide value everywhere else.
 
 ```dart
 // Before
@@ -102,18 +121,10 @@ weekNumberBuilder: (context, range) {
 },
 ```
 
-### The schedule and overlay builders take a `BuildContext`
+#### The two overlay builders take the context positionally
 
-| Before | After |
-| --- | --- |
-| `leadingDateBuilder: (date, style) =>` | `leadingDateBuilder: (context, date) =>` |
-| `scheduleTileHighlightBuilder: (date, range, style, child) =>` | `scheduleTileHighlightBuilder: (context, date, range, child) =>` |
-| `emptyItemBuilder: (tileRange) =>` | `emptyItemBuilder: (context, tileRange) =>` |
-| `monthItemBuilder: (monthRange) =>` | `monthItemBuilder: (context, monthRange) =>` |
-| `multiDayPortalOverlayButtonBuilder: (controller, rows, style) =>` | `multiDayPortalOverlayButtonBuilder: (context, controller, rows) =>` |
-
-The two overlay builders take all their arguments by name. The context goes in
-front of them as a positional argument, and the style parameter is gone:
+They take all their other arguments by name, so the context goes in front of
+them:
 
 ```dart
 // Before
@@ -135,34 +146,7 @@ The overlay is built into an `Overlay` rather than below the calendar.
 `KalenderTheme` is an `InheritedTheme`, so `KalenderTheme.of` still reaches it
 from the overlay builder's context.
 
-### The tile and trigger builders take a `BuildContext`
-
-These carry no style, so the context is the only change. Every app that draws its
-own tiles is affected.
-
-| Before | After |
-| --- | --- |
-| `tileBuilder: (event, tileRange) =>` | `tileBuilder: (context, event, tileRange) =>` |
-| `overlayTileBuilder: (event, tileRange) =>` | `overlayTileBuilder: (context, event, tileRange) =>` |
-| `tileWhenDraggingBuilder: (event) =>` | `tileWhenDraggingBuilder: (context, event) =>` |
-| `feedbackTileBuilder: (event, size) =>` | `feedbackTileBuilder: (context, event, size) =>` |
-| `dropTargetTile: (event) =>` | `dropTargetTile: (context, event) =>` |
-| `leftTriggerBuilder: (pageWidth) =>` | `leftTriggerBuilder: (context, pageWidth) =>` |
-| `topTriggerBuilder: (viewPortHeight) =>` | `topTriggerBuilder: (context, viewPortHeight) =>` |
-
-A tile builder written as a named function or a static takes the context the same
-way:
-
-```dart
-// Before
-static EventTile builder(CalendarEvent event, DateTimeRange tileRange) => EventTile(event: event);
-
-// After
-static EventTile builder(BuildContext context, CalendarEvent event, DateTimeRange tileRange) =>
-    EventTile(event: event);
-```
-
-### `ResizeHandlePositioner` takes a `BuildContext`
+#### `ResizeHandlePositioner` also loses its `TileComponents`
 
 The context goes in front, and the lookup moves off the widget:
 
@@ -779,7 +763,7 @@ The multi-day body, header and drag overlay previously worked out the left timel
 
 `MultiDayBodyComponents.prototypeTimeLine`, the `PrototypeTimeline` widget, and the `PrototypeTimeLineBuilder` typedef have been removed.
 
-**If you only set `bodyStyles.timelineStyle`** (including a custom `stringBuilder`): no change needed — the header and body now always match.
+**If you only set `bodyStyles.timelineStyle`** (including a custom `stringBuilder`): no change needed. The header and body now always match.
 
 **If you overrode `prototypeTimeLine`:** return the width as a `double` from `timelineWidth` instead of building a widget.
 
@@ -838,7 +822,7 @@ The received `date` is already in the calendar's configured location, so any man
 | On switching view type (e.g. Week → Month → Week) | Before (`0.18.x`) | Now (`0.19.0`) |
 |---|---|---|
 | Vertical scroll (time-of-day) | **Reset** to `initialTimeOfDay` every time | **Preserved** (`ScrollTransition.preserve`) |
-| Zoom (`heightPerMinute`) | Preserved only between *adjacent* multi-day views; lost through a non-scrolling view (e.g. Month) | **Preserved**, including across a round-trip through Month (`ZoomTransition.preserve`) |
+| Zoom (`heightPerMinute`) | Preserved only between *adjacent* multi-day views. Lost through a non-scrolling view, for example Month | **Preserved**, including across a round-trip through Month (`ZoomTransition.preserve`) |
 | Visible date | Carried forward from the outgoing view | Unchanged (`DateTransition.carryFocus`) |
 
 To restore the old "always reset the scroll on a view change" behaviour:
@@ -852,7 +836,7 @@ MultiDayViewConfiguration.week(
 
 ### `EmptyDayBehavior.showToday` renamed to `showOnlyToday`
 
-`EmptyDayBehavior.showToday` has been renamed to `EmptyDayBehavior.showOnlyToday`. The behaviour is unchanged — among empty days, only today is shown — the new name just removes the ambiguity (it never showed *all* empty days plus today).
+`EmptyDayBehavior.showToday` has been renamed to `EmptyDayBehavior.showOnlyToday`. The behaviour is unchanged: among empty days, only today is shown. The new name removes the ambiguity, since it never showed *all* empty days plus today.
 
 **Before:**
 ```dart
@@ -868,8 +852,8 @@ ScheduleBodyConfiguration(emptyDay: EmptyDayBehavior.showOnlyToday)
 
 `ViewConfiguration.initialDateSelectionStrategy` has been removed. How a view switch transfers state is now expressed per dimension:
 
-- **Date** (all views): `dateTransition` — `DateTransition.carryFocus` (default) or `restorePerView` — plus an optional `dateResolver` for custom logic.
-- **Scroll / zoom** (`MultiDayViewConfiguration` only): `scrollTransition` / `zoomTransition` — `preserve` (default), `reset`, or `restorePerView` — plus optional `scrollResolver` / `zoomResolver`.
+- **Date** (all views): `dateTransition`, either `DateTransition.carryFocus` (default) or `restorePerView`, plus an optional `dateResolver` for custom logic.
+- **Scroll and zoom** (`MultiDayViewConfiguration` only): `scrollTransition` and `zoomTransition`, either `preserve` (default), `reset`, or `restorePerView`, plus optional `scrollResolver` and `zoomResolver`.
 
 A custom `initialDateSelectionStrategy` becomes a `dateResolver`. The signature changes from named parameters to a single `ViewTransitionContext`, and the built-in `kDefaultTo*` helpers now take the outgoing `ViewController` directly (or use `kCarryFocusDate(transition)`).
 
@@ -911,9 +895,9 @@ Resize handle behavior is now driven by **input precision** (`InputMode`) instea
 
 | Value | Meaning |
 |-------|---------|
-| `auto` (default) | Detect dynamically — hover indicates precise input, selection indicates imprecise |
-| `precise` | Mouse, stylus, trackpad — full-width handles, shown on hover |
-| `imprecise` | Touch/finger — corner handles, shown on selection |
+| `auto` (default) | Detect dynamically. Hover indicates precise input, selection indicates imprecise |
+| `precise` | Mouse, stylus, trackpad. Full-width handles, shown on hover |
+| `imprecise` | Touch or finger. Corner handles, shown on selection |
 
 **`CalendarInteraction` has two new fields:**
 ```dart
@@ -989,7 +973,7 @@ class MyResizeHandles extends ResizeHandles {
 CalendarEvent<MyData>(dateTimeRange: range, data: MyData(...))
 ```
 
-**After** — extend `CalendarEvent` instead:
+**After**, extend `CalendarEvent` instead:
 ```dart
 class MyEvent extends CalendarEvent {
   final String title;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,6 +106,14 @@ Giving the builders one removes the reason for every pre-merge in the package, a
 
 The default for each builder moves off the widget and onto the components class that holds it, the shape `ScrollConfiguration.of(context).buildScrollbar(context, child, details)` uses. Fields become nullable and default to null, which makes "did the app override this" a question the package can ask. It cannot today: `month_body.dart` decides whether to build the day cell layer by comparing the field against `MonthDayCell.builder`, because a non-null tear-off default leaves nothing else to compare. Both statics on each component, `builder` and `fromContext`, are removed.
 
+### 0.28.0, the next breaking window
+
+Two API decisions deferred out of 0.27.0. Both are breaking, and neither has a deprecation path that costs less than doing it in a release that already breaks, so they wait for the next such release rather than for 1.0.0.
+
+**`OnEventTapped` drops its `RenderBox`.** `TapDetail` already carries the same object, which is what makes the parameter redundant on `OnEventTappedWithDetail`. `OnEventTapped` has no detail to fall back on, so removing it there means pointing callers at the other callback instead. That is the deprecation of a whole callback rather than the trim of a parameter, and the question underneath it is whether `OnEventTapped` earns its place at all once `OnEventTappedWithDetail` gives strictly more.
+
+**`MultiDayBodyConfiguration` folds into `VerticalConfiguration`.** The TODO on it reads as a rename, but the class extends `VerticalConfiguration` and adds `keepPagesAlive`, so the two are not interchangeable today. Moving that field up is what makes a replacement honest, and only then can a deprecation message name one. Which way the merge goes is open: `MultiDayBodyConfiguration` is the more discoverable of the two names.
+
 ### Tests
 
 Coverage is 88.2% of lines, up from 84.4% at 0.23.0, and still uneven. It gates the composability work below. The backfill during 0.24.0 went where the known bugs were, so the models improved sharply and the widget directories did not move at all.

--- a/lib/src/calendar_view.dart
+++ b/lib/src/calendar_view.dart
@@ -93,7 +93,6 @@ class CalendarViewState extends State<CalendarView> {
     widget.calendarController.attach(_viewController);
   }
 
-  // TODO: This needs to be improved on.
   @override
   void didUpdateWidget(covariant CalendarView oldWidget) {
     super.didUpdateWidget(oldWidget);

--- a/lib/src/models/providers/calendar_provider.dart
+++ b/lib/src/models/providers/calendar_provider.dart
@@ -76,8 +76,7 @@ class LocaleProvider extends InheritedWidget {
 }
 
 /// The [LocationProvider] is used to provide the [Location] for the calendar.
-///
-/// TODO: Check that the calendar updates correctly when the location changes.
+// TODO: Check that the calendar updates correctly when the location changes.
 class LocationProvider extends InheritedNotifier<ValueNotifier<Location?>> {
   /// Creates a [LocationProvider] with the specified location.
   const LocationProvider({super.key, required super.notifier, required super.child});

--- a/lib/src/models/view_configurations/page_index_calculator.dart
+++ b/lib/src/models/view_configurations/page_index_calculator.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:kalender/src/models/view_configurations/multi_day_view_configuration.dart';
 import 'package:kalender/src/models/view_configurations/view_configuration.dart';
 
-/// TODO: these will also need to be refactored to work with TZDateTime and Locations.
+// TODO: these will also need to be refactored to work with TZDateTime and Locations.
 
 /// Calculates page indices and date ranges for paginated calendar views.
 ///
@@ -324,7 +324,11 @@ class CustomIndexCalculator extends PageIndexCalculator {
   int get hashCode => Object.hash(CustomIndexCalculator, dateTimeRange, numberOfDays);
 }
 
-/// TODO: see if this can be removed and replaced with [DayIndexCalculator].
+/// Maps every day in the range to its own index, for the free-scrolling band.
+///
+/// Unlike the paginated calculators there is no page: the band scrolls
+/// continuously, so an index is a day offset from the start of the range.
+// TODO: see if this can be removed and replaced with [DayIndexCalculator].
 class FreeScrollFunctions extends PageIndexCalculator {
   FreeScrollFunctions({required super.dateTimeRange});
 

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -5,8 +5,6 @@ import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
 import 'package:kalender/src/widgets/internal_components/day_number.dart';
 
-// TODO: update
-
 /// The day header builder.
 ///
 /// The [date] is the date that the header will be displayed for.

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -363,7 +363,6 @@ class TimeLine extends StatelessWidget with TimeLineUtils {
       );
     });
 
-    // TODO: Improve this.
     final eventBeingDraggedTimes = ValueListenableBuilder(
       valueListenable: visibleDateTimeRange,
       builder: (context, visibleRange, child) {

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -5,11 +5,14 @@ import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
-// TODO: Update docs to reflect visibleDateTimeRange change.
 /// The time line builder.
 ///
 /// The [heightPerMinute] is the height of each minute.
 /// The [timeOfDayRange] is the range of time that the time line will be displayed for.
+/// The [eventBeingDragged] is the event currently being dragged or resized, which
+/// the default timeline labels with its start and end time.
+/// The [visibleDateTimeRange] is the range the calendar is showing, which those
+/// labels are only drawn for.
 ///
 /// Resolve the style with [GutterStyles.timelineStyleOf], the same value the
 /// gutter width is measured from.

--- a/lib/src/widgets/drag_targets/schedule_drag_target.dart
+++ b/lib/src/widgets/drag_targets/schedule_drag_target.dart
@@ -184,7 +184,6 @@ class _ScheduleDragTargetState extends State<ScheduleDragTarget> with DragTarget
     // Get the date for the item index.
     final date = viewController.dateTimeFromIndex(itemIndex);
 
-    // TODO: This needs to be checked.
     if (date == null) return null;
     return InternalDateTime.fromDateTime(date);
   }

--- a/lib/src/widgets/drag_targets/vertical_drag_target.dart
+++ b/lib/src/widgets/drag_targets/vertical_drag_target.dart
@@ -5,8 +5,6 @@ import 'package:kalender/src/models/mixins/snap_points.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/internal_components/cursor_navigation_trigger.dart';
 
-/// TODO: This needs to be tested :D
-
 /// A [StatefulWidget] that provides a [DragTarget] for [Create], [Resize], [Reschedule] objects.
 ///
 /// The [VerticalDragTarget] specializes in accepting [Draggable] widgets for a multi day body.

--- a/lib/src/widgets/event_tiles/event_tile.dart
+++ b/lib/src/widgets/event_tiles/event_tile.dart
@@ -11,8 +11,6 @@ import 'package:kalender/src/widgets/event_tiles/tiles/multi_day_overlay_tile.da
 import 'package:kalender/src/widgets/event_tiles/tiles/multi_day_tile.dart';
 import 'package:kalender/src/widgets/event_tiles/tiles/schedule_tile.dart';
 
-// TODO(werner): Update docs.
-
 /// The function that is called when the event is tapped.
 typedef EventTileOnTapUp = void Function(TapUpDetails details, BuildContext context);
 

--- a/lib/src/widgets/event_tiles/tile.dart
+++ b/lib/src/widgets/event_tiles/tile.dart
@@ -6,8 +6,6 @@ import 'package:kalender/src/models/controllers/calendar_controller.dart';
 import 'package:kalender/src/models/controllers/events_controller.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
-// TODO(werner): Update docs.
-
 /// The tile widget that displays the user-defined event content.
 ///
 /// This widget manages the visual transition between normal and dragging states

--- a/lib/src/widgets/multi_day/multi_day_body.dart
+++ b/lib/src/widgets/multi_day/multi_day_body.dart
@@ -192,7 +192,6 @@ class MultiDayPage extends StatefulWidget {
 }
 
 class _MultiDayPageState extends State<MultiDayPage> {
-  /// TODO: figure out the exact rebuilds needed here ....
   PageIndexCalculator get _pageNavigation => widget.viewController.viewConfiguration.pageIndexCalculator;
 
   @override

--- a/lib/src/widgets/schedule/schedule_body.dart
+++ b/lib/src/widgets/schedule/schedule_body.dart
@@ -91,7 +91,6 @@ class _PaginatedScheduleState extends State<PaginatedSchedule> {
       itemCount: widget.viewController.viewConfiguration.pageIndexCalculator.numberOfPages(context.location),
       physics: widget.configuration.pageScrollPhysics,
       onPageChanged: (value) {
-        // TODO: Should be fine.
         final range =
             widget.viewController.viewConfiguration.pageIndexCalculator.dateTimeRangeFromIndex(value, context.location);
         context.callbacks?.onPageChanged?.call(range);
@@ -251,8 +250,6 @@ class _SchedulePositionListState extends State<SchedulePositionList> {
   /// schedule items (months, events, empty days) based on the configuration
   /// and available events. This is a potentially expensive operation for
   /// large date ranges with many events.
-  ///
-  /// TODO: Performance optimization needed for large event collections.
   void _generateMap() {
     // Get the range of dates from the view configuration.
     final dates = widget.dateTimeRange.dates();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.26.0
+version: 0.27.0-dev.1
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
The release's scope is complete, so this is the version bump plus two loose ends.

**0.27.0 as the roadmap defined it:**

- `TimeOfDayRange.isAllDay` removed (#447)
- Every builder typedef takes a `BuildContext` (#449, #450, #451, #452)

Both done. `grep -rn "@Deprecated" lib/` is empty, so nothing is sitting past its window, and AGENTS.md's audit already records that.

**Two stale TODOs**, both on typedefs whose documentation the builder work rewrote:

- `ScheduleDateBuilder` carried a bare `// TODO: update`, which the rewrite answered.
- `TimeLineBuilder` carried one asking for `visibleDateTimeRange` to be documented. It now is, along with `eventBeingDragged`, which was also undocumented.

**On the changelog heading.** It stays `## 0.27.0` rather than `## 0.27.0-dev.1`, matching every previous dev release. `flutter pub publish --dry-run` warns that the changelog does not name the current version; `v0.26.0-dev.1` shipped with the same warning. Otherwise the dry run is clean at 186 KB.

Tagging is yours — merge this and the tag triggers the publish.