### PR TITLE
fix!: a schedule drop keeps the event's time of day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ See [MIGRATION.md](MIGRATION.md#v027x--v0280) for what to change.
 ### Behavior Changes
 
 - `MultiDayViewConfiguration.type` takes part in `==` and `hashCode`. Two configurations of different view types over the same range compared equal where the view type was the only difference between them.
+- A drop in the schedule view keeps the event's time of day. It took the time of day from the target day, so a 09:00 meeting dragged to another day landed at midnight. The multi-day header already kept it, and the schedule now uses the same path.
 
 ## 0.27.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,7 +4,7 @@ Each section covers one upgrade. Versions not listed below need no changes.
 
 | Upgrade | What changes |
 | --- | --- |
-| [v0.27.x → v0.28.0](#v027x--v0280) | The free scroll band stops drawing a day past its display range. `FreeScrollFunctions` is removed. The tap callbacks drop their `RenderBox`. The `default*` constants take a `k` prefix. Two enums and typedefs are renamed. |
+| [v0.27.x → v0.28.0](#v027x--v0280) | The free scroll band stops drawing a day past its display range. A schedule drop keeps the event's time of day. `FreeScrollFunctions` is removed. The tap callbacks drop their `RenderBox`. The `default*` constants take a `k` prefix. Two enums and typedefs are renamed. |
 | [v0.26.x → v0.27.0](#v026x--v0270) | Every builder takes a `BuildContext` and resolves its own styles. `TimeOfDayRange.isAllDay` is removed. |
 | [v0.25.x → v0.26.0](#v025x--v0260) | The deprecated style fields on `CalendarComponents` are removed, along with the containers reached through them. The three strategy fields become classes. `CalendarEvent.copyWith` becomes `copyWithData`. |
 | [v0.24.x → v0.25.0](#v024x--v0250) | The deprecated `isMultiDayEvent` getter is removed. |
@@ -26,6 +26,25 @@ That covers the default range and any range written the usual way. A range
 ending part way through a day is unchanged.
 
 Extend the range by a day if you were relying on the extra column.
+
+### A schedule drop keeps the event's time of day
+
+Nothing stops compiling. A drop in the schedule view took the time of day from
+the target day, so a 09:00 meeting dragged to another day landed at midnight. It
+now lands at 09:00 on the target day, which is what the multi-day header already
+did.
+
+The event handed to `onEventChanged` changes accordingly. Reset the time
+yourself if you were relying on the old result:
+
+```dart
+CalendarCallbacks(
+  onEventChanged: (original, updated) {
+    final start = DateTime(updated.start.year, updated.start.month, updated.start.day);
+    return save(updated.withDateTimeRange(DateTimeRange(start: start, end: start.add(updated.duration))));
+  },
+);
+```
 
 ### `FreeScrollFunctions` is removed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -168,7 +168,7 @@ The rest runs from 79% to 100% with no large gap.
 
 Both areas the 0.24.0 backfill named are now closed, so the coverage gate on the composability work below is met. What is left is smaller and spread out: `schedule_view_configuration.dart` at 42%, `multi_day_overlay_tile.dart` at 31% and `schedule_tile.dart` at 39%.
 
-The pattern from 0.24.0 held again, in that closing a gap turned something up. Covering the schedule drag target showed that a drop takes the time of day from the target day rather than keeping the event's, so a 09:00 meeting moved to another day lands at midnight. The multi-day body keeps it. The components classes were sound: the tests found no dropped field, which matches the audit done during 0.27.0.
+The pattern from 0.24.0 held again, in that closing a gap turned something up. Covering the schedule drag target showed that a drop took the time of day from the target day rather than keeping the event's, so a 09:00 meeting moved to another day landed at midnight. The multi-day header already kept it, and the schedule uses the same path in 0.28.0. The components classes were sound: the tests found no dropped field, which matches the audit done during 0.27.0.
 
 ### Composability
 

--- a/lib/src/widgets/drag_targets/schedule_drag_target.dart
+++ b/lib/src/widgets/drag_targets/schedule_drag_target.dart
@@ -189,27 +189,14 @@ class _ScheduleDragTargetState extends State<ScheduleDragTarget> with DragTarget
   }
 
   @override
-  CalendarEvent? rescheduleEvent(CalendarEvent event, DateTime cursorDateTime) {
-    final rangeAsUtc = event.internalRange(location: context.location);
-    // Set the highlighted date in the schedule view controller.
+  CalendarEvent? rescheduleEvent(CalendarEvent event, InternalDateTime cursorDateTime) {
+    // The highlight marks whole rows, so it stays anchored to the target day.
     widget.viewController.highlightedDateTimeRange.value = InternalDateTimeRange(
       start: cursorDateTime,
-      end: cursorDateTime.add(rangeAsUtc.duration),
+      end: cursorDateTime.add(event.duration),
     );
-    if (event.spansMultipleDays(location: context.location, defaultRule: context.multiDayRule)) {
-      final duration = rangeAsUtc.duration;
-      final endTime = cursorDateTime.add(duration);
-      final newRange = InternalDateTimeRange(start: cursorDateTime, end: endTime);
-      return event.withDateTimeRange(toLocationDateTimeRange(newRange));
-    } else {
-      // Calculate the new dateTimeRange for the event.
-      final newStartTime = cursorDateTime;
-      final duration = event.duration;
-      final endTime = newStartTime.add(duration);
-      final newRange = InternalDateTimeRange(start: newStartTime, end: endTime);
 
-      return event.withDateTimeRange(toLocationDateTimeRange(newRange));
-    }
+    return rescheduleToDate(event, cursorDateTime);
   }
 
   @override

--- a/test/widgets/schedule/schedule_drag_target_test.dart
+++ b/test/widgets/schedule/schedule_drag_target_test.dart
@@ -112,18 +112,23 @@ void main() {
     expect(changed!.start.isAfter(originalStart), isTrue, reason: 'a downward drag moves the event forward');
   });
 
-  testWidgets('a drop takes the time of day from the target day, not the event', (tester) async {
+  testWidgets('a drop keeps the time of day of the event', (tester) async {
     // The schedule view has no time axis, so a drop carries only a date. The
-    // event lands at the start of the target day rather than keeping 09:00.
+    // event takes that date and keeps 09:00, the way the multi-day header does.
     CalendarEvent? changed;
     final id = addEvent(DateTime(2025, 6, 2, 9), const Duration(hours: 1));
     await pumpSchedule(tester, callbacks: CalendarCallbacks(onEventChanged: (_, updated) => changed = updated));
 
+    final original = eventsController.byId(id)!;
     final gesture = await dragDownBy(tester, find.byKey(ScheduleEventTile.tileKey(id)), 120);
     await gesture.up();
     await tester.pumpAndSettle();
 
-    expect(changed!.start.toLocal().hour, 0, reason: 'the event lands at the start of the target day');
+    final start = changed!.start.toLocal();
+    final originalStart = original.start.toLocal();
+    expect(start.hour, originalStart.hour, reason: 'the hour is kept');
+    expect(start.minute, originalStart.minute, reason: 'the minute is kept');
+    expect(start.isAfter(originalStart), isTrue, reason: 'the drag moved the event to a later day');
     expect(changed!.duration, equals(const Duration(hours: 1)), reason: 'the duration is kept');
   });
 


### PR DESCRIPTION
A drop in the schedule view took the time of day from the target day, so a 09:00 meeting dragged to another day landed at midnight. It now lands at 09:00 on the target day.

`ScheduleDragTarget.rescheduleEvent` built the new range from the cursor date directly, and the cursor in a schedule is a whole day. It now calls `rescheduleToDate`, the shared helper the multi-day header already used, which copies the hour, minute, second and sub-second parts off the event's own start. That is DST-correct, since it rebuilds the wall clock rather than adding a duration.

Its two branches collapsed into one. They differed only in reading the duration off the internal range rather than off the event, and the helper covers both.

The drag highlight is unchanged. It marks whole rows, so its range stays anchored to the target day.

The test that pinned the old behavior is rewritten to assert the time is kept. It asserts against the event's own start rather than a literal clock value, so it holds in all six CI timezones.