### PR TITLE
test: the components classes cover copyWith and equality

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -142,14 +142,14 @@ The missing `ResizeHandleStyle` moved to 0.28.0 above.
 
 ### Tests
 
-Coverage is 90.5% of lines, up from 88.2% at 0.24.0 and 84.4% at 0.23.0. It gates the composability work below. The two areas the 0.24.0 backfill named as next have still not moved, and the release that rewrote the worst-covered area fixed it outright.
+Coverage is 92.3% of lines, up from 88.2% at 0.24.0 and 84.4% at 0.23.0. It gates the composability work below, and that gate is now met.
 
 Both columns are line coverage of the directory and everything under it, measured with `flutter test --coverage`.
 
 | Area | 0.24.0 | Now | What is missing |
 |---|---|---|---|
-| `models/` | 87% | 83% | Went down, because of a directory this table had no row for. See below. |
-| `models/components/` | not tracked | 58% | The lowest in the package. `copyWith`, `==` and `hashCode` on the components classes have no test at all. Audited for dropped fields and there are none, so it is untested rather than wrong. |
+| `models/` | 87% | 89% | Recovered, and past the 0.24.0 figure, once the directory below was covered. |
+| `models/components/` | not tracked | 98% | Done. `copyWith`, `==` and `hashCode` on the nine components classes had no test at all. What is left is six bare `@override` lines that lcov counts and no test can reach. |
 | `models/mixins/` | 84% | 84% | Untouched. |
 | `models/view_configurations/` | 83% | 84% | `schedule_view_configuration.dart` at 42%. |
 | `widgets/drag_targets/` | 71% | 91% | Done. `schedule_drag_target.dart` went from 10 of its 87 lines to 82, which covered the whole reschedule path in the schedule view. |
@@ -158,7 +158,9 @@ Both columns are line coverage of the directory and everything under it, measure
 
 The rest runs from 79% to 100% with no large gap.
 
-`models/components/` is the one left, and it is the shape the package has already shipped twice: a `copyWith` that silently drops a field, found in `view_configurations` as late as 0.24.0, in a class nothing tested. The pattern worth taking from 0.24.0 held again here. Covering the schedule drag target showed that a drop takes the time of day from the target day rather than keeping the event's, so a 09:00 meeting moved to another day lands at midnight. The multi-day body keeps it.
+Both areas the 0.24.0 backfill named are now closed, so the coverage gate on the composability work below is met. What is left is smaller and spread out: `schedule_view_configuration.dart` at 42%, `multi_day_overlay_tile.dart` at 31% and `schedule_tile.dart` at 39%.
+
+The pattern from 0.24.0 held again, in that closing a gap turned something up. Covering the schedule drag target showed that a drop takes the time of day from the target day rather than keeping the event's, so a 09:00 meeting moved to another day lands at midnight. The multi-day body keeps it. The components classes were sound: the tests found no dropped field, which matches the audit done during 0.27.0.
 
 ### Composability
 

--- a/test/models/component_copywith_test.dart
+++ b/test/models/component_copywith_test.dart
@@ -1,0 +1,314 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+/// Every components class has to survive a `copyWith`, and every field on it has
+/// to be reachable through one.
+///
+/// A `copyWith` that silently drops a field is a no-op with no error, which the
+/// package has shipped twice: `MonthBodyConfiguration.copyWith` dropped
+/// `eventPadding` (#252) and `PageTriggerConfiguration.copyWith` dropped
+/// `triggerWidth` (#302). These classes had no test at all.
+///
+/// Two checks cover it, without naming each field twice:
+///   * `copyWith()` with no arguments returns an equal instance, so no field is
+///     dropped on the way through.
+///   * setting each field on an empty instance breaks equality, so every field
+///     is applied, and reaches `==` and `hashCode`.
+///
+/// What this does not catch is a `copyWith` that sets a second field of the same
+/// type as a side effect, since the copy still differs from the empty instance.
+/// The analyzer catches the version of that where the types differ.
+void main() {
+  /// Asserts [full] survives a no-argument copy, and that each mutation in
+  /// [mutations] changes [empty].
+  void checkClass<T extends Object>(
+    String name, {
+    required T full,
+    required T empty,
+    required T Function() copyWithNothing,
+    required Map<String, T Function()> mutations,
+  }) {
+    group(name, () {
+      test('a copy with no arguments keeps every field', () {
+        expect(copyWithNothing(), equals(full), reason: 'copyWith() dropped a field');
+        expect(copyWithNothing().hashCode, equals(full.hashCode));
+      });
+
+      test('a fully populated instance differs from an empty one', () {
+        expect(full, isNot(equals(empty)));
+        expect(full.hashCode, isNot(equals(empty.hashCode)));
+      });
+
+      for (final entry in mutations.entries) {
+        test('copyWith applies ${entry.key}', () {
+          final copy = entry.value();
+          expect(copy, isNot(equals(empty)), reason: '${entry.key} is missing from copyWith or from ==');
+          expect(copy.hashCode, isNot(equals(empty.hashCode)), reason: '${entry.key} is missing from hashCode');
+        });
+      }
+    });
+  }
+
+  const overlayBuilders = OverlayBuilders(
+    multiDayOverlayBuilder: _overlay,
+    multiDayOverlayPortalBuilder: _overlayPortal,
+    multiDayPortalOverlayButtonBuilder: _overlayButton,
+    multiDayPortalOverlayButtonStringBuilder: _hiddenCount,
+  );
+
+  const monthBody = MonthBodyComponents(
+    monthGridBuilder: _grid,
+    monthDayHeaderBuilder: _dateWidget,
+    monthDayHeaderStringBuilder: _dateString,
+    monthDayCellBuilder: _dayCell,
+    weekNumberBuilder: _weekNumber,
+    leftTriggerBuilder: _horizontalTrigger,
+    rightTriggerBuilder: _horizontalTrigger,
+    overlayBuilders: overlayBuilders,
+  );
+
+  const monthHeader = MonthHeaderComponents(
+    weekDayHeaderBuilder: _dateWidget,
+    weekDayHeaderStringBuilder: _dateString,
+  );
+
+  const multiDayHeader = MultiDayHeaderComponents(
+    dayHeaderBuilder: _dateWidget,
+    dayHeaderStringBuilder: _dateString,
+    dayHeaderNumberStringBuilder: _dateString,
+    weekNumberBuilder: _weekNumber,
+    leftTriggerBuilder: _horizontalTrigger,
+    rightTriggerBuilder: _horizontalTrigger,
+    overlayBuilders: overlayBuilders,
+  );
+
+  const multiDayBody = MultiDayBodyComponents(
+    hourLines: _hourLines,
+    timeline: _timeline,
+    timelineStringBuilder: _timeString,
+    timelineWidth: _timelineWidth,
+    daySeparator: _daySeparator,
+    timeIndicator: _timeIndicator,
+    leftTriggerBuilder: _horizontalTrigger,
+    rightTriggerBuilder: _horizontalTrigger,
+    topTriggerBuilder: _verticalTrigger,
+    bottomTriggerBuilder: _verticalTrigger,
+  );
+
+  const schedule = ScheduleComponents(
+    leadingDateBuilder: _scheduleDate,
+    leadingDateStringBuilder: _dateString,
+    scheduleTileHighlightBuilder: _tileHighlight,
+    emptyItemBuilder: _rangeWidget,
+    monthItemBuilder: _rangeWidget,
+  );
+
+  const month = MonthComponents(bodyComponents: monthBody, headerComponents: monthHeader);
+  const multiDay = MultiDayComponents(headerComponents: multiDayHeader, bodyComponents: multiDayBody);
+
+  const calendar = CalendarComponents(
+    monthComponents: month,
+    multiDayComponents: multiDay,
+    scheduleComponents: schedule,
+    overlayBuilders: overlayBuilders,
+  );
+
+  checkClass(
+    'OverlayBuilders',
+    full: overlayBuilders,
+    empty: const OverlayBuilders(),
+    copyWithNothing: overlayBuilders.copyWith,
+    mutations: {
+      'multiDayOverlayBuilder': () => const OverlayBuilders().copyWith(multiDayOverlayBuilder: _overlay),
+      'multiDayOverlayPortalBuilder': () =>
+          const OverlayBuilders().copyWith(multiDayOverlayPortalBuilder: _overlayPortal),
+      'multiDayPortalOverlayButtonBuilder': () =>
+          const OverlayBuilders().copyWith(multiDayPortalOverlayButtonBuilder: _overlayButton),
+      'multiDayPortalOverlayButtonStringBuilder': () =>
+          const OverlayBuilders().copyWith(multiDayPortalOverlayButtonStringBuilder: _hiddenCount),
+    },
+  );
+
+  checkClass(
+    'MonthBodyComponents',
+    full: monthBody,
+    empty: const MonthBodyComponents(),
+    copyWithNothing: monthBody.copyWith,
+    mutations: {
+      'monthGridBuilder': () => const MonthBodyComponents().copyWith(monthGridBuilder: _grid),
+      'monthDayHeaderBuilder': () => const MonthBodyComponents().copyWith(monthDayHeaderBuilder: _dateWidget),
+      'monthDayHeaderStringBuilder': () =>
+          const MonthBodyComponents().copyWith(monthDayHeaderStringBuilder: _dateString),
+      'monthDayCellBuilder': () => const MonthBodyComponents().copyWith(monthDayCellBuilder: _dayCell),
+      'weekNumberBuilder': () => const MonthBodyComponents().copyWith(weekNumberBuilder: _weekNumber),
+      'leftTriggerBuilder': () => const MonthBodyComponents().copyWith(leftTriggerBuilder: _horizontalTrigger),
+      'rightTriggerBuilder': () => const MonthBodyComponents().copyWith(rightTriggerBuilder: _horizontalTrigger),
+      'overlayBuilders': () => const MonthBodyComponents().copyWith(overlayBuilders: overlayBuilders),
+    },
+  );
+
+  checkClass(
+    'MonthHeaderComponents',
+    full: monthHeader,
+    empty: const MonthHeaderComponents(),
+    copyWithNothing: monthHeader.copyWith,
+    mutations: {
+      'weekDayHeaderBuilder': () => const MonthHeaderComponents().copyWith(weekDayHeaderBuilder: _dateWidget),
+      'weekDayHeaderStringBuilder': () =>
+          const MonthHeaderComponents().copyWith(weekDayHeaderStringBuilder: _dateString),
+    },
+  );
+
+  checkClass(
+    'MonthComponents',
+    full: month,
+    empty: const MonthComponents(),
+    copyWithNothing: month.copyWith,
+    mutations: {
+      'bodyComponents': () => const MonthComponents().copyWith(bodyComponents: monthBody),
+      'headerComponents': () => const MonthComponents().copyWith(headerComponents: monthHeader),
+    },
+  );
+
+  checkClass(
+    'MultiDayHeaderComponents',
+    full: multiDayHeader,
+    empty: const MultiDayHeaderComponents(),
+    copyWithNothing: multiDayHeader.copyWith,
+    mutations: {
+      'dayHeaderBuilder': () => const MultiDayHeaderComponents().copyWith(dayHeaderBuilder: _dateWidget),
+      'dayHeaderStringBuilder': () => const MultiDayHeaderComponents().copyWith(dayHeaderStringBuilder: _dateString),
+      'dayHeaderNumberStringBuilder': () =>
+          const MultiDayHeaderComponents().copyWith(dayHeaderNumberStringBuilder: _dateString),
+      'weekNumberBuilder': () => const MultiDayHeaderComponents().copyWith(weekNumberBuilder: _weekNumber),
+      'leftTriggerBuilder': () => const MultiDayHeaderComponents().copyWith(leftTriggerBuilder: _horizontalTrigger),
+      'rightTriggerBuilder': () => const MultiDayHeaderComponents().copyWith(rightTriggerBuilder: _horizontalTrigger),
+      'overlayBuilders': () => const MultiDayHeaderComponents().copyWith(overlayBuilders: overlayBuilders),
+    },
+  );
+
+  checkClass(
+    'MultiDayBodyComponents',
+    full: multiDayBody,
+    empty: const MultiDayBodyComponents(),
+    copyWithNothing: multiDayBody.copyWith,
+    mutations: {
+      'hourLines': () => const MultiDayBodyComponents().copyWith(hourLines: _hourLines),
+      'timeline': () => const MultiDayBodyComponents().copyWith(timeline: _timeline),
+      'timelineStringBuilder': () => const MultiDayBodyComponents().copyWith(timelineStringBuilder: _timeString),
+      'timelineWidth': () => const MultiDayBodyComponents().copyWith(timelineWidth: _timelineWidth),
+      'daySeparator': () => const MultiDayBodyComponents().copyWith(daySeparator: _daySeparator),
+      'timeIndicator': () => const MultiDayBodyComponents().copyWith(timeIndicator: _timeIndicator),
+      'leftTriggerBuilder': () => const MultiDayBodyComponents().copyWith(leftTriggerBuilder: _horizontalTrigger),
+      'rightTriggerBuilder': () => const MultiDayBodyComponents().copyWith(rightTriggerBuilder: _horizontalTrigger),
+      'topTriggerBuilder': () => const MultiDayBodyComponents().copyWith(topTriggerBuilder: _verticalTrigger),
+      'bottomTriggerBuilder': () => const MultiDayBodyComponents().copyWith(bottomTriggerBuilder: _verticalTrigger),
+    },
+  );
+
+  checkClass(
+    'MultiDayComponents',
+    full: multiDay,
+    empty: const MultiDayComponents(),
+    copyWithNothing: multiDay.copyWith,
+    mutations: {
+      'headerComponents': () => const MultiDayComponents().copyWith(headerComponents: multiDayHeader),
+      'bodyComponents': () => const MultiDayComponents().copyWith(bodyComponents: multiDayBody),
+    },
+  );
+
+  checkClass(
+    'ScheduleComponents',
+    full: schedule,
+    empty: const ScheduleComponents(),
+    copyWithNothing: schedule.copyWith,
+    mutations: {
+      'leadingDateBuilder': () => const ScheduleComponents().copyWith(leadingDateBuilder: _scheduleDate),
+      'leadingDateStringBuilder': () => const ScheduleComponents().copyWith(leadingDateStringBuilder: _dateString),
+      'scheduleTileHighlightBuilder': () =>
+          const ScheduleComponents().copyWith(scheduleTileHighlightBuilder: _tileHighlight),
+      'emptyItemBuilder': () => const ScheduleComponents().copyWith(emptyItemBuilder: _rangeWidget),
+      'monthItemBuilder': () => const ScheduleComponents().copyWith(monthItemBuilder: _rangeWidget),
+    },
+  );
+
+  checkClass(
+    'CalendarComponents',
+    full: calendar,
+    empty: const CalendarComponents(),
+    copyWithNothing: calendar.copyWith,
+    mutations: {
+      'monthComponents': () => const CalendarComponents().copyWith(monthComponents: month),
+      'multiDayComponents': () => const CalendarComponents().copyWith(multiDayComponents: multiDay),
+      'scheduleComponents': () => const CalendarComponents().copyWith(scheduleComponents: schedule),
+      'overlayBuilders': () => const CalendarComponents().copyWith(overlayBuilders: overlayBuilders),
+    },
+  );
+}
+
+// One named function per builder shape. A tear-off of the same function compares
+// equal, which is what lets the "no arguments" copy be checked with `==`.
+
+Widget _overlay(
+  BuildContext context, {
+  required DateTime date,
+  required List<CalendarEvent> events,
+  required double tileHeight,
+  required OverlayPortalController portalController,
+  required RenderBoxCallback getMultiDayEventLayoutRenderBox,
+  required RenderBoxCallback getOverlayPortalRenderBox,
+  required MultiDayOverlayEventTileBuilder overlayTileBuilder,
+}) =>
+    const SizedBox();
+
+Widget _overlayPortal(
+  BuildContext context, {
+  required DateTime date,
+  required List<CalendarEvent> events,
+  required int numberOfHiddenRows,
+  required double tileHeight,
+  required RenderBoxCallback getMultiDayEventLayoutRenderBox,
+  required MultiDayOverlayEventTileBuilder overlayTileBuilder,
+  required OverlayBuilders? overlayBuilders,
+}) =>
+    const SizedBox();
+
+Widget _overlayButton(BuildContext context, OverlayPortalController controller, int hidden) => const SizedBox();
+String _hiddenCount(BuildContext context, int hidden) => '$hidden';
+Widget _grid(BuildContext context, int numberOfRows) => const SizedBox();
+Widget _dateWidget(BuildContext context, DateTime date) => const SizedBox();
+String _dateString(BuildContext context, DateTime date) => '';
+Widget _dayCell(BuildContext context, MonthDayCellDetails details) => const SizedBox();
+Widget _weekNumber(BuildContext context, DateTimeRange range) => const SizedBox();
+Widget _horizontalTrigger(BuildContext context, double pageWidth) => const SizedBox();
+Widget _verticalTrigger(BuildContext context, double viewPortHeight) => const SizedBox();
+Widget _hourLines(BuildContext context, double heightPerMinute, TimeOfDayRange range) => const SizedBox();
+
+Widget _timeline(
+  BuildContext context,
+  double heightPerMinute,
+  TimeOfDayRange range,
+  ValueNotifier<CalendarEvent?> eventBeingDragged,
+  ValueNotifier<DateTimeRange?> visibleDateTimeRange,
+) =>
+    const SizedBox();
+
+String _timeString(BuildContext context, TimeOfDay time) => '';
+double _timelineWidth(BuildContext context, TimeOfDayRange range) => 56;
+Widget _daySeparator(BuildContext context) => const SizedBox();
+
+Widget _timeIndicator(BuildContext context, TimeOfDayRange range, double heightPerMinute, Location? location) =>
+    const SizedBox();
+
+Widget _scheduleDate(BuildContext context, InternalDateTime date) => const SizedBox();
+
+Widget _tileHighlight(
+  BuildContext context,
+  InternalDateTime date,
+  ValueNotifier<InternalDateTimeRange?> dateTimeRange,
+  Widget child,
+) =>
+    child;
+
+Widget _rangeWidget(BuildContext context, DateTimeRange range) => const SizedBox();


### PR DESCRIPTION
Stacked on #467.

`models/components/` was the lowest covered area in the package at 58%, and `copyWith`, `==` and `hashCode` on the nine components classes had no test at all. The roadmap named it as the shape that has already shipped a bug twice: a `copyWith` that silently drops a field, which is a no-op with no error.

Two checks per class cover it without naming each field twice. A copy with no arguments has to equal the original, which fails if any field is dropped on the way through. Setting each field on an empty instance has to break equality, which fails if the field is missing from `copyWith`, from `==` or from `hashCode`. Both failure modes were confirmed by breaking them and watching the right test fail.

That takes `models/components/` from 58% to 98%, with four of the six files at 100%. What is left is six bare `@override` lines that lcov counts and no test can reach.

The classes turned out to be sound. The tests found no dropped field, which matches the audit done during 0.27.0.

With #467 the package is at 92.3%, up from 89.2%, and both areas the 0.24.0 backfill named as next are closed. The roadmap table is remeasured.
