### PR TITLE
test: the schedule drag target is covered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ build/
 
 # Written by tool/analyze_doc_snippets.dart on every run.
 /examples/doc_snippets/lib/generated/
+
+# Written by `flutter test --coverage`.
+/coverage/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -142,7 +142,7 @@ The missing `ResizeHandleStyle` moved to 0.28.0 above.
 
 ### Tests
 
-Coverage is 89.2% of lines, up from 88.2% at 0.24.0 and 84.4% at 0.23.0. It gates the composability work below. The two areas the 0.24.0 backfill named as next have still not moved, and the release that rewrote the worst-covered area fixed it outright.
+Coverage is 90.5% of lines, up from 88.2% at 0.24.0 and 84.4% at 0.23.0. It gates the composability work below. The two areas the 0.24.0 backfill named as next have still not moved, and the release that rewrote the worst-covered area fixed it outright.
 
 Both columns are line coverage of the directory and everything under it, measured with `flutter test --coverage`.
 
@@ -152,13 +152,13 @@ Both columns are line coverage of the directory and everything under it, measure
 | `models/components/` | not tracked | 58% | The lowest in the package. `copyWith`, `==` and `hashCode` on the components classes have no test at all. Audited for dropped fields and there are none, so it is untested rather than wrong. |
 | `models/mixins/` | 84% | 84% | Untouched. |
 | `models/view_configurations/` | 83% | 84% | `schedule_view_configuration.dart` at 42%. |
-| `widgets/drag_targets/` | 71% | 71% | Untouched. `schedule_drag_target.dart` covers 10 of its 87 lines, still the largest single gap in the package. |
+| `widgets/drag_targets/` | 71% | 91% | Done. `schedule_drag_target.dart` went from 10 of its 87 lines to 82, which covered the whole reschedule path in the schedule view. |
 | `widgets/event_tiles/` | 81% | 82% | Barely moved. `multi_day_overlay_tile.dart` at 31% and `schedule_tile.dart` at 39%. |
 | `theme/` | 78% | 97% | Done. 0.25.0 rewrote this code and tested it, taking it from the lowest covered area to one of the highest. |
 
 The rest runs from 79% to 100% with no large gap.
 
-`schedule_drag_target.dart` is still the one to start with, and `models/components/` is the new one. The latter is the shape the package has already shipped twice: a `copyWith` that silently drops a field, found in `view_configurations` as late as 0.24.0, in a class nothing tested. The pattern worth taking from 0.24.0 is that every gap closed turned up a bug that was already shipped.
+`models/components/` is the one left, and it is the shape the package has already shipped twice: a `copyWith` that silently drops a field, found in `view_configurations` as late as 0.24.0, in a class nothing tested. The pattern worth taking from 0.24.0 held again here. Covering the schedule drag target showed that a drop takes the time of day from the target day rather than keeping the event's, so a 09:00 meeting moved to another day lands at midnight. The multi-day body keeps it.
 
 ### Composability
 

--- a/test/widgets/schedule/schedule_drag_target_test.dart
+++ b/test/widgets/schedule/schedule_drag_target_test.dart
@@ -1,0 +1,245 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/src/widgets/event_tiles/tiles/schedule_tile.dart';
+import 'package:kalender/src/widgets/internal_components/cursor_navigation_trigger.dart';
+
+import '../../utilities.dart';
+
+/// Rescheduling in the schedule view, which is a list of day rows rather than a
+/// grid, so a drop carries a day and no time of day.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  final displayRange = DateTimeRange(start: DateTime(2025, 6), end: DateTime(2025, 7));
+
+  final interaction = CalendarInteraction(
+    allowRescheduling: true,
+    inputMode: InputMode.precise,
+    createEventGesture: CreateEventGesture.tap,
+    modifyEventGesture: CreateEventGesture.tap,
+  );
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  String addEvent(DateTime start, Duration duration) {
+    return eventsController
+        .addEvent(CalendarEvent(dateTimeRange: DateTimeRange(start: start, end: start.add(duration))));
+  }
+
+  Future<void> pumpSchedule(
+    WidgetTester tester, {
+    CalendarCallbacks? callbacks,
+    bool paginated = false,
+  }) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        callbacks: callbacks,
+        viewConfiguration: paginated
+            ? ScheduleViewConfiguration.paginated(displayRange: displayRange, initialDateTime: DateTime(2025, 6, 2))
+            : ScheduleViewConfiguration.continuous(displayRange: displayRange, initialDateTime: DateTime(2025, 6, 2)),
+        body: CalendarBody(
+          interaction: interaction,
+          scheduleBodyConfiguration: ScheduleBodyConfiguration(emptyDay: EmptyDayBehavior.show),
+        ),
+      ),
+    );
+  }
+
+  ScheduleViewController schedule() => calendarController.viewController! as ScheduleViewController;
+
+  /// Picks [tile] up and moves it down by [dy] without releasing.
+  Future<TestGesture> dragDownBy(WidgetTester tester, Finder tile, double dy) async {
+    final gesture = await tester.startGesture(tester.getCenter(tile));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(Offset(0, dy));
+    await tester.pumpAndSettle();
+    return gesture;
+  }
+
+  testWidgets('dragging a tile onto a later day previews the move', (tester) async {
+    final id = addEvent(DateTime(2025, 6, 2, 9), const Duration(hours: 1));
+    addEvent(DateTime(2025, 6, 5, 9), const Duration(hours: 1));
+    await pumpSchedule(tester);
+
+    final original = eventsController.byId(id)!;
+    final gesture = await dragDownBy(tester, find.byKey(ScheduleEventTile.tileKey(id)), 120);
+
+    final preview = calendarController.selectedEvent.value;
+    expect(preview, isNotNull, reason: 'the schedule should preview a reschedule while the drag is held');
+    expect(preview!.start.isAfter(original.start), isTrue, reason: 'the preview should follow the cursor down');
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('the highlighted range follows the drag and clears on drop', (tester) async {
+    final id = addEvent(DateTime(2025, 6, 2, 9), const Duration(hours: 1));
+    await pumpSchedule(tester);
+
+    expect(schedule().highlightedDateTimeRange.value, isNull, reason: 'nothing is highlighted before a drag');
+
+    final gesture = await dragDownBy(tester, find.byKey(ScheduleEventTile.tileKey(id)), 120);
+    final highlighted = schedule().highlightedDateTimeRange.value;
+    expect(highlighted, isNotNull, reason: 'the row under the cursor should be highlighted');
+    expect(highlighted!.duration, equals(const Duration(hours: 1)), reason: 'the highlight spans the event duration');
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(schedule().highlightedDateTimeRange.value, isNull, reason: 'the drop should clear the highlight');
+  });
+
+  testWidgets('dropping commits the new date', (tester) async {
+    CalendarEvent? changed;
+    final id = addEvent(DateTime(2025, 6, 2, 9), const Duration(hours: 1));
+    await pumpSchedule(tester, callbacks: CalendarCallbacks(onEventChanged: (_, updated) => changed = updated));
+
+    final originalStart = eventsController.byId(id)!.start;
+    final gesture = await dragDownBy(tester, find.byKey(ScheduleEventTile.tileKey(id)), 120);
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(changed, isNotNull, reason: 'releasing over a day row should commit, not snap back');
+    expect(changed!.start.isAfter(originalStart), isTrue, reason: 'a downward drag moves the event forward');
+  });
+
+  testWidgets('a drop takes the time of day from the target day, not the event', (tester) async {
+    // The schedule view has no time axis, so a drop carries only a date. The
+    // event lands at the start of the target day rather than keeping 09:00.
+    CalendarEvent? changed;
+    final id = addEvent(DateTime(2025, 6, 2, 9), const Duration(hours: 1));
+    await pumpSchedule(tester, callbacks: CalendarCallbacks(onEventChanged: (_, updated) => changed = updated));
+
+    final gesture = await dragDownBy(tester, find.byKey(ScheduleEventTile.tileKey(id)), 120);
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(changed!.start.toLocal().hour, 0, reason: 'the event lands at the start of the target day');
+    expect(changed!.duration, equals(const Duration(hours: 1)), reason: 'the duration is kept');
+  });
+
+  testWidgets('a multi-day event keeps its duration across a drop', (tester) async {
+    CalendarEvent? changed;
+    final id = addEvent(DateTime(2025, 6, 2, 9), const Duration(days: 2));
+    await pumpSchedule(tester, callbacks: CalendarCallbacks(onEventChanged: (_, updated) => changed = updated));
+
+    final original = eventsController.byId(id)!;
+    final gesture = await dragDownBy(tester, find.byKey(ScheduleEventTile.tileKey(id)).first, 120);
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(changed, isNotNull);
+    expect(changed!.duration, equals(original.duration), reason: 'a multi-day event should not be resized by a move');
+  });
+
+  testWidgets('dragging away from the schedule clears the highlighted range', (tester) async {
+    final id = addEvent(DateTime(2025, 6, 2, 9), const Duration(hours: 1));
+    await pumpSchedule(tester);
+
+    final gesture = await dragDownBy(tester, find.byKey(ScheduleEventTile.tileKey(id)), 120);
+    expect(schedule().highlightedDateTimeRange.value, isNotNull);
+
+    // Off the drag target entirely, which is a leave rather than a drop.
+    await gesture.moveTo(const Offset(-50, -50));
+    await tester.pumpAndSettle();
+    expect(schedule().highlightedDateTimeRange.value, isNull, reason: 'leaving should clear the highlight');
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  group('navigation triggers', () {
+    /// Drags [tile] to [target] in steps, so the trigger registers a drag-enter
+    /// and starts its timer, then holds long enough for it to fire.
+    Future<TestGesture> holdAt(WidgetTester tester, Finder tile, Offset target) async {
+      final center = tester.getCenter(tile);
+      final gesture = await tester.startGesture(center);
+      await tester.pump();
+      await gesture.moveTo(Offset(center.dx, (center.dy + target.dy) / 2));
+      await tester.pump();
+      await gesture.moveTo(target);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 800));
+      await tester.pump(const Duration(milliseconds: 250));
+      return gesture;
+    }
+
+    int firstVisibleIndex() => schedule().itemPositionsListener!.itemPositions.value.map((p) => p.index).reduce(min);
+
+    testWidgets('holding a drag at the bottom edge scrolls the schedule down', (tester) async {
+      final id = addEvent(DateTime(2025, 6, 2, 9), const Duration(hours: 1));
+      await pumpSchedule(tester);
+
+      final before = firstVisibleIndex();
+      final size = tester.getSize(find.byType(CalendarView));
+      final gesture = await holdAt(
+        tester,
+        find.byKey(ScheduleEventTile.tileKey(id)),
+        Offset(size.width / 2, size.height - 4),
+      );
+
+      expect(firstVisibleIndex(), greaterThan(before), reason: 'the bottom edge should scroll the list on');
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('holding a drag at the top edge scrolls the schedule back', (tester) async {
+      addEvent(DateTime(2025, 6, 15, 9), const Duration(hours: 1));
+      // Two rows below the top of the viewport, so the drag starts outside the
+      // trigger band and entering it registers.
+      final id = addEvent(DateTime(2025, 6, 17, 9), const Duration(hours: 1));
+      await pumpSchedule(tester);
+      calendarController.jumpToDate(DateTime(2025, 6, 15));
+      await tester.pumpAndSettle();
+
+      final before = firstVisibleIndex();
+      final gesture = await holdAt(
+        tester,
+        find.byKey(ScheduleEventTile.tileKey(id)),
+        Offset(tester.getSize(find.byType(CalendarView)).width / 2, 4),
+      );
+
+      expect(firstVisibleIndex(), lessThan(before), reason: 'the top edge should scroll the list back');
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('the paginated schedule offers page triggers while dragging', (tester) async {
+      final id = addEvent(DateTime(2025, 6, 2, 9), const Duration(hours: 1));
+      await pumpSchedule(tester, paginated: true);
+
+      expect(find.byType(CursorNavigationTrigger), findsNothing, reason: 'no triggers before a drag starts');
+
+      final gesture = await dragDownBy(tester, find.byKey(ScheduleEventTile.tileKey(id)), 120);
+      // Two scroll triggers and two page triggers.
+      expect(find.byType(CursorNavigationTrigger), findsNWidgets(4));
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('the continuous schedule offers only scroll triggers', (tester) async {
+      final id = addEvent(DateTime(2025, 6, 2, 9), const Duration(hours: 1));
+      await pumpSchedule(tester);
+
+      final gesture = await dragDownBy(tester, find.byKey(ScheduleEventTile.tileKey(id)), 120);
+      // A continuous schedule is not paginated, so the two page triggers are
+      // not built and only the top and bottom scroll triggers remain.
+      expect(find.byType(CursorNavigationTrigger), findsNWidgets(2));
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+  });
+}


### PR DESCRIPTION
`schedule_drag_target.dart` covered 10 of its 87 lines, the largest single gap in the package, and none of the covered ones were the drag path. Everything below the constructor was untested: accepting a reschedule, mapping a cursor position to a day row, building the new range, the highlighted row, and both navigation triggers.

Eleven tests take it to 82 of 87, which moves `widgets/drag_targets/` from 71% to 91% and the package from 89.2% to 90.5%. What is left is two `@override` annotations, the deliberate `UnimplementedError` on `visibleDates`, and the closure that refuses a resize, which cannot be reached from a view that builds no resize handles.

Covering it turned up one thing worth deciding separately. A drop takes the time of day from the target day rather than keeping the event's, so an event at 09:00 dragged to another day lands at midnight. The multi-day body preserves it. The test records the current behavior and the roadmap notes it, rather than changing it here.

`coverage/` is now ignored, since a coverage run left the tree dirty.
