### PR TITLE
fix: GutterStyles.weekNumberStyleOf is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ See [MIGRATION.md](MIGRATION.md#v026x--v0270) for what to change.
 - The month week number gutter publishes the style it measures with, including its top alignment, to the scope it draws in. A custom `weekNumberBuilder` reads the month's value with `KalenderTheme.of(context)` where it previously had to be handed one.
 - `MultiDayEventOverlayTile` is exported. `MultiDayOverlayEventTileBuilder` returns it, and the class was not reachable, so the typedef was public but could not be implemented.
 - `ResizeDetector` is exported, the draggable that wraps the handle widget an app supplies. It was already reachable as the return of `ResizeHandleDetails.startResizeDetector` with no way to name it. It carries `event` and `direction`, so a handle is findable with `find.byType` and a predicate rather than only by key. It was named `ResizeHandle` while it was internal, which collides with the obvious name for the widget an app puts in `TileComponents.verticalResizeHandle`.
-- `GutterStyles` is public, with `GutterStyles.timelineStyleOf` and `GutterStyles.weekNumberStyleOf`. A custom gutter builder can resolve the style the gutter is measured from, which a `KalenderTheme` scoped inside the calendar cannot move.
+- `GutterStyles` is public, with `GutterStyles.timelineStyleOf`. A custom `timeline` or `timelineWidth` builder resolves the style the gutter is measured from, which a `KalenderTheme` scoped inside the calendar cannot move. A custom `weekNumberBuilder` reads `KalenderTheme.of(context).weekNumberStyle` instead, which is the month's own value inside the month gutter.
 
 ## 0.26.0
 

--- a/lib/src/models/providers/gutter_styles.dart
+++ b/lib/src/models/providers/gutter_styles.dart
@@ -41,13 +41,6 @@ class GutterStyles extends InheritedWidget {
     return maybeOf(context)?.timelineStyle ?? KalenderTheme.of(context).timelineStyle ?? const TimelineStyle();
   }
 
-  /// The week number style the month gutter is measured from.
-  ///
-  /// Falls back to [KalenderTheme] where there is no [GutterStyles], which is
-  /// the case outside a [CalendarView].
-  static WeekNumberStyle weekNumberStyleOf(BuildContext context) {
-    return maybeOf(context)?.weekNumberStyle ?? KalenderTheme.of(context).weekNumberStyle ?? const WeekNumberStyle();
-  }
 
   /// The [GutterStyles] above [context], or null when there is none.
   ///

--- a/lib/src/models/providers/gutter_styles.dart
+++ b/lib/src/models/providers/gutter_styles.dart
@@ -41,7 +41,6 @@ class GutterStyles extends InheritedWidget {
     return maybeOf(context)?.timelineStyle ?? KalenderTheme.of(context).timelineStyle ?? const TimelineStyle();
   }
 
-
   /// The [GutterStyles] above [context], or null when there is none.
   ///
   /// Null where a component widget is built outside a [CalendarView], which the


### PR DESCRIPTION
Stacked on #459.

`weekNumberStyleOf` returned the calendar-wide week number style, which is the wrong value in the only place a week number builder would ask for it. The month gutter merges its own top alignment into the scope it draws in, so `KalenderTheme.of(context).weekNumberStyle` returns the month's value there while `weekNumberStyleOf` returns the one without it. A custom `weekNumberBuilder` following the 0.27.0 changelog got a centred week number in the month view, which is what #416, #419 and #423 were three PRs of work to fix.

It had no caller in `lib/`, no test, and no mention in the guides. The month gutter reads `GutterStyles.of(context).weekNumberStyle` directly, so the field it exposed stays.

`timelineStyleOf` is unaffected. It has four call sites and is the right answer for the timeline, whose style the whole gutter is measured from.