### PR TITLE
fix!: the free scroll band stops at the end of its display range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,11 +273,12 @@ before tagging it:
   next breaking window: the `renderBox` parameter on `OnEventTapped` and
   `OnEventTappedWithDetail`, the `MultiDayBodyConfiguration` merge into
   `VerticalConfiguration`, `CreateEventGesture` to `EventInteractionGesture`, and
-  the `k` prefix on the `default*` constants. Find them
-  with `grep -rn "TODO" lib/`. Each one is a decision still owed. Keep them as
-  `//` comments: a `///` one renders as prose in the API reference, which is how
+  the `k` prefix on the `default*` constants. Find them with
+  `grep -rn "TODO" lib/`. Each one is a decision still owed. Keep them as `//`
+  comments: a `///` one renders as prose in the API reference, which is how
   `FreeScrollFunctions` shipped with a TODO as its entire published
-  documentation. `grep -rn "/// TODO" lib/` is the check.
+  documentation before it was removed in 0.28.0. `grep -rn "/// TODO" lib/` is
+  the check.
 - **Deprecations past their window.** None. `lib/` carries no `@Deprecated` at
   all: `TimeOfDayRange.isAllDay` was removed in 0.27.0 as its 0.26.0 message
   named, and the `CalendarComponents` style fields with the seven containers they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.28.0
+
+See [MIGRATION.md](MIGRATION.md#v027x--v0280) for what to change.
+
+### Breaking Changes
+
+- `FreeScrollFunctions` is removed. It duplicated `DayIndexCalculator`, which `PageIndexCalculator.freeScroll` now returns. Name `DayIndexCalculator` where the removed class was named.
+
+### Bug Fixes
+
+- The free scroll band no longer draws a day past the end of its display range. It rounded the range end up to the next midnight whatever it was, so a range already ending at midnight gained a day, which includes the default range and any range written the usual way. A range ending part way through a day is unaffected.
+
+### Behavior Changes
+
+- `MultiDayViewConfiguration.type` takes part in `==` and `hashCode`. Two configurations of different view types over the same range compared equal where the view type was the only difference between them.
+
 ## 0.27.0
 
 See [MIGRATION.md](MIGRATION.md#v026x--v0270) for what to change.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ Each section covers one upgrade. Versions not listed below need no changes.
 
 | Upgrade | What changes |
 | --- | --- |
+| [v0.27.x → v0.28.0](#v027x--v0280) | The free scroll band stops drawing a day past its display range. `FreeScrollFunctions` is removed. |
 | [v0.26.x → v0.27.0](#v026x--v0270) | Every builder takes a `BuildContext` and resolves its own styles. `TimeOfDayRange.isAllDay` is removed. |
 | [v0.25.x → v0.26.0](#v025x--v0260) | The deprecated style fields on `CalendarComponents` are removed, along with the containers reached through them. The three strategy fields become classes. `CalendarEvent.copyWith` becomes `copyWithData`. |
 | [v0.24.x → v0.25.0](#v024x--v0250) | The deprecated `isMultiDayEvent` getter is removed. |
@@ -13,6 +14,32 @@ Each section covers one upgrade. Versions not listed below need no changes.
 | [v0.18.x → v0.19.0](#v018x--v0190) | The timeline gutter width, view-transition controls, and the month day header's date type. |
 | [v0.16.x → v0.17.0](#v016x--v0170) | Input mode replaces the mobile/desktop split. |
 | [v0.15.x → v0.16.0](#v015x--v0160) | `CalendarEvent` is no longer generic and event ids become `String`. |
+
+## v0.27.x → v0.28.0
+
+### The free scroll band stops one day earlier
+
+Nothing stops compiling, and a free scroll calendar loses its last column. The
+band rounded the end of the display range up to the next midnight whatever it
+was, so a range already ending at midnight gained a day it should not have had.
+That covers the default range and any range written the usual way. A range
+ending part way through a day is unchanged.
+
+Extend the range by a day if you were relying on the extra column.
+
+### `FreeScrollFunctions` is removed
+
+`PageIndexCalculator.freeScroll` returns a `DayIndexCalculator` now, so only code
+that names the removed type changes.
+
+```dart
+// Before
+if (config.pageIndexCalculator is FreeScrollFunctions) { ... }
+
+// After. This no longer tells a free scroll view from a single day one, since
+// both use the same calculator. Read `MultiDayViewConfiguration.type` for that.
+if (config.pageIndexCalculator is DayIndexCalculator) { ... }
+```
 
 ## v0.26.x → v0.27.0
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -132,7 +132,7 @@ The breaking changes with nowhere cheaper to go. None has a deprecation path tha
 
 **A `ResizeHandleStyle`, moved here from the theming list.** It adds rather than changes API, so it needs no breaking window, but it belongs with the resize handle work the previous release started. `KalenderThemeData` carries thirteen style classes and the resize handles are the only thing the calendar draws without one. The handle length is a hardcoded 24 for imprecise input and 16 otherwise, with a TODO on it in `DefaultResizeHandles`. Less pressing since 0.27.0, because changing the layout is now a lambda where it used to mean subclassing an abstract class.
 
-`FreeScrollFunctions` carries a TODO asking whether `DayIndexCalculator` can replace it. It became public with the rest of `PageIndexCalculator` in 0.26.0, so removing it is breaking and belongs here if the answer turns out to be yes. It is a question rather than a decision, so nothing is planned for it.
+**`FreeScrollFunctions` is removed, and it took a defect with it.** Its TODO asked whether `DayIndexCalculator` could replace it. The two were the same code but for one line, and that line rounded the end of the display range up to the next midnight whatever it was, so a range already ending at midnight gained a day and the band drew a column outside it. Every other calculator guards that end with a conditional. The default range ends at midnight, as does any range written the usual way, so most free scroll calendars had it. `MultiDayViewConfiguration.type` joins `==` and `hashCode` with it, since the calculator's runtime type was what told a free scroll configuration apart from a single day one.
 
 ### Theming, still open
 

--- a/lib/src/models/view_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_view_configuration.dart
@@ -343,6 +343,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
     if (identical(this, other)) return true;
 
     return other is MultiDayViewConfiguration &&
+        other.type == type &&
         other.name == name &&
         other.initialDateTime == initialDateTime &&
         other.dateTransition == dateTransition &&
@@ -362,6 +363,7 @@ class MultiDayViewConfiguration extends ViewConfiguration {
   @override
   int get hashCode {
     return Object.hash(
+      type,
       name,
       initialDateTime,
       dateTransition,

--- a/lib/src/models/view_configurations/page_index_calculator.dart
+++ b/lib/src/models/view_configurations/page_index_calculator.dart
@@ -69,9 +69,12 @@ abstract class PageIndexCalculator {
     return CustomIndexCalculator(dateTimeRange: dateTimeRange, numberOfDays: numberOfDays);
   }
 
-  /// Creates a [PageIndexCalculator] for a single day [MultiDayViewConfiguration.freeScroll].
+  /// Creates a [PageIndexCalculator] for a free scrolling [MultiDayViewConfiguration.freeScroll].
+  ///
+  /// The band scrolls continuously rather than paging, so an index is a day offset from the start of
+  /// the range.
   factory PageIndexCalculator.freeScroll(DateTimeRange dateTimeRange) {
-    return FreeScrollFunctions(dateTimeRange: dateTimeRange);
+    return DayIndexCalculator(dateTimeRange: dateTimeRange);
   }
 
   /// Creates a [PageIndexCalculator] for a schedule [ContinuousScheduleIndexCalculator].
@@ -322,57 +325,6 @@ class CustomIndexCalculator extends PageIndexCalculator {
 
   @override
   int get hashCode => Object.hash(CustomIndexCalculator, dateTimeRange, numberOfDays);
-}
-
-/// Maps every day in the range to its own index, for the free-scrolling band.
-///
-/// Unlike the paginated calculators there is no page: the band scrolls
-/// continuously, so an index is a day offset from the start of the range.
-// TODO: see if this can be removed and replaced with [DayIndexCalculator].
-class FreeScrollFunctions extends PageIndexCalculator {
-  FreeScrollFunctions({required super.dateTimeRange});
-
-  @override
-  InternalDateTimeRange dateTimeRangeFromIndex(int index, Location? location) {
-    final internalRange = this.internalRange(location);
-    // Add the index to the start date to get the date to display.
-    final start = internalRange.start.add(Duration(days: index));
-    final end = start.add(const Duration(days: 1));
-    return InternalDateTimeRange(start: start, end: end);
-  }
-
-  @override
-  int indexFromDate(DateTime date, Location? location) {
-    final startOfDate = InternalDateTime.fromExternal(date, location: location);
-    final startOfRange = internalRange(location).start;
-    // Calculate the difference in days between the two dates.
-    final days = startOfDate.difference(startOfRange).inDays;
-    // Guard against an empty range (numberOfPages == 0), where numberOfPages - 1
-    // would be a negative upper bound and make clamp throw.
-    final pageCount = numberOfPages(location);
-    return pageCount == 0 ? 0 : days.clamp(0, pageCount - 1);
-  }
-
-  @override
-  int numberOfPages(Location? location) {
-    final range = internalRange(location);
-    return range.end.difference(range.start).inDays;
-  }
-
-  @override
-  InternalDateTimeRange internalRange(Location? location) {
-    return InternalDateTimeRange(
-      start: InternalDateTime.fromExternal(dateTimeRange.start, location: location).startOfDay,
-      end: InternalDateTime.fromExternal(dateTimeRange.end, location: location).endOfDay,
-    );
-  }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) || other is FreeScrollFunctions && other.dateTimeRange == dateTimeRange;
-
-  @override
-  int get hashCode => Object.hash(FreeScrollFunctions, dateTimeRange);
 }
 
 /// Calculates page indices and date ranges for a month view.

--- a/test/models/page_index_calculator_test.dart
+++ b/test/models/page_index_calculator_test.dart
@@ -99,6 +99,30 @@ void main() {
       });
     });
 
+    group('freeScroll for $location', () {
+      test('the band maps a day per index, the same as a single day view', () {
+        expect(PageIndexCalculator.freeScroll(range), isA<DayIndexCalculator>());
+      });
+
+      // The band used to round the end of the range up to the next midnight
+      // whatever it was, so a range already ending at midnight gained a day and
+      // the last column fell outside it.
+      test('a range ending at midnight is not extended by a day', () {
+        final calculator = PageIndexCalculator.freeScroll(range);
+        expect(calculator.numberOfPages(location), 366);
+
+        final last = calculator.dateTimeRangeFromIndex(calculator.numberOfPages(location) - 1, location);
+        expect(last.start, InternalDateTime(2020, 12, 31));
+        expect(last.end, InternalDateTime(2021));
+      });
+
+      test('a range ending mid-day still covers the part day', () {
+        final partDay = DateTimeRange(start: TZDateTime(location, 2020), end: TZDateTime(location, 2020, 1, 8, 13, 30));
+        final calculator = PageIndexCalculator.freeScroll(partDay);
+        expect(calculator.numberOfPages(location), 8);
+      });
+    });
+
     group('WeekIndexCalculator for $location', () {
       late WeekIndexCalculator calculator;
       setUpAll(() {

--- a/test/widgets/page_boundary_test.dart
+++ b/test/widgets/page_boundary_test.dart
@@ -71,6 +71,27 @@ void main() {
     expect(range.dominantMonthDate.month, 6, reason: 'The last month of the range should be reachable');
   });
 
+  testWidgets('free scroll stops at the end of the range', (tester) async {
+    // 2025-06-01 through 2025-06-07, the end exclusive at midnight. The band
+    // used to round that end up to the next midnight and draw an eighth column
+    // for 2025-06-08, a day outside the range.
+    await pump(
+      tester,
+      MultiDayViewConfiguration.freeScroll(
+        numberOfDays: 3,
+        displayRange: DateTimeRange(start: DateTime(2025, 6), end: DateTime(2025, 6, 8)),
+        initialDateTime: DateTime(2025, 6),
+      ),
+    );
+
+    final viewController = calendarController.viewController! as MultiDayViewController;
+    expect(viewController.numberOfPages, 7, reason: 'one column per day in the range, and no more');
+
+    final last = viewController.viewConfiguration.pageIndexCalculator
+        .dateTimeRangeFromIndex(viewController.numberOfPages - 1, null);
+    expect(last.start, InternalDateTime(2025, 6, 7), reason: 'the last column is the last day of the range');
+  });
+
   testWidgets('paginated schedule renders a single-month range', (tester) async {
     await pump(
       tester,

--- a/test/widgets/view_configuration_identity_test.dart
+++ b/test/widgets/view_configuration_identity_test.dart
@@ -90,6 +90,25 @@ void main() {
     test('nowCallback also reaches hashCode', () {
       expect(week().hashCode, isNot(equals(weekWith(nowCallback: _stubNow).hashCode)));
     });
+
+    // A free scroll view and a single day view over the same range share a page
+    // index calculator, so `type` is what tells the two configurations apart.
+    test('type', () {
+      final singleDay = MultiDayViewConfiguration.singleDay(
+        name: 'same',
+        displayRange: year2025DisplayRange,
+        initialDateTime: DateTime(2025, 1, 13),
+      );
+      final freeScroll = MultiDayViewConfiguration.freeScroll(
+        name: 'same',
+        numberOfDays: 1,
+        displayRange: year2025DisplayRange,
+        initialDateTime: DateTime(2025, 1, 13),
+      );
+
+      expect(singleDay, isNot(equals(freeScroll)));
+      expect(singleDay.hashCode, isNot(equals(freeScroll.hashCode)));
+    });
   });
 
   group('fields that deliberately do not break equality', () {


### PR DESCRIPTION
Opens the 0.28.0 breaking window with the `FreeScrollFunctions` question the roadmap left as a question, and the answer turned out to be a defect.

The class was `DayIndexCalculator` with one line changed. Every other calculator guards the end of the display range with a conditional, this one rounded it up to the next midnight whatever it was, so a range already ending at midnight gained a day and the band drew a column outside it. `numberOfPages` goes straight to `itemCount` with no clamping, so the extra column reached the screen.

A range of 2025-06-01 to 2025-06-08 built eight day columns, the last one 2025-06-08. `kDefaultRange` ends at midnight, as does any range written the usual way, so most free scroll calendars had it. A range ending part way through a day was already correct and is unchanged.

`PageIndexCalculator.freeScroll` returns a `DayIndexCalculator` now. Naming the removed type is the only thing that stops compiling.

`MultiDayViewConfiguration.type` joins `==` and `hashCode` with it, since the calculator's runtime type was what separated a free scroll configuration from a single day one over the same range.
