### PR TITLE
refactor!: CreateEventGesture is now EventInteractionGesture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ Mixins `DayEventTileUtils` and `MultiDayEventTileUtils` provide helper methods f
 - Native `Draggable`/`LongPressDraggable` for existing events. `NewDraggable` mixin for creating new events.
 - Drag targets: `VerticalDragTarget` (day/week), `HorizontalDragTarget` (month/header), `ScheduleDragTarget`.
 - Drag data: `DraggableEvent` for existing events, create markers for new events, `ResizeDirection` enum for resize operations.
-- Platform-aware gestures: Desktop uses tap, mobile uses long-press (configurable via `CreateEventGesture`).
+- Platform-aware gestures: Desktop uses tap, mobile uses long-press (configurable via `EventInteractionGesture`).
 - Callbacks: `onEventCreate()`, `onEventChange()`, `onWillAcceptWithDetails*()`.
 
 ### Error Handling
@@ -272,11 +272,10 @@ before tagging it:
 - **TODOs on public API.** Several are renames or removals held for 0.28.0, the
   next breaking window: the `renderBox` parameter on `OnEventTapped` and
   `OnEventTappedWithDetail`, the `MultiDayBodyConfiguration` merge into
-  `VerticalConfiguration`, `CreateEventGesture` to `EventInteractionGesture`, and
-  the `k` prefix on the `default*` constants. Find them with
-  `grep -rn "TODO" lib/`. Each one is a decision still owed. Keep them as `//`
-  comments: a `///` one renders as prose in the API reference, which is how
-  `FreeScrollFunctions` shipped with a TODO as its entire published
+  `VerticalConfiguration`, and the `k` prefix on the `default*` constants. Find
+  them with `grep -rn "TODO" lib/`. Each one is a decision still owed. Keep them
+  as `//` comments: a `///` one renders as prose in the API reference, which is
+  how `FreeScrollFunctions` shipped with a TODO as its entire published
   documentation before it was removed in 0.28.0. `grep -rn "/// TODO" lib/` is
   the check.
 - **Deprecations past their window.** None. `lib/` carries no `@Deprecated` at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ See [MIGRATION.md](MIGRATION.md#v027x--v0280) for what to change.
 ### Breaking Changes
 
 - `FreeScrollFunctions` is removed. It duplicated `DayIndexCalculator`, which `PageIndexCalculator.freeScroll` now returns. Name `DayIndexCalculator` where the removed class was named.
+- `CreateEventGesture` is renamed to `EventInteractionGesture`. The enum decides how an event is modified as well as created. The `createEventGesture` and `modifyEventGesture` fields on `CalendarInteraction` keep their names.
 
 ### Bug Fixes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,7 +4,7 @@ Each section covers one upgrade. Versions not listed below need no changes.
 
 | Upgrade | What changes |
 | --- | --- |
-| [v0.27.x → v0.28.0](#v027x--v0280) | The free scroll band stops drawing a day past its display range. `FreeScrollFunctions` is removed. |
+| [v0.27.x → v0.28.0](#v027x--v0280) | The free scroll band stops drawing a day past its display range. `FreeScrollFunctions` is removed. `CreateEventGesture` is renamed. |
 | [v0.26.x → v0.27.0](#v026x--v0270) | Every builder takes a `BuildContext` and resolves its own styles. `TimeOfDayRange.isAllDay` is removed. |
 | [v0.25.x → v0.26.0](#v025x--v0260) | The deprecated style fields on `CalendarComponents` are removed, along with the containers reached through them. The three strategy fields become classes. `CalendarEvent.copyWith` becomes `copyWithData`. |
 | [v0.24.x → v0.25.0](#v024x--v0250) | The deprecated `isMultiDayEvent` getter is removed. |
@@ -39,6 +39,26 @@ if (config.pageIndexCalculator is FreeScrollFunctions) { ... }
 // After. This no longer tells a free scroll view from a single day one, since
 // both use the same calculator. Read `MultiDayViewConfiguration.type` for that.
 if (config.pageIndexCalculator is DayIndexCalculator) { ... }
+```
+
+### `CreateEventGesture` is now `EventInteractionGesture`
+
+The enum decides how an event is modified as well as created, which the old name
+covered only half of. The `createEventGesture` and `modifyEventGesture` fields on
+`CalendarInteraction` keep their names, so only the type changes.
+
+```dart
+// Before
+CalendarInteraction(
+  createEventGesture: CreateEventGesture.tap,
+  modifyEventGesture: CreateEventGesture.longPress,
+);
+
+// After
+CalendarInteraction(
+  createEventGesture: EventInteractionGesture.tap,
+  modifyEventGesture: EventInteractionGesture.longPress,
+);
 ```
 
 ## v0.26.x → v0.27.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -124,7 +124,7 @@ The breaking changes with nowhere cheaper to go. None has a deprecation path tha
 
 **`MultiDayBodyConfiguration` folds into `VerticalConfiguration`.** The TODO on it reads as a rename, but the class extends `VerticalConfiguration` and adds `keepPagesAlive`, so the two are not interchangeable today. Moving that field up is what makes a replacement honest, and only then can a deprecation message name one. Which way the merge goes is open: `MultiDayBodyConfiguration` is the more discoverable of the two names.
 
-**`CreateEventGesture` becomes `EventInteractionGesture`.** The name says "create" and the enum also decides how an event is modified, which is why `CalendarInteraction` carries it twice, as `createEventGesture` and `modifyEventGesture`. A public enum cannot be renamed behind a deprecation, so it goes in a breaking batch or not at all. Carried a TODO with no release attached until now.
+**`CreateEventGesture` is now `EventInteractionGesture`.** The old name said "create" and the enum also decides how an event is modified, which is why `CalendarInteraction` carries it twice, as `createEventGesture` and `modifyEventGesture`. A public enum cannot be renamed behind a deprecation, so it went into this batch or nowhere. The two field names are unchanged.
 
 **The `default*` constants take a `k` prefix.** `defaultTileHeight`, `defaultNewEventDuration`, `defaultEventLayoutStrategy` and the rest are public top-level constants, so renaming them is breaking. Worth doing with the others rather than alone, and worth deciding against outright if the prefix is not wanted, since the TODO has outlived several releases.
 

--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -25,9 +25,9 @@ CalendarBody(
     allowRescheduling: true,
     allowEventCreation: true,
     // Tap on desktop, long-press on mobile, when left unset.
-    createEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
     // The gesture that starts modifying an existing event, same defaults.
-    modifyEventGesture: CreateEventGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
     // Input mode affects resize handle positioning and visibility:
     //   auto:      detects dynamically from pointer events
     //   precise:   mouse, stylus, trackpad (full-width handles, hover-to-show)

--- a/examples/web_demo/lib/models/demo_configuration.dart
+++ b/examples/web_demo/lib/models/demo_configuration.dart
@@ -78,12 +78,12 @@ class DemoConfiguration extends ChangeNotifier {
 
   /// The header interaction of the calendar.
   late final ValueNotifier<CalendarInteraction> interactionHeader = ValueNotifier(CalendarInteraction(
-    createEventGesture: isMobile ? CreateEventGesture.longPress : CreateEventGesture.tap,
+    createEventGesture: isMobile ? EventInteractionGesture.longPress : EventInteractionGesture.tap,
   ));
 
   /// The body interaction of the calendar.
   late final ValueNotifier<CalendarInteraction> interactionBody = ValueNotifier(CalendarInteraction(
-    createEventGesture: isMobile ? CreateEventGesture.longPress : CreateEventGesture.tap,
+    createEventGesture: isMobile ? EventInteractionGesture.longPress : EventInteractionGesture.tap,
   ));
 
   /// The snapping configuration of the calendar.

--- a/lib/src/models/calendar_interaction.dart
+++ b/lib/src/models/calendar_interaction.dart
@@ -103,13 +103,12 @@ enum InputMode {
   imprecise,
 }
 
-/// The [CreateEventGesture] is used to differentiate between the different ways to create an event.
-// TODO: Rename this to EventInteractionGesture in 0.28.0.
-enum CreateEventGesture {
-  /// Creates event on tap gesture.
+/// The [EventInteractionGesture] is used to differentiate between the different ways to create and modify an event.
+enum EventInteractionGesture {
+  /// Uses a tap gesture.
   tap,
 
-  /// Creates event on tap hold gesture.
+  /// Uses a tap and hold gesture.
   longPress,
 }
 
@@ -150,17 +149,17 @@ class CalendarInteraction {
   ///
   /// This gesture determines how users can create new events in the calendar.
   /// It can be either a tap or a long press gesture.
-  final CreateEventGesture createEventGesture;
-  static const defaultCreateEventGesture = CreateEventGesture.tap;
-  static const defaultMobileCreateEventGesture = CreateEventGesture.longPress;
+  final EventInteractionGesture createEventGesture;
+  static const defaultCreateEventGesture = EventInteractionGesture.tap;
+  static const defaultMobileCreateEventGesture = EventInteractionGesture.longPress;
 
   /// The gesture used to modify an event.
   ///
   /// This gesture determines how users can modify existing events in the calendar.
   /// It can be either a tap or a long press gesture.
-  final CreateEventGesture modifyEventGesture;
-  static const defaultModifyEventGesture = CreateEventGesture.tap;
-  static const defaultMobileModifyEventGesture = CreateEventGesture.longPress;
+  final EventInteractionGesture modifyEventGesture;
+  static const defaultModifyEventGesture = EventInteractionGesture.tap;
+  static const defaultMobileModifyEventGesture = EventInteractionGesture.longPress;
 
   /// The input mode for the calendar.
   ///
@@ -198,8 +197,8 @@ class CalendarInteraction {
     this.allowEventCreation = defaultAllowEventCreation,
     this.inputMode = defaultInputMode,
     this.allowHorizontalImpreciseResize = defaultAllowHorizontalImpreciseResize,
-    CreateEventGesture? createEventGesture,
-    CreateEventGesture? modifyEventGesture,
+    EventInteractionGesture? createEventGesture,
+    EventInteractionGesture? modifyEventGesture,
   })  : createEventGesture =
             createEventGesture ?? (isMobileDevice ? defaultMobileCreateEventGesture : defaultCreateEventGesture),
         modifyEventGesture =
@@ -213,8 +212,8 @@ class CalendarInteraction {
     bool? allowEventCreation,
     InputMode? inputMode,
     bool? allowHorizontalImpreciseResize,
-    CreateEventGesture? createEventGesture,
-    CreateEventGesture? modifyEventGesture,
+    EventInteractionGesture? createEventGesture,
+    EventInteractionGesture? modifyEventGesture,
   }) {
     return CalendarInteraction(
       allowResizing: allowResizing ?? this.allowResizing,

--- a/lib/src/widgets/draggable/day_draggable.dart
+++ b/lib/src/widgets/draggable/day_draggable.dart
@@ -57,7 +57,7 @@ class _DayDraggableState extends State<DayDraggable> with NewDraggableWidget {
                           : null,
                       child: context.interaction.allowEventCreation
                           ? switch (context.interaction.createEventGesture) {
-                              CreateEventGesture.tap => Draggable(
+                              EventInteractionGesture.tap => Draggable(
                                   dragAnchorStrategy: pointerDragAnchorStrategy,
                                   onDragStarted: () => createNewEvent(context, date, position),
                                   onDraggableCanceled: onDragFinished,
@@ -66,7 +66,7 @@ class _DayDraggableState extends State<DayDraggable> with NewDraggableWidget {
                                   feedback: Container(color: Colors.transparent, width: 1, height: 1),
                                   child: Container(color: Colors.transparent, height: widget.pageHeight),
                                 ),
-                              CreateEventGesture.longPress => LongPressDraggable(
+                              EventInteractionGesture.longPress => LongPressDraggable(
                                   dragAnchorStrategy: pointerDragAnchorStrategy,
                                   onDragStarted: () => createNewEvent(context, date, position),
                                   onDraggableCanceled: onDragFinished,

--- a/lib/src/widgets/draggable/multi_day_draggable.dart
+++ b/lib/src/widgets/draggable/multi_day_draggable.dart
@@ -42,7 +42,7 @@ class _MultiDayDraggableState extends State<MultiDayDraggable> with NewDraggable
                         : null,
                     child: context.interaction.allowEventCreation
                         ? switch (context.interaction.createEventGesture) {
-                            CreateEventGesture.tap => Draggable(
+                            EventInteractionGesture.tap => Draggable(
                                 onDragStarted: () => createNewEvent(context, date, position),
                                 onDraggableCanceled: onDragFinished,
                                 onDragEnd: onDragFinished,
@@ -51,7 +51,7 @@ class _MultiDayDraggableState extends State<MultiDayDraggable> with NewDraggable
                                 feedback: Container(color: Colors.transparent, width: 1, height: 1),
                                 child: Container(color: Colors.transparent),
                               ),
-                            CreateEventGesture.longPress => LongPressDraggable(
+                            EventInteractionGesture.longPress => LongPressDraggable(
                                 onDragStarted: () => createNewEvent(context, date, position),
                                 onDraggableCanceled: onDragFinished,
                                 onDragEnd: onDragFinished,

--- a/lib/src/widgets/event_tiles/tile_draggable.dart
+++ b/lib/src/widgets/event_tiles/tile_draggable.dart
@@ -49,8 +49,8 @@ class TileDraggable extends StatelessWidget {
     }
 
     return switch (context.interaction.modifyEventGesture) {
-      CreateEventGesture.tap => Draggable.new,
-      CreateEventGesture.longPress => LongPressDraggable.new,
+      EventInteractionGesture.tap => Draggable.new,
+      EventInteractionGesture.longPress => LongPressDraggable.new,
     }(
       key: rescheduleDraggableKey,
       data: Reschedule(event: event),

--- a/test/interactions/calendar_callback_test.dart
+++ b/test/interactions/calendar_callback_test.dart
@@ -15,16 +15,16 @@ void main() {
     allowRescheduling: true,
     allowEventCreation: true,
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
   final impreciseInteraction = CalendarInteraction(
     allowResizing: true,
     allowRescheduling: true,
     allowEventCreation: true,
     inputMode: InputMode.imprecise,
-    createEventGesture: CreateEventGesture.longPress,
-    modifyEventGesture: CreateEventGesture.longPress,
+    createEventGesture: EventInteractionGesture.longPress,
+    modifyEventGesture: EventInteractionGesture.longPress,
   );
 
   setUp(() {

--- a/test/interactions/interaction_test.dart
+++ b/test/interactions/interaction_test.dart
@@ -16,8 +16,8 @@ void main() {
     allowRescheduling: true,
     allowEventCreation: true,
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
 
   final impreciseInteraction = CalendarInteraction(
@@ -25,8 +25,8 @@ void main() {
     allowRescheduling: true,
     allowEventCreation: true,
     inputMode: InputMode.imprecise,
-    createEventGesture: CreateEventGesture.longPress,
-    modifyEventGesture: CreateEventGesture.longPress,
+    createEventGesture: EventInteractionGesture.longPress,
+    modifyEventGesture: EventInteractionGesture.longPress,
   );
 
   final autoInteraction = CalendarInteraction(
@@ -34,8 +34,8 @@ void main() {
     allowRescheduling: true,
     allowEventCreation: true,
     inputMode: InputMode.auto,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
 
   late String dayEventID;

--- a/test/models/calendar_interaction_test.dart
+++ b/test/models/calendar_interaction_test.dart
@@ -79,23 +79,23 @@ void main() {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       addTearDown(() => debugDefaultTargetPlatformOverride = null);
       final interaction = CalendarInteraction();
-      expect(interaction.createEventGesture, equals(CreateEventGesture.longPress));
-      expect(interaction.modifyEventGesture, equals(CreateEventGesture.longPress));
+      expect(interaction.createEventGesture, equals(EventInteractionGesture.longPress));
+      expect(interaction.modifyEventGesture, equals(EventInteractionGesture.longPress));
     });
 
     test('desktop defaults to tap for create/modify', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.linux;
       addTearDown(() => debugDefaultTargetPlatformOverride = null);
       final interaction = CalendarInteraction();
-      expect(interaction.createEventGesture, equals(CreateEventGesture.tap));
-      expect(interaction.modifyEventGesture, equals(CreateEventGesture.tap));
+      expect(interaction.createEventGesture, equals(EventInteractionGesture.tap));
+      expect(interaction.modifyEventGesture, equals(EventInteractionGesture.tap));
     });
 
     test('an explicit gesture overrides the platform default', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
       addTearDown(() => debugDefaultTargetPlatformOverride = null);
-      final interaction = CalendarInteraction(createEventGesture: CreateEventGesture.tap);
-      expect(interaction.createEventGesture, equals(CreateEventGesture.tap));
+      final interaction = CalendarInteraction(createEventGesture: EventInteractionGesture.tap);
+      expect(interaction.createEventGesture, equals(EventInteractionGesture.tap));
     });
   });
 
@@ -109,31 +109,31 @@ void main() {
         allowEventCreation: true,
         inputMode: InputMode.precise,
         allowHorizontalImpreciseResize: false,
-        createEventGesture: CreateEventGesture.tap,
-        modifyEventGesture: CreateEventGesture.tap,
+        createEventGesture: EventInteractionGesture.tap,
+        modifyEventGesture: EventInteractionGesture.tap,
       );
 
       final copy = original.copyWith(
         allowResizing: false,
         inputMode: InputMode.imprecise,
-        modifyEventGesture: CreateEventGesture.longPress,
+        modifyEventGesture: EventInteractionGesture.longPress,
       );
 
       expect(copy.allowResizing, isFalse);
       expect(copy.inputMode, equals(InputMode.imprecise));
-      expect(copy.modifyEventGesture, equals(CreateEventGesture.longPress));
+      expect(copy.modifyEventGesture, equals(EventInteractionGesture.longPress));
       // Untouched fields are preserved.
       expect(copy.allowRescheduling, isTrue);
       expect(copy.allowEventCreation, isTrue);
       expect(copy.allowHorizontalImpreciseResize, isFalse);
-      expect(copy.createEventGesture, equals(CreateEventGesture.tap));
+      expect(copy.createEventGesture, equals(EventInteractionGesture.tap));
     });
 
     test('copyWith with no arguments preserves every field', () {
       final original = CalendarInteraction(
         allowResizing: false,
         inputMode: InputMode.imprecise,
-        createEventGesture: CreateEventGesture.longPress,
+        createEventGesture: EventInteractionGesture.longPress,
       );
       final copy = original.copyWith();
       expect(copy.allowResizing, equals(original.allowResizing));
@@ -151,8 +151,8 @@ void main() {
           allowEventCreation: true,
           inputMode: InputMode.precise,
           allowHorizontalImpreciseResize: false,
-          createEventGesture: CreateEventGesture.tap,
-          modifyEventGesture: CreateEventGesture.tap,
+          createEventGesture: EventInteractionGesture.tap,
+          modifyEventGesture: EventInteractionGesture.tap,
         );
 
     test('identical configurations are equal with matching hashCodes', () {
@@ -166,8 +166,8 @@ void main() {
       'allowEventCreation': (i) => i.copyWith(allowEventCreation: false),
       'inputMode': (i) => i.copyWith(inputMode: InputMode.imprecise),
       'allowHorizontalImpreciseResize': (i) => i.copyWith(allowHorizontalImpreciseResize: true),
-      'createEventGesture': (i) => i.copyWith(createEventGesture: CreateEventGesture.longPress),
-      'modifyEventGesture': (i) => i.copyWith(modifyEventGesture: CreateEventGesture.longPress),
+      'createEventGesture': (i) => i.copyWith(createEventGesture: EventInteractionGesture.longPress),
+      'modifyEventGesture': (i) => i.copyWith(modifyEventGesture: EventInteractionGesture.longPress),
     }.entries) {
       test('differing ${entry.key} breaks equality', () {
         expect(entry.value(make()), isNot(equals(make())));

--- a/test/widgets/drag_move_coalescing_test.dart
+++ b/test/widgets/drag_move_coalescing_test.dart
@@ -46,8 +46,8 @@ void main() {
         body: CalendarBody(
           interaction: CalendarInteraction(
             inputMode: InputMode.precise,
-            createEventGesture: CreateEventGesture.tap,
-            modifyEventGesture: CreateEventGesture.tap,
+            createEventGesture: EventInteractionGesture.tap,
+            modifyEventGesture: EventInteractionGesture.tap,
           ),
           multiDayTileComponents: TileComponents(
             tileBuilder: (context, event, tileRange) => Container(key: ValueKey(event.id), color: Colors.red),

--- a/test/widgets/event_all_day_test.dart
+++ b/test/widgets/event_all_day_test.dart
@@ -23,8 +23,8 @@ void main() {
 
   final interaction = CalendarInteraction(
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
 
   setUp(() {

--- a/test/widgets/free_scroll_interaction_test.dart
+++ b/test/widgets/free_scroll_interaction_test.dart
@@ -26,8 +26,8 @@ void main() {
 
   final precise = CalendarInteraction(
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
 
   MultiDayViewController viewController() => calendarController.viewController as MultiDayViewController;

--- a/test/widgets/multi_day_body_test.dart
+++ b/test/widgets/multi_day_body_test.dart
@@ -12,8 +12,8 @@ void main() {
 
   final preciseInteraction = CalendarInteraction(
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
 
   final components = TileComponents(
@@ -240,8 +240,8 @@ void main() {
 
       final impreciseInteraction = CalendarInteraction(
         inputMode: InputMode.imprecise,
-        createEventGesture: CreateEventGesture.longPress,
-        modifyEventGesture: CreateEventGesture.longPress,
+        createEventGesture: EventInteractionGesture.longPress,
+        modifyEventGesture: EventInteractionGesture.longPress,
       );
 
       final impreciseViewConfigurations = [

--- a/test/widgets/multi_day_drag_over_body_test.dart
+++ b/test/widgets/multi_day_drag_over_body_test.dart
@@ -16,8 +16,8 @@ void main() {
 
   final interaction = CalendarInteraction(
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
 
   setUp(() {

--- a/test/widgets/multi_day_rule_on_view_test.dart
+++ b/test/widgets/multi_day_rule_on_view_test.dart
@@ -17,8 +17,8 @@ void main() {
 
   final interaction = CalendarInteraction(
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
 
   setUp(() {

--- a/test/widgets/overlay_test.dart
+++ b/test/widgets/overlay_test.dart
@@ -13,8 +13,8 @@ void main() {
   final viewConfiguration = MultiDayViewConfiguration.week();
   final preciseInteraction = CalendarInteraction(
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
   const headerConfiguration = MultiDayHeaderConfiguration(maximumNumberOfVerticalEvents: 1);
 

--- a/test/widgets/page_trigger_test.dart
+++ b/test/widgets/page_trigger_test.dart
@@ -28,8 +28,8 @@ void main() {
 
   final precise = CalendarInteraction(
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
 
   MultiDayViewController viewController() => calendarController.viewController as MultiDayViewController;

--- a/test/widgets/schedule/schedule_drag_target_test.dart
+++ b/test/widgets/schedule/schedule_drag_target_test.dart
@@ -19,8 +19,8 @@ void main() {
   final interaction = CalendarInteraction(
     allowRescheduling: true,
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
 
   setUp(() {

--- a/test/widgets/scroll_trigger_test.dart
+++ b/test/widgets/scroll_trigger_test.dart
@@ -26,8 +26,8 @@ void main() {
 
   final precise = CalendarInteraction(
     inputMode: InputMode.precise,
-    createEventGesture: CreateEventGesture.tap,
-    modifyEventGesture: CreateEventGesture.tap,
+    createEventGesture: EventInteractionGesture.tap,
+    modifyEventGesture: EventInteractionGesture.tap,
   );
 
   MultiDayViewController viewController() => calendarController.viewController as MultiDayViewController;


### PR DESCRIPTION
The enum decides how an event is modified as well as created, which is why `CalendarInteraction` carries it twice, as `createEventGesture` and `modifyEventGesture`. The old name covered only half of that.

A public enum cannot be renamed behind a deprecation, so this goes into a breaking release or nowhere. The two field names are unchanged, so only the type name changes at a call site.

Changelog and migration entries are added to the existing 0.28.0 sections.