### PR TITLE
chore: prepare 0.27.0-dev.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,10 +269,11 @@ git branch release/0.23.x v0.23.0
 A pre-1.0.0 release can carry unfinished work that a 1.0.0 cannot. Audit these
 before tagging it:
 
-- **TODOs on public API.** Several are renames or removals deferred to 1.0.0,
-  including `CreateEventGesture` to `EventInteractionGesture`, the `renderBox`
-  parameter on `OnEventTapped` and `OnEventTappedWithDetail`, and
-  `MultiDayBodyConfiguration` in favour of `VerticalConfiguration`. Find them
+- **TODOs on public API.** Several are renames or removals deferred to a later
+  release. The `renderBox` parameter on `OnEventTapped` and
+  `OnEventTappedWithDetail` and the `MultiDayBodyConfiguration` merge into
+  `VerticalConfiguration` are both held for 0.28.0, the next breaking window.
+  `CreateEventGesture` to `EventInteractionGesture` carries no release. Find them
   with `grep -rn "TODO" lib/`. Each one is a decision still owed. Keep them as
   `//` comments: a `///` one renders as prose in the API reference, which is how
   `FreeScrollFunctions` shipped with a TODO as its entire published

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -87,6 +87,11 @@ static EventTile builder(BuildContext context, CalendarEvent event, DateTimeRang
     EventTile(event: event);
 ```
 
+The package's own `defaultTileBuilder`, `defaultTileWhenDraggingBuilder`,
+`defaultFeedbackTileBuilder` and `defaultDropTargetBuilder` gained the context
+the same way. Passing one as a tear-off needs no change. Calling one inside a
+builder of your own means passing the context along.
+
 Four cases need more than the signature change.
 
 #### The timeline resolves from `GutterStyles`, not the theme
@@ -96,6 +101,17 @@ overlay all measure from. A theme scoped inside the calendar cannot move it.
 
 ```dart
 timelineWidth: (context, range) => GutterStyles.timelineStyleOf(context).width ?? 56,
+```
+
+`defaultTimelineWidth` resolves the style the same way, so it no longer takes
+one. A builder that measured the default and adjusted it drops the argument:
+
+```dart
+// Before
+timelineWidth: (context, range, style) => defaultTimelineWidth(context, range, style) + 8,
+
+// After
+timelineWidth: (context, range) => defaultTimelineWidth(context, range) + 8,
 ```
 
 #### The month week number keeps its top alignment

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,7 +90,7 @@ The all-day flag was scoped out to 0.27.0, on the argument that new public API d
 
   What this does not do is let an app pick arbitrary visible days. See [#90](https://github.com/werner-scholtz/kalender/issues/90) below.
 
-### 0.27.0, the builders take a context, shipped in 0.27.0-dev.1
+### 0.27.0, the builders take a context, previewed in 0.27.0-dev.2
 
 One concept, across the widest customisation surface the package has. It gets a release of its own rather than riding along with model changes, and it happens before 1.0.0 because a freeze would put it behind a 2.0.0. What the plan below did not anticipate is how much doing it turned up, which the last three items record.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.27.0-dev.1
+version: 0.27.0-dev.2
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
`0.27.0-dev.1` is on pub.dev and main has moved past it. Since that tag:

- `ResizeHandlePositioner` returns a plain `Widget` and takes a `ResizeHandleDetails`
- the resize draggable is exported as `ResizeDetector`
- `MultiDayEventOverlayTile` is exported, so `MultiDayOverlayEventTileBuilder` can be implemented
- `GutterStyles.weekNumberStyleOf` is removed

Anyone who took dev.1 and followed the migration guide on main would write a positioner that does not compile, which is what this bump is for.

The changelog heading stays at `0.27.0`, matching every previous dev release, so pub warns that the changelog does not name the version. `0.26.0-dev.1` and `0.27.0-dev.1` both published with that warning. Entries added since dev.1 amend the `0.27.0` section rather than appending a dev.2 one, since the version is not tagged and someone upgrading should read what the release does rather than how it got there.

The pre-release checks in `AGENTS.md` pass: `lib/` carries no `@Deprecated` and no `/// TODO`.

## Migration coverage

The rule is that a breaking change gets a changelog entry **and** a migration section showing the before and after. Two entries had the first and not the second.

`defaultTimelineWidth` lost its `TimelineStyle` parameter and resolves one from the context. The builder table does not cover it: the table shows a typedef gaining a context, while this function also drops an argument, so a caller reading only the table fixes half of it. `advanced_example` needed exactly this change when the signature moved.

The four `default*` tile builders gained the context like every other builder. A tear-off is unaffected, so it is a sentence rather than a section, but they were named in the changelog and nowhere else.

`MIGRATION.md` is not compiled by the snippet checker and cannot be, since a "Before" block names API the release removed. Worth knowing when editing it, because that is how the `resizeHandle(axis)` sample drifted.

## Also

The pre-release checklist in `AGENTS.md` still said the `renderBox` parameters and the `MultiDayBodyConfiguration` merge were deferred to 1.0.0. #459 moved both to 0.28.0 in the roadmap and in the code comments, leaving the checklist as the last place naming the old target.
