### PR TITLE
docs: the gutter note lives in the appearance guide only

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,6 @@ The detailed guides live in [`doc/`](doc/README.md):
 - **[Layout](doc/layout.md).** Where tiles are placed and sized, and how overlapping events share a column. Only needed for a custom layout strategy, such as one lane per person.
 - **[Timezones & Locales](doc/timezones-and-locales.md).** Events stored as UTC and displayed in any IANA location, across daylight saving changes and midnight. Day and month names from intl in the calendar's locale, right-to-left layouts, and replacing any string.
 
-> [!NOTE]
-> `weekNumberStyle` and `timelineStyle` decide how wide the calendar's gutters are. Those gutters are drawn in the body and reserved again in the header, so the calendar measures them once above both, and a `KalenderTheme` placed inside only the header or only the body cannot change them. Set either one above the `CalendarView`, or on the `KalenderThemeData` registered on `ThemeData.extensions`. A scoped value the calendar has to ignore is reported in debug builds.
-
 ---
 
 ## Contributing


### PR DESCRIPTION
The readme and `doc/appearance.md` carried the same note about `weekNumberStyle` and `timelineStyle` being measured once above the header and the body. Both were added in the same commit as the fix they describe.

The guide keeps it. It sits under "How a style is resolved" and is framed as the exception to layer 2, which names what the exception is to. The readme copy sat between the guide list and the contributing heading with nothing around it about theming.

The behaviour is unchanged, and `debugCheckGutterStyleReaches` still reports a scoped value the calendar ignores.