### PR TITLE
docs: the guides follow the project's writing style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
-# Kalender – Project Guidelines
+# Kalender: Project Guidelines
 
 ## Overview
 
-Kalender is a Flutter calendar widget package providing four views: **MultiDay** (day/week), **Month**, **Schedule**, and a generic **CalendarView** orchestrator. The library is pre-1.0 (v0.15.0) and actively developed.
+Kalender is a Flutter calendar widget package providing four views: **MultiDay** (day/week), **Month**, **Schedule**, and a generic **CalendarView** orchestrator. The library is pre-1.0 and actively developed.
 
 - **SDK constraints**: Dart `>=3.0.0 <4.0.0`, Flutter `>=3.22.0`
 - **Key dependencies**: `intl`, `timezone`, `collection`, `linked_pageview`, `scrollable_positioned_list`
@@ -11,8 +11,8 @@ Kalender is a Flutter calendar widget package providing four views: **MultiDay**
 
 | Path | Purpose |
 |------|---------|
-| `lib/kalender.dart` | Main barrel export — organized by category (Widgets, Enumerations, Layout, Models, Components, Utils) |
-| `lib/kalender_extensions.dart` | Public extension APIs — `DateTimeExtensions`, `InternalDateTime`, `InternalDateTimeRange`, `TimeOfDay` |
+| `lib/kalender.dart` | Main barrel export: organized by category (Widgets, Enumerations, Layout, Models, Components, Utils) |
+| `lib/kalender_extensions.dart` | Public extension APIs: `DateTimeExtensions`, `InternalDateTime`, `InternalDateTimeRange`, `TimeOfDay` |
 | `lib/src/` | All implementation code |
 | `lib/src/models/` | Core data structures: controllers, events, view configurations, providers, components, mixins |
 | `lib/src/models/controllers/` | `CalendarController` (ChangeNotifier), `EventsController` (abstract), `ViewController` (abstract), view-specific controllers |
@@ -31,8 +31,8 @@ Kalender is a Flutter calendar widget package providing four views: **MultiDay**
 | `test/utilities.dart` | Shared test helpers: `TestProvider`, `wrapWithMaterialApp`, `testWithTimeZones`, `WidgetTesterUtils` |
 | `doc/` | The user-facing guides, indexed by `doc/README.md` |
 | `examples/` | Example Flutter apps (`example/`, `advanced_example/`, `riverpod/`, `recurrence/`, `ics/`, `testing/`, `web_demo/`) |
-| `example/` | README only — the pub.dev Example tab, which links to `examples/` |
-| `tool/` | Dev scripts — `test_timezones_linux.dart` replicates the CI timezone matrix locally, `pin_release_links.dart` pins documentation links at publish |
+| `example/` | README only: the pub.dev Example tab, which links to `examples/` |
+| `tool/` | Dev scripts: `test_timezones_linux.dart` replicates the CI timezone matrix locally, `pin_release_links.dart` pins documentation links at publish |
 | `.github/workflows/` | CI: `flutter_analyze_and_test.yml`, `analyze_examples.yml`, `performance_profiling.yml`, `deploy_dashboard.yml`, `publish.yml`, `web_demo.yml` |
 
 ## Code Style
@@ -41,11 +41,11 @@ Kalender is a Flutter calendar widget package providing four views: **MultiDay**
 - **Formatter page width**: 120 characters.
 - **Imports**: Always use `package:` imports (never relative). Enforced by `always_use_package_imports: true`. Follow `directives_ordering` (dart:, package:, relative in that order).
 - **Strings**: Prefer `single_quotes`.
-- **Variables/fields**: Prefer `final` locals (`prefer_final_locals`) and `final` fields (`prefer_final_fields`). Use `omit_local_variable_types` and `avoid_types_on_closure_parameters` — let type inference work.
+- **Variables/fields**: Prefer `final` locals (`prefer_final_locals`) and `final` fields (`prefer_final_fields`). Use `omit_local_variable_types` and `avoid_types_on_closure_parameters` so type inference does the work.
 - **Constructors**: Prefer `const` constructors (`prefer_const_constructors`).
 - **Trailing commas**: Required on every multi-line argument list (`require_trailing_commas`).
 - **No print**: `avoid_print` is enforced.
-- **Widget ordering**: `sort_child_properties_last` — the `child` parameter goes last.
+- **Widget ordering**: `sort_child_properties_last`: the `child` parameter goes last.
 - **Unnecessary wrappers**: `avoid_unnecessary_containers` and `unnecessary_lambdas`.
 - **Naming**: snake_case for files (`calendar_event.dart`), PascalCase for classes. Widget files match their class name. View widgets use `Body`/`Header` suffixes (e.g. `MonthBody`, `MonthHeader`).
 
@@ -64,7 +64,7 @@ flutter test
 # Run tests in a specific timezone (CI runs six timezones)
 TZ=America/New_York flutter test
 
-# Run all timezones locally (Linux) — mirrors CI matrix
+# Run all timezones locally (Linux), mirroring the CI matrix
 dart tool/test_timezones_linux.dart
 
 # Run specific test file across all timezones
@@ -81,10 +81,10 @@ dart tool/test_timezones_linux.dart test/extensions/internal_date_time_test.dart
 
 - Test directory mirrors `lib/src/` structure: `test/extensions/`, `test/configuration/`, `test/interactions/`, `test/layout/`, `test/models/`, `test/widgets/`.
 - Use the shared `test/utilities.dart` helpers:
-  - `testWithTimeZones()` — wraps test groups to run against the current `TZ` environment variable.
-  - `TestProvider` — wraps widgets with all required InheritedWidget providers for widget tests.
-  - `wrapWithMaterialApp()` / `pumpAndSettleWithMaterialApp()` — standard MaterialApp + Scaffold wrappers.
-  - `WidgetTesterUtils.hoverOn()` / `createMouseGesture()` — mouse interaction helpers.
+  - `testWithTimeZones()`: wraps test groups to run against the current `TZ` environment variable.
+  - `TestProvider`: wraps widgets with all required InheritedWidget providers for widget tests.
+  - `wrapWithMaterialApp()` / `pumpAndSettleWithMaterialApp()`: standard MaterialApp + Scaffold wrappers.
+  - `WidgetTesterUtils.hoverOn()` / `createMouseGesture()`: mouse interaction helpers.
 - DST transition dates from multiple regions are defined in `datesToTest` for thorough timezone coverage.
 - Timezone-sensitive tests **must** use `testWithTimeZones` and the shared `datesToTest` / `locationsToTest` lists.
 
@@ -94,15 +94,15 @@ dart tool/test_timezones_linux.dart test/extensions/internal_date_time_test.dart
 
 Each calendar view (MultiDay, Month, Schedule) follows the same layered structure:
 
-1. **ViewController** (`models/controllers/view_controllers/`) — manages view-specific state (page index, visible range). Abstract base: `ViewController`.
-2. **ViewConfiguration** (`models/view_configurations/`) — holds layout parameters. Configuration mixins: `VerticalConfiguration` (event layout strategy, scroll physics), `HorizontalConfiguration` (tile height, multi-day layout).
-3. **Body widget** (`widgets/<view>/<view>_body.dart`) — renders the main content area.
-4. **Header widget** (`widgets/<view>/<view>_header.dart`) — renders the top navigation/day headers.
-5. **TileComponents** — customizable builder functions for rendering event tiles.
+1. **ViewController** (`models/controllers/view_controllers/`): manages view-specific state (page index, visible range). Abstract base: `ViewController`.
+2. **ViewConfiguration** (`models/view_configurations/`): holds layout parameters. Configuration mixins: `VerticalConfiguration` (event layout strategy, scroll physics), `HorizontalConfiguration` (tile height, multi-day layout).
+3. **Body widget** (`widgets/<view>/<view>_body.dart`): renders the main content area.
+4. **Header widget** (`widgets/<view>/<view>_header.dart`): renders the top navigation/day headers.
+5. **TileComponents**: customizable builder functions for rendering event tiles.
 
 `CalendarBody` and `CalendarHeader` select the correct sub-widget via a `switch` on the active `ViewController` type.
 
-### State Management (InheritedWidget only — no external packages)
+### State Management (InheritedWidget only, no external packages)
 
 All state flows through InheritedWidget providers in `lib/src/models/providers/calendar_provider.dart`:
 
@@ -121,22 +121,22 @@ All state flows through InheritedWidget providers in `lib/src/models/providers/c
 
 ### Event Model
 
-- `CalendarEvent` is the base class — extend it to attach custom data (title, colour, etc.).
+- `CalendarEvent` is the base class: extend it to attach custom data (title, colour, etc.).
 - Events store UTC internally (`start` and `end` as `DateTime` in UTC). Use `internalStart()`/`internalEnd()` for wall-clock access.
 - Event IDs are `String` (10-char random alphanumeric, auto-generated).
 - Override `copyWithData()`, `==`, and `hashCode` in subclasses. `copyWithData` carries `@mustBeOverridden`, and `CalendarEvent` reapplies `id`, `interaction` and `multiDayRule` through `carryOver` afterwards, so a subclass never forwards those by hand.
 - `EventInteraction` controls per-event permissions (resizing, rescheduling).
-- `layoutEquals()` is used for render optimisation — returns true if the event occupies the same visual space.
+- `layoutEquals()` is used for render optimisation: returns true if the event occupies the same visual space.
 
 ### Controller Hierarchy
 
-- **CalendarController** (`ChangeNotifier` + mixins) — top-level orchestrator. Manages `visibleDateTimeRange`, `visibleEvents`, `selectedEvent`. Attaches/detaches from a `ViewController`.
-- **EventsController** (abstract `ChangeNotifier`) — event CRUD interface. `addEvent()` returns `String` id. Implement or use `DefaultEventsController`.
-- **ViewController** (abstract) — view-specific state. Implementations: `MultiDayViewController`, `MonthViewController`, `ScheduleViewController`.
+- **CalendarController** (`ChangeNotifier` + mixins): top-level orchestrator. Manages `visibleDateTimeRange`, `visibleEvents`, `selectedEvent`. Attaches/detaches from a `ViewController`.
+- **EventsController** (abstract `ChangeNotifier`): event CRUD interface. `addEvent()` returns `String` id. Implement or use `DefaultEventsController`.
+- **ViewController** (abstract): view-specific state. Implementations: `MultiDayViewController`, `MonthViewController`, `ScheduleViewController`.
 
 ### DateTime & Timezone Handling
 
-- **All dates stored in UTC** — `CalendarEvent.start`/`.end` are always UTC.
+- **All dates stored in UTC**: `CalendarEvent.start`/`.end` are always UTC.
 - **Wall-clock arithmetic** uses `InternalDateTime` and `InternalDateTimeRange` (in `lib/src/extensions/`) to handle DST transitions safely.
 - Use `InternalDateTime.fromExternal(utcDateTime, location: location)` to convert for display.
 - The `timezone` package provides `Location` objects for timezone-aware logic.
@@ -170,7 +170,7 @@ Mixins `DayEventTileUtils` and `MultiDayEventTileUtils` provide helper methods f
 
 ### Drag & Drop
 
-- Native `Draggable`/`LongPressDraggable` for existing events; `NewDraggable` mixin for creating new events.
+- Native `Draggable`/`LongPressDraggable` for existing events. `NewDraggable` mixin for creating new events.
 - Drag targets: `VerticalDragTarget` (day/week), `HorizontalDragTarget` (month/header), `ScheduleDragTarget`.
 - Drag data: `DraggableEvent` for existing events, create markers for new events, `ResizeDirection` enum for resize operations.
 - Platform-aware gestures: Desktop uses tap, mobile uses long-press (configurable via `CreateEventGesture`).
@@ -178,7 +178,7 @@ Mixins `DayEventTileUtils` and `MultiDayEventTileUtils` provide helper methods f
 
 ### Error Handling
 
-- **Asserts** for provider lookups ("No XyzProvider found") — these are development-time checks.
+- **Asserts** for provider lookups ("No XyzProvider found"): these are development-time checks.
 - **Input validation** via asserts (e.g. `TimeOfDayRange` start ≤ end).
 - No custom exception classes (pre-1.0 assert-based approach).
 
@@ -299,10 +299,10 @@ Key breaking changes to be aware of:
 
 ## Documentation
 
-- [README.md](README.md) — feature list, quick-start, previews.
-- [doc/README.md](doc/README.md) — index of the guides. One guide per topic: views, events, interaction, controllers and callbacks, appearance, layout, timezones and locales.
-- [MIGRATION.md](MIGRATION.md) — breaking-change migration guides between versions.
-- [CHANGELOG.md](CHANGELOG.md) — version history.
+- [README.md](README.md): feature list, quick-start, previews.
+- [doc/README.md](doc/README.md): index of the guides. One guide per topic: views, events, interaction, controllers and callbacks, appearance, layout, timezones and locales.
+- [MIGRATION.md](MIGRATION.md): breaking-change migration guides between versions.
+- [CHANGELOG.md](CHANGELOG.md): version history.
 
 A guide links to a class with its pub.dev API page, not a `lib/src` blob URL.
 `pin_release_links.dart` rewrites both, so a published version keeps linking to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,7 +271,7 @@ Both are removed in 0.24.0.
 
 - `monthDayHeaderBuilder` now receives a localized wall-clock `DateTime` instead of a UTC-flagged `InternalDateTime`, matching `dayHeaderBuilder`. [#248](https://github.com/werner-scholtz/kalender/issues/248)
 - Replaced `ViewConfiguration.initialDateSelectionStrategy` with per-dimension view-transition options: `dateTransition` on all views, and `scrollTransition` / `zoomTransition` on `MultiDayViewConfiguration`, each with an optional resolver for custom logic. [#249](https://github.com/werner-scholtz/kalender/issues/249)
-- View switches now preserve the vertical scroll (time-of-day) and zoom by default instead of resetting to `initialTimeOfDay`; opt out with `ScrollTransition.reset` / `ZoomTransition.reset`. [#249](https://github.com/werner-scholtz/kalender/issues/249)
+- View switches now preserve the vertical scroll (time-of-day) and zoom by default instead of resetting to `initialTimeOfDay`. Opt out with `ScrollTransition.reset` / `ZoomTransition.reset`. [#249](https://github.com/werner-scholtz/kalender/issues/249)
 - Renamed `EmptyDayBehavior.showToday` to `EmptyDayBehavior.showOnlyToday`, since it shows only today among empty days. [#253](https://github.com/werner-scholtz/kalender/issues/253)
 - Replaced `MultiDayBodyComponents.prototypeTimeLine` with a `timelineWidth` builder that returns the gutter width directly (`double`). The multi-day body, header and drag overlay now share this one width, so customizing the timeline can no longer misalign the header. Removed the `PrototypeTimeline` widget and `PrototypeTimeLineBuilder`. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 
@@ -286,11 +286,11 @@ Both are removed in 0.24.0.
 
 ### Fixes
 
-- Fixed schedule view event tiles not lining up; every row now shares a fixed-width leading column whether or not it shows a date. [#253](https://github.com/werner-scholtz/kalender/issues/253)
-- Fixed the continuous schedule view scrolling to the wrong position when today has no events; the initial scroll and `animateToDateTime` now target today, or the nearest day when it is hidden. [#253](https://github.com/werner-scholtz/kalender/issues/253)
-- Fixed the free-scroll multi-day header "wobbling" (re-animating its height) whenever a calendar item changed; its paged content now keeps its state across rebuilds instead of being rebuilt from scratch. [#282](https://github.com/werner-scholtz/kalender/pull/282)
-- Fixed the free-scroll multi-day header clipping days that have more events than the leading day; the header now sizes to the tallest day currently in view. [#283](https://github.com/werner-scholtz/kalender/pull/283)
-- Fixed the multi-day/week header drifting out of alignment with the body when the timeline used a custom `stringBuilder` or width; the gutter width now has a single source. [#180](https://github.com/werner-scholtz/kalender/issues/180)
+- Fixed schedule view event tiles not lining up. Every row now shares a fixed-width leading column whether or not it shows a date. [#253](https://github.com/werner-scholtz/kalender/issues/253)
+- Fixed the continuous schedule view scrolling to the wrong position when today has no events. The initial scroll and `animateToDateTime` now target today, or the nearest day when it is hidden. [#253](https://github.com/werner-scholtz/kalender/issues/253)
+- Fixed the free-scroll multi-day header re-animating its height whenever a calendar item changed. Its paged content now keeps its state across rebuilds instead of being rebuilt from scratch. [#282](https://github.com/werner-scholtz/kalender/pull/282)
+- Fixed the free-scroll multi-day header clipping days that have more events than the leading day. The header now sizes to the tallest day currently in view. [#283](https://github.com/werner-scholtz/kalender/pull/283)
+- Fixed the multi-day/week header drifting out of alignment with the body when the timeline used a custom `stringBuilder` or width. The gutter width now has a single source. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 - The timeline gutter width now accounts for the text scale factor, so it no longer under-sizes when text is enlarged. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 - The timeline gutter now measures every label across the day rather than a single sample, so a custom label format whose widest entry is not at 23:59 no longer clips. [#180](https://github.com/werner-scholtz/kalender/issues/180)
 
@@ -404,7 +404,7 @@ Both are removed in 0.24.0.
 
 - New `InputMode` enum (`auto`, `precise`, `imprecise`) on `CalendarInteraction` replaces platform-based mobile/desktop detection for resize handle behavior.
 - Resize handle positioning and visibility is now driven by input precision (mouse/stylus/trackpad vs touch) instead of platform (`iOS`/`Android`).
-- `InputMode.auto` (default) detects input type dynamically — hover triggers precise mode, selection triggers imprecise mode.
+- `InputMode.auto` (default) detects input type dynamically. Hover triggers precise mode, selection triggers imprecise mode.
 - New `allowHorizontalImpreciseResize` option on `CalendarInteraction` to opt-in to horizontal resize handles for touch input (disabled by default).
 - `CalendarInteraction.resolveIsImprecise()` provides a way to query the resolved input mode.
 - Removed direct `isMobileDevice` usage from resize handle widgets.
@@ -419,7 +419,7 @@ Both are removed in 0.24.0.
 - Event IDs changed from `int` to `String`. This affects `addEvent` (returns `String`), `addEvents` (returns `List<String>`), `removeById`, `byId`, and any code that stores or compares event IDs.
 - `EventTile.eventId` is now a `String`.
 - `MultiDayOverlayEventTile` renamed to `MultiDayEventOverlayTile`.
-- `EventsController` folder moved into the `controllers` folder; update any direct imports.
+- `EventsController` folder moved into the `controllers` folder. Update any direct imports.
 
 ### Features
 
@@ -436,7 +436,7 @@ Both are removed in 0.24.0.
 ### Improvements
 
 - `EventLayoutDelegateCache` is now cleared automatically when `heightPerMinute` changes.
-- `eventsFromDateTimeRange` — the `location` parameter is no longer required.
+- `eventsFromDateTimeRange`: the `location` parameter is no longer required.
 - Vertical drag-target behavior improved.
 - `DefaultEventsController` is now exported from `kalender.dart` directly.
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The detailed guides live in [`doc/`](doc/README.md):
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or pull request on [GitHub](https://github.com/werner-scholtz/kalender).
+Contributions are welcome. Please open an issue or pull request on [GitHub](https://github.com/werner-scholtz/kalender).
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ So "Before 1.0.0" holds both: the breaking work, and the features that introduce
 
 All five items planned for this release shipped. See [CHANGELOG.md](CHANGELOG.md) for the full list, which is longer, since the release also absorbed work that was never planned here.
 
-- **Split the readme.** Reference material moved to `doc/` and the readme became the shop window.
+- **Split the readme.** Reference material moved to `doc/` and the readme kept the overview.
 - **Remove the deprecated string builders,** along with `MonthDayHeaderStyle.textStyle`.
 - **Stop re-exporting the whole `timezone` package.** `Location` and `TZDateTime` stayed.
 - **Widen value equality on `CalendarInteraction` and `HorizontalConfiguration`.** Four missing fields, each one a change that never reached the calendar. This grew too. `CalendarSnapping` was dropping its snap strategy, and `ScheduleViewConfiguration` and `PageIndexCalculator` had no `==` at all, so every rebuild recreated the view controller and its layout caches.
@@ -58,7 +58,7 @@ The all-day flag was scoped out to 0.27.0, on the argument that new public API d
 
   The builders receive the theme-resolved style rather than null, which leaves them better off than today, where a custom builder gets an empty style unless the app used the deprecated container.
 
-  The month week number needs rescuing: its top alignment can only be set through `MonthBodyComponentStyles` today, because the month body passes that style to the widget and a passed style wins over the theme, so removing the container would make the alignment unreachable. Dropping the unconditional `Alignment.center` from `KalenderThemeData.defaults` lets the month body read the theme instead, since the widget already falls back to centre on its own. That part is non-breaking on its own and can land ahead of the removal.
+  The month week number needs one fix first. Its top alignment can only be set through `MonthBodyComponentStyles` today, because the month body passes that style to the widget and a passed style wins over the theme, so removing the container would make the alignment unreachable. Dropping the unconditional `Alignment.center` from `KalenderThemeData.defaults` lets the month body read the theme instead, since the widget already falls back to centre on its own. That part is non-breaking on its own and can land ahead of the removal.
 
   One behavior change follows. Afterwards the only route to that alignment is `KalenderThemeData.weekNumberStyle`, which feeds both the month gutter and the multi-day header, so an app cannot set them apart any more. Defaults are unaffected, so this reaches only an app that set a non-default alignment.
 
@@ -155,7 +155,7 @@ The rest runs from 79% to 100% with no large gap.
 
 No release attached yet. It reshapes public API, so the shape has to settle before 1.0.0, and it touches enough of the package that it waits on the test coverage above.
 
-Theming was the first slice of a larger idea: assembling a calendar from parts rather than configuring one whole. Three pieces are unbuilt.
+Theming was the first part of a larger idea: assembling a calendar from parts rather than configuring one whole. Three pieces are unbuilt.
 
 - **The state layer is closed.** The providers carrying calendar state are private, so nothing outside the package can read them.
 - **View types are hardcoded.** Three switches map a `ViewConfiguration` to its controller, body and header, so a view type cannot be added without forking.

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -246,7 +246,7 @@ For tiles that need to know the exact tapped time or find nearby events, use the
 
 ## Theming
 
-Out of the box the calendar follows your app's Material 3 theme: line colors, text styles, and the rest are derived from the ambient `ColorScheme` and `TextTheme`.
+By default the calendar follows your app's Material 3 theme: line colors, text styles, and the rest are derived from the ambient `ColorScheme` and `TextTheme`.
 
 To change how every calendar in the app looks, register a `KalenderThemeData` on your theme. Any field you leave out keeps its Material 3 default.
 

--- a/doc/events.md
+++ b/doc/events.md
@@ -8,7 +8,7 @@ on screen, see [Layout](layout.md). For what they look like, see
 
 ## Custom Events
 
-Since v0.16.0, `CalendarEvent` is no longer generic. The idiomatic way to attach custom data (title, color, description, etc.) is to **extend** `CalendarEvent` directly.
+Since v0.16.0, `CalendarEvent` is no longer generic. Attach custom data (title, color, description, and so on) by **extending** `CalendarEvent` directly.
 
 <!-- snippet: file -->
 ```dart

--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -83,7 +83,7 @@ it through with `super.interaction`, as in [Custom Events](events.md#custom-even
 
 Zoom the calendar in and out by changing the `heightPerMinute` value on the `MultiDayViewController`. The [`web_demo`](../examples/web_demo) example shows a full implementation with [`ZoomDetector`](../examples/web_demo/lib/widgets/calendar/zoom.dart).
 
-Here's a minimal example of wiring up zoom with Ctrl+scroll on desktop. `PointerScrollEvent` and `HardwareKeyboard` are not exported by `material.dart`, so both imports are needed:
+Here is a minimal example of driving zoom from Ctrl+scroll on desktop. `PointerScrollEvent` and `HardwareKeyboard` are not exported by `material.dart`, so both imports are needed:
 
 <!-- snippet: file -->
 ```dart

--- a/doc/layout.md
+++ b/doc/layout.md
@@ -22,7 +22,7 @@ Built-in strategies (pass via `MultiDayBodyConfiguration.eventLayoutStrategy`):
 
 To create a custom strategy, subclass `EventLayoutDelegate`. See [`CustomSideBySideLayoutDelegate`](../examples/advanced_example/lib/layout_strategy.dart) in the advanced example.
 
-Here's a minimal skeleton:
+Here is a minimal implementation:
 
 <!-- snippet: file -->
 ```dart


### PR DESCRIPTION
Stacked on #460.

A punctuation and wording pass over every markdown file. No meaning changes.

Removed every m-dash and en-dash, and every semicolon used in prose. Most were in `AGENTS.md`, where a dash introduced a description in a table cell or a list item and a colon reads the same, and in older changelog entries where a semicolon joined two sentences.

Replaced the figurative and insider phrasing the style guide names: the readme as a "shop window", a week number that "needs rescuing", theming as a "slice" of an idea, a header that "wobbles", "out of the box", "the idiomatic way", "wiring up" zoom, and a code "skeleton".

`AGENTS.md` still described the package as v0.15.0.

Two things I left alone and would rather you decide on. `CONTRIBUTING.md` calls the project "a fun way to explore Flutter and learn together" and tells contributors not to "stress about" matching the architecture. Both are informal by the letter of the guide, but they are deliberate warmth toward contributors rather than loose technical writing, and rewriting them would lose that.

Changelog entries for released versions are edited here too, which is wording only and leaves every version's contents as they were. Easy to drop that part if you would rather the shipped entries stay untouched.