### PR TITLE
fix: the timeline labels are positioned by the segments above them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See [MIGRATION.md](MIGRATION.md#v027x--v0280) for what to change.
 
 ### Bug Fixes
 
+- The timeline labels are positioned by the segments above them rather than by a multiple of their own height. The last segment carries whatever is left of the `TimeOfDayRange`, so it is shorter than the rest unless the range divides evenly by the segment length, and its label was drawn near the top of the timeline. A range of 09:00 to 18:00 showed 18:00 above 10:00. The hour lines were already positioned this way and did not move. `TimeOfDayRange.allDay` divides evenly, which is why the default range was unaffected.
 - The free scroll band no longer draws a day past the end of its display range. It rounded the range end up to the next midnight whatever it was, so a range already ending at midnight gained a day, which includes the default range and any range written the usual way. A range ending part way through a day is unaffected.
 
 ### Behavior Changes

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -333,15 +333,18 @@ class TimeLine extends StatelessWidget with TimeLineUtils {
     final textXOffset = itemSize.height / 2;
     final segmentDuration = this.segmentDuration(timeOfDayRange, heightPerMinute, itemSize.height);
     final segments = timeOfDayRange.splitIntoSegments(segmentDuration);
+    // The last segment is shorter than the rest whenever the range does not
+    // divide evenly, so each label is placed after the segments before it rather
+    // than at a multiple of its own height.
+    var offset = 0.0;
     final positionedTimes = segments.indexed.map((e) {
       final (index, range) = e;
 
-      final height = range.duration.inMinutes * heightPerMinute;
-
-      final pos = index * height;
+      final pos = offset;
+      offset += range.duration.inMinutes * heightPerMinute;
 
       // Always skip the first item.
-      if (index == 0 || index == segments.length) return null;
+      if (index == 0) return null;
 
       // The time to display is the next hour.
       final displayTime = range.start;

--- a/test/widgets/timeline_label_position_test.dart
+++ b/test/widgets/timeline_label_position_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+/// Regression coverage for #472: the timeline labels are positioned by the
+/// segments before them, not by a multiple of their own height.
+///
+/// [TimeOfDayRange.splitIntoSegments] gives the last segment whatever is left of
+/// the range, so it is shorter than the rest unless the range divides evenly.
+/// [TimeOfDayRange.allDay] is one that does, which is why the default range was
+/// unaffected.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  tearDown(() {
+    eventsController.dispose();
+    calendarController.dispose();
+  });
+
+  Future<void> pumpDay(WidgetTester tester, TimeOfDayRange timeOfDayRange) {
+    return pumpAndSettleWithMaterialApp(
+      tester,
+      CalendarView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        viewConfiguration: MultiDayViewConfiguration.singleDay(
+          displayRange: year2025DisplayRange,
+          timeOfDayRange: timeOfDayRange,
+          initialTimeOfDay: timeOfDayRange.start,
+          initialDateTime: DateTime(2025),
+        ),
+        body: CalendarBody(
+          multiDayTileComponents: TileComponents(tileBuilder: (context, event, range) => const SizedBox()),
+        ),
+      ),
+    );
+  }
+
+  /// The vertical position of every timeline label, in the order it is drawn.
+  List<double> labelPositions(WidgetTester tester) {
+    final positions = <double>[];
+    for (var hour = 0; hour < TimeOfDay.hoursPerDay; hour++) {
+      for (var minute = 0; minute < TimeOfDay.minutesPerHour; minute += 5) {
+        final finder = find.byKey(TimeLine.getTimeKey(hour, minute));
+        if (finder.evaluate().isEmpty) continue;
+        positions.add(tester.getTopLeft(finder).dy);
+      }
+    }
+    return positions;
+  }
+
+  /// Asserts the labels run down the timeline in order, evenly spaced.
+  void expectEvenlySpaced(WidgetTester tester) {
+    final positions = labelPositions(tester);
+    expect(positions.length, greaterThan(2), reason: 'the range should show several labels');
+
+    final spacing = positions[1] - positions[0];
+    expect(spacing, greaterThan(0), reason: 'the labels run down the timeline');
+    for (var i = 1; i < positions.length; i++) {
+      expect(
+        positions[i] - positions[i - 1],
+        moreOrLessEquals(spacing, epsilon: 0.5),
+        reason: 'label $i sits one segment below the one before it',
+      );
+    }
+  }
+
+  testWidgets('the all day range labels are evenly spaced', (tester) async {
+    await pumpDay(tester, TimeOfDayRange.allDay());
+    expectEvenlySpaced(tester);
+  });
+
+  testWidgets('a range ending on a segment boundary labels its last segment in place', (tester) async {
+    // 09:00 to 18:00 leaves a one minute segment at the end, whose label used to
+    // land at the top of the timeline.
+    await pumpDay(
+      tester,
+      TimeOfDayRange(start: const TimeOfDay(hour: 9, minute: 0), end: const TimeOfDay(hour: 18, minute: 0)),
+    );
+    expectEvenlySpaced(tester);
+  });
+
+  testWidgets('a range ending part way through a segment labels its last segment in place', (tester) async {
+    // 09:00 to 17:30 leaves a 31 minute segment at the end, so it is affected
+    // without producing the one minute segment above.
+    await pumpDay(
+      tester,
+      TimeOfDayRange(start: const TimeOfDay(hour: 9, minute: 0), end: const TimeOfDay(hour: 17, minute: 30)),
+    );
+    expectEvenlySpaced(tester);
+  });
+
+  testWidgets('the labels line up with the hour lines', (tester) async {
+    final range = TimeOfDayRange(
+      start: const TimeOfDay(hour: 9, minute: 0),
+      end: const TimeOfDay(hour: 18, minute: 0),
+    );
+    await pumpDay(tester, range);
+
+    final content = tester.getRect(find.byType(HourLines));
+    final positions = labelPositions(tester);
+    final spacing = positions[1] - positions[0];
+
+    // The last label marks the end of the range, one segment below the one
+    // before it and within the drawn area.
+    expect(positions.last - positions[positions.length - 2], moreOrLessEquals(spacing, epsilon: 0.5));
+    expect(positions.last, lessThan(content.bottom));
+  });
+}


### PR DESCRIPTION
The timeline labels were placed at a multiple of their own segment height. `TimeOfDayRange.splitIntoSegments` gives the last segment whatever is left of the range, so it is shorter than the rest unless the range divides evenly by the segment length, and its label was drawn near the top of the timeline. A range of 09:00 to 18:00 showed 18:00 above 10:00.

Each label is now placed at the sum of the segment heights above it, which is what `HourLines` already did. That is why the grid lines stayed correct while the labels did not.

This is not limited to ranges ending on a segment boundary. 09:00 to 17:30 leaves a 31 minute segment at the end and drew 17:00 on top of 13:00. `TimeOfDayRange.allDay` divides evenly, so the default range does not move.

The `index == segments.length` clause is removed. `index` stops at `segments.length - 1`, so it could never be true.

Closes #472