### PR TITLE
chore: release 0.27.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,11 +269,11 @@ git branch release/0.23.x v0.23.0
 A pre-1.0.0 release can carry unfinished work that a 1.0.0 cannot. Audit these
 before tagging it:
 
-- **TODOs on public API.** Several are renames or removals deferred to a later
-  release. The `renderBox` parameter on `OnEventTapped` and
-  `OnEventTappedWithDetail` and the `MultiDayBodyConfiguration` merge into
-  `VerticalConfiguration` are both held for 0.28.0, the next breaking window.
-  `CreateEventGesture` to `EventInteractionGesture` carries no release. Find them
+- **TODOs on public API.** Several are renames or removals held for 0.28.0, the
+  next breaking window: the `renderBox` parameter on `OnEventTapped` and
+  `OnEventTappedWithDetail`, the `MultiDayBodyConfiguration` merge into
+  `VerticalConfiguration`, `CreateEventGesture` to `EventInteractionGesture`, and
+  the `k` prefix on the `default*` constants. Find them
   with `grep -rn "TODO" lib/`. Each one is a decision still owed. Keep them as
   `//` comments: a `///` one renders as prose in the API reference, which is how
   `FreeScrollFunctions` shipped with a TODO as its entire published

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,7 +90,7 @@ The all-day flag was scoped out to 0.27.0, on the argument that new public API d
 
   What this does not do is let an app pick arbitrary visible days. See [#90](https://github.com/werner-scholtz/kalender/issues/90) below.
 
-### 0.27.0, the builders take a context, previewed in 0.27.0-dev.2
+### 0.27.0, the builders take a context, done
 
 One concept, across the widest customisation surface the package has. It gets a release of its own rather than riding along with model changes, and it happens before 1.0.0 because a freeze would put it behind a 2.0.0. What the plan below did not anticipate is how much doing it turned up, which the last three items record.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,18 +118,27 @@ The default for each builder moves off the widget and onto the components class 
 
 ### 0.28.0, the next breaking window
 
-Two API decisions deferred out of 0.27.0. Both are breaking, and neither has a deprecation path that costs less than doing it in a release that already breaks, so they wait for the next such release rather than for 1.0.0.
+The breaking changes with nowhere cheaper to go. None has a deprecation path that costs less than doing it in a release that already breaks, so they wait for the next such release rather than for 1.0.0. Batching them is the point: a break that lands on its own costs a migration entry and a minor version for one item.
 
 **`OnEventTapped` drops its `RenderBox`.** `TapDetail` already carries the same object, which is what makes the parameter redundant on `OnEventTappedWithDetail`. `OnEventTapped` has no detail to fall back on, so removing it there means pointing callers at the other callback instead. That is the deprecation of a whole callback rather than the trim of a parameter, and the question underneath it is whether `OnEventTapped` earns its place at all once `OnEventTappedWithDetail` gives strictly more.
 
 **`MultiDayBodyConfiguration` folds into `VerticalConfiguration`.** The TODO on it reads as a rename, but the class extends `VerticalConfiguration` and adds `keepPagesAlive`, so the two are not interchangeable today. Moving that field up is what makes a replacement honest, and only then can a deprecation message name one. Which way the merge goes is open: `MultiDayBodyConfiguration` is the more discoverable of the two names.
 
+**`CreateEventGesture` becomes `EventInteractionGesture`.** The name says "create" and the enum also decides how an event is modified, which is why `CalendarInteraction` carries it twice, as `createEventGesture` and `modifyEventGesture`. A public enum cannot be renamed behind a deprecation, so it goes in a breaking batch or not at all. Carried a TODO with no release attached until now.
+
+**The `default*` constants take a `k` prefix.** `defaultTileHeight`, `defaultNewEventDuration`, `defaultEventLayoutStrategy` and the rest are public top-level constants, so renaming them is breaking. Worth doing with the others rather than alone, and worth deciding against outright if the prefix is not wanted, since the TODO has outlived several releases.
+
+**Whether the tile key factories are public API.** Nine of the twenty-two `static Key` factories sit on classes nothing exports, so `DayEventTile.tileKey` and its siblings cannot be reached from an app at all. Either the tiles are exported or the factories stop being public, and both are breaking. 0.27.0 showed the third option works: `ResizeDetector` carries `event` and `direction`, so it is findable with `find.byType` and a predicate and needs no key. Flutter publishes no key factories anywhere and its own tests use `find.byType` over `find.byKey` about four to one.
+
+**A `ResizeHandleStyle`, moved here from the theming list.** It adds rather than changes API, so it needs no breaking window, but it belongs with the resize handle work the previous release started. `KalenderThemeData` carries thirteen style classes and the resize handles are the only thing the calendar draws without one. The handle length is a hardcoded 24 for imprecise input and 16 otherwise, with a TODO on it in `DefaultResizeHandles`. Less pressing since 0.27.0, because changing the layout is now a lambda where it used to mean subclassing an abstract class.
+
+`FreeScrollFunctions` carries a TODO asking whether `DayIndexCalculator` can replace it. It became public with the rest of `PageIndexCalculator` in 0.26.0, so removing it is breaking and belongs here if the answer turns out to be yes. It is a question rather than a decision, so nothing is planned for it.
+
 ### Theming, still open
 
-Both are here rather than after 1.0.0 because the first adds public API and the second changes it.
+**Three public fields keep Material in the API,** carried forward from 0.25.0 since changing them is breaking: `MultiDayOverlayStyle.cardTheme` is a `CardThemeData`, `MultiDayOverlayStyle.closeButtonStyle` is a `ButtonStyle`, and `WeekNumberStyle.visualDensity` is a `VisualDensity`. A framework neutral core cannot name any of those types. No release is attached, so they can ride along with the next breaking one or wait.
 
-- **The resize handles have no style class.** `KalenderThemeData` carries thirteen and every other thing the calendar draws has one. The handle length is a hardcoded 24 for imprecise input and 16 otherwise, with a TODO on it in `DefaultResizeHandles`. A `ResizeHandleStyle` is the shape that matches the rest, rather than a length parameter bolted on. Less pressing since 0.27.0, because changing the layout is now a lambda where it used to mean subclassing an abstract class.
-- **Three public fields keep Material in the API,** carried forward from 0.25.0 since changing them is breaking: `MultiDayOverlayStyle.cardTheme` is a `CardThemeData`, `MultiDayOverlayStyle.closeButtonStyle` is a `ButtonStyle`, and `WeekNumberStyle.visualDensity` is a `VisualDensity`. A framework neutral core cannot name any of those types.
+The missing `ResizeHandleStyle` moved to 0.28.0 above.
 
 ### Tests
 

--- a/lib/src/models/calendar_interaction.dart
+++ b/lib/src/models/calendar_interaction.dart
@@ -104,7 +104,7 @@ enum InputMode {
 }
 
 /// The [CreateEventGesture] is used to differentiate between the different ways to create an event.
-// TODO: Rename this to EventInteractionGesture.
+// TODO: Rename this to EventInteractionGesture in 0.28.0.
 enum CreateEventGesture {
   /// Creates event on tap gesture.
   tap,

--- a/lib/src/models/view_configurations/view_configuration.dart
+++ b/lib/src/models/view_configurations/view_configuration.dart
@@ -265,7 +265,7 @@ abstract class HorizontalConfiguration {
   }
 }
 
-// TODO: rename these to use `k` prefix
+// TODO: Decide on the `k` prefix in 0.28.0, renaming these is breaking.
 const defaultTileHeight = 24.0;
 const defaultNewEventDuration = Duration(minutes: 30);
 const defaultShowMultiDayEvents = false;

--- a/lib/src/widgets/components/resize_handles.dart
+++ b/lib/src/widgets/components/resize_handles.dart
@@ -124,7 +124,7 @@ class DefaultResizeHandles extends StatelessWidget {
     final length = isVertical ? details.size.height : details.size.width;
 
     // The length of the resize handle.
-    // TODO: Make this configurable in the future.
+    // TODO: Move to a ResizeHandleStyle on the theme in 0.28.0.
     final handleLength = isImprecise ? 24.0 : 16.0;
 
     // Determine whether to hide the start resize handle.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.27.0-dev.2
+version: 0.27.0
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
Everything the roadmap listed for 0.27.0 has shipped and has had two dev previews. The scope is complete: `TimeOfDayRange.isAllDay` is gone, all twenty-four builder typedefs take a leading `BuildContext`, and the resize handle positioner returns a plain `Widget`.

`flutter pub publish --dry-run` reports **0 warnings**, unlike the dev releases, since the changelog heading and the version now match. `lib/` carries no `@Deprecated` and no `/// TODO`.

## 0.28.0 gains what this release left owed

The section held two API decisions. It now holds every breaking change with nowhere cheaper to go, which is what the deprecation rules in `AGENTS.md` ask for: batch them, since a break that lands alone still costs a migration entry and a minor version.

Three came out of the 0.27.0 work:

- **Whether the tile key factories are public API.** Nine of the twenty-two sit on classes nothing exports, so `DayEventTile.tileKey` cannot be reached from an app at all. Exporting the tiles or making the factories internal are both breaking. `ResizeDetector` showed the third option works.
- **A `ResizeHandleStyle`,** moved from the theming list. The resize handles are the only thing the calendar draws with no style class, and the hardcoded handle length has a TODO on it.
- **`FreeScrollFunctions`,** recorded as a question rather than a plan. It became public in 0.26.0, so the TODO asking whether `DayIndexCalculator` replaces it now has a cost attached.

Two were TODOs in `lib/` with no release named, both breaking and so both needing a window: `CreateEventGesture` to `EventInteractionGesture`, and the `k` prefix on the public `default*` constants.

The code comments and the pre-release checklist now name the same release the roadmap does. Those last two are the ones I grouped rather than you, so say if either should come back out.