### PR TITLE
ci: the benchmark runs once per stack rather than once per merge

### DIFF
--- a/.github/workflows/performance_profiling.yml
+++ b/.github/workflows/performance_profiling.yml
@@ -25,11 +25,14 @@ permissions:
   contents: write
   pull-requests: write
 
-# Serialise runs that may push to gh-pages so concurrent main pushes don't
-# conflict on the data file.
+# One run at a time per ref, and a newer one replaces an older one. Merging a
+# stack of pull requests pushes to main once per merge, so without this every
+# intermediate commit is profiled for 17 minutes and publishes a data point that
+# the next merge immediately supersedes. Cancelling also keeps two runs from
+# pushing to the gh-pages data file at once.
 concurrency:
   group: benchmarks-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   benchmark:
@@ -109,12 +112,31 @@ jobs:
         run: git restore .
 
       # --- Publish to the dashboard at gh-pages/dev/bench ----------------------
+      # A run is only cancelled while main moves under it if the cancellation
+      # arrives in time. This covers the rest: results for a commit that is no
+      # longer the tip are measured but not stored, so the dashboard carries one
+      # point per stack rather than one per merge.
+      - name: Check this commit is still the tip of main
+        id: tip
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tip=$(gh api "repos/${{ github.repository }}/commits/main" --jq .sha)
+          if [ "$tip" != "${{ github.sha }}" ]; then
+            echo "main is now $tip, so results for ${{ github.sha }} are not stored."
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "superseded=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Comment-only: fail-on-alert is false, so regressions are surfaced in a PR
       # comment but never block the build. Alert thresholds sit above the
       # measured noise floors (micro is far tighter than frame). On main we
-      # persist (auto-push); on PRs we only compare + comment (save-data-file
+      # persist (auto-push). On PRs we only compare and comment (save-data-file
       # false) so PR runs never mutate the stored history.
       - name: Store micro-benchmark results
+        if: steps.tip.outputs.superseded != 'true'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Kalender Micro-benchmarks
@@ -131,6 +153,7 @@ jobs:
           summary-always: true
 
       - name: Store frame profiling results
+        if: steps.tip.outputs.superseded != 'true'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Kalender Frame Profiling


### PR DESCRIPTION
Merging a stack pushes to main once per merge, and any merge touching `lib/` starts a 17 minute profile. Merging #458 through #460 produced three runs:

| merge | run | outcome |
| --- | --- | --- |
| #458 | 06:53:37 to 07:11:08 | success, 17.5 minutes |
| #459 | 06:59:59 to 07:08:01 | cancelled while pending |
| #460 | 07:08:00 to 07:11:10 | ran |

GitHub already cancels a run that is still *pending* when a newer one arrives, which is what happened to the middle one. What it does not do is stop the run already going, so #458 profiled to completion and published a data point for a commit that was three merges out of date by the time it finished.

`cancel-in-progress` now applies to the concurrency group, so a newer push replaces a run still going. That also removes the case the group was serialising against, since two runs can no longer reach the gh-pages data file at once.

Cancellation only helps when it arrives in time, so the publish steps also check that the commit is still the tip of main and store nothing when it is not. The check is skipped on pull requests, where the steps already compare and comment without storing.

**The trade-off.** A commit in the middle of a stack gets no data point, so a regression introduced there and left in place is attributed to the stack rather than to one merge. Labelling a single pull request `profile` still measures it on its own before merge, which is the way to keep per-change numbers when that matters.

Worth noting separately: #459 triggered a full profile because it edited two TODO comments in files under `lib/`. A path filter cannot see that the change was comment-only, and nothing here fixes that.