### PR TITLE
feat: an example renders the calendar with intl4x

### DIFF
--- a/.github/workflows/analyze_examples.yml
+++ b/.github/workflows/analyze_examples.yml
@@ -30,6 +30,7 @@ jobs:
           - recurrence
           - riverpod
           - ics
+          - intl4x
           - web_demo
           - testing
     steps:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,17 +146,33 @@ What an app cannot reach comes to two things rather than ten: the drag or gestur
 
 **`FreeScrollFunctions` is removed, and removing it fixed a defect.** Its TODO asked whether `DayIndexCalculator` could replace it. The two were the same code but for one line, and that line rounded the end of the display range up to the next midnight even when it already fell on one, so a range already ending at midnight gained a day and the band drew a column outside it. Every other calculator guards that end with a conditional. The default range ends at midnight, as does any range written the usual way, so most free scroll calendars had it. `MultiDayViewConfiguration.type` is included in `==` and `hashCode` by the same change, since the calculator's runtime type was what told a free scroll configuration apart from a single day one.
 
+### 0.29.0, the state layer
+
+**The state layer becomes public, as one model rather than five widgets.** Composability's first piece, and the gate on [#215](https://github.com/werner-scholtz/kalender/issues/215), [#89](https://github.com/werner-scholtz/kalender/issues/89), [#262](https://github.com/werner-scholtz/kalender/issues/262), [#40](https://github.com/werner-scholtz/kalender/issues/40) and [#264](https://github.com/werner-scholtz/kalender/issues/264). The coverage gate it waited on is met.
+
+Today `calendar_provider.dart` holds five `InheritedWidget`s, `EventsControllerProvider`, `CalendarControllerProvider`, `LocaleProvider`, `LocationProvider` and `TileComponentProvider`. The classes are public but the file is not exported, so no app can name one, and `CalendarView.build` nests them in a fixed order.
+
+Exporting the five is the obvious move and is rejected. It makes the tree shape public, so apps come to depend on which provider sits where, on each one existing, and on inserting their own between them. That cannot be walked back after 1.0.0. `GutterStyles` is the standing example of the cost: it went public in 0.27.0 and now the guide and a debug report both exist to explain where it must sit.
+
+The shape is `MediaQuery`. It is an `InheritedModel` over a **private** aspect enum, and its public surface is about forty static accessors, `sizeOf`, `paddingOf`, `textScalerOf`, each with a `maybeXOf` twin. A widget reading the size does not rebuild when the padding changes. Kalender takes the same form: one widget over the five providers, a private aspect enum, and one accessor per value. The tree stays free to change, rebuilds stay narrow, and the granularity itself is not public, so aspects can be added or removed without a break.
+
+**`CalendarView.locale` becomes `Locale`.** It reaches intl's `DateFormat`, which takes a `String?`, so the `dynamic` lets a typo compile and fail at runtime. `Locale` is `dart:ui` rather than Material, it carries value equality, and an app holding `Localizations.localeOf(context)` has one already. `Intl.canonicalizedLocale` rewrites the separator, so `toLanguageTag`'s `en-US` and intl's `en_US` both resolve to the same data and no conversion rule is needed. intl's own `Locale` in `package:intl/locale.dart` is not used, since `DateFormat` does not accept it and it would put an intl type in the public API.
+
+Nine declarations carry the type. Three are public: the field, `CalendarLocale.calendarLocale` on `BuildContext`, and the optional parameter on the four `DateTimeExtensions` localized methods. It breaks anyone passing a `String`, and anyone assigning `calendarLocale` to a non-nullable `String`, since the implicit downcast a `dynamic` allowed becomes a compile error.
+
+**An intl4x example.** `examples/intl4x` supplies the six builders that answer with intl and renders the calendar through [intl4x](https://pub.dev/packages/intl4x) instead. Its test calls no `initializeDateFormatting`, so the default builders throw for `de` and the intl4x ones do not, which shows the substitution is complete rather than partial. Kalender keeps intl as its default, since a calendar with no localized names out of the box is a regression, and intl4x documents its API as still changing.
+
 ### The next breaking window
 
 Breaking changes with no release attached. The 0.28.0 entry above explains the batching: a break that lands on its own costs a migration entry and a minor version for one item, so these wait for the next release that already breaks.
 
-**`CalendarView.locale` is typed `dynamic`.** It reaches intl's `DateFormat`, which takes a `String?`, so the `dynamic` lets a typo or a wrong type compile and fail at runtime. intl typed this late: 0.20.2 still declared `DateFormat.EEEE([locale])` with no type and 0.20.3 declares `String? locale`. Kalender allows `>=0.19.0 <0.23.0`, which covers both, and a `String?` works against every version in that range.
+**The gutter styles contradict the rule the rest of the theme follows.** `weekNumberStyle` and `timelineStyle` size the gutters, which are drawn in the body and reserved again in the header, so the calendar resolves them once above both. A `KalenderTheme` scoped inside either half is ignored for those two fields and honoured for every other one. 0.27.0 taught that a builder resolves its styles from the nearest scope, and these are the two places where that is untrue. The debug report added with `GutterStyles` covers the case rather than removing it.
 
-Nine declarations carry the type. Three are public: the field, `CalendarLocale.calendarLocale` on `BuildContext`, and the optional parameter on the four `DateTimeExtensions` localized methods. The rest are `LocaleProvider` and its accessors.
+Flutter does not have this problem because it does not use an inherited widget when two siblings must agree on a measurement. `Table` takes `columnWidths` as a property and `CustomMultiChildLayout` computes in the parent. Every inherited widget Flutter ships honours the nearest scope.
 
-It breaks anyone passing something other than a `String`, and anyone assigning `calendarLocale` to a non-nullable `String`, since the implicit downcast a `dynamic` allowed becomes a compile error.
+The direction is to stop offering a setting where it cannot work: take the two fields out of `KalenderThemeData` and give them one home that only exists above the header and the body. The trap then cannot be expressed and the debug report, the guide note and the assert all go.
 
-One question comes first: `String?` or Flutter's `Locale`. `String?` is what intl takes and needs no conversion. `Locale` is the Flutter convention, but `toLanguageTag` produces `en-US` where intl's locale names use `en_US`, so it would need a stated conversion at the boundary.
+The cost is that gutter appearance leaves the theme extension, so an app theming through `ThemeData.extensions` has two places to look and the gutter no longer interpolates with the rest of the theme. That trade is not settled, so this has no release attached.
 
 ### Theming, still open
 

--- a/examples/intl4x/README.md
+++ b/examples/intl4x/README.md
@@ -1,0 +1,37 @@
+# intl4x
+
+Renders the calendar's localized strings with [intl4x](https://pub.dev/packages/intl4x) instead of
+intl.
+
+Kalender formats day names, month names and the overflow count with intl, and each of those has a
+builder. Supplying all of them replaces intl at runtime without the package knowing. `lib/main.dart`
+holds the six in `intl4xComponents`.
+
+`test/intl4x_replaces_intl_test.dart` shows the substitution is real rather than additive.
+`initializeDateFormatting` is never called, so intl throws for any locale other than `en_US`. The
+default builders throw for `de`. The intl4x builders render it.
+
+## What intl4x does not cover
+
+**Weekday names.** There is no weekday-only formatter. `DateTimeFormat.yearMonthDayWeekday` returns
+the whole date, `Mon, 1/6/25`, and `DisplayNames` covers languages, regions, scripts and currencies
+only. The day headers here use `MaterialLocalizations.narrowWeekdays` instead.
+
+**Month names default to numbers.** `DateTimeFormat.month` defaults to `DateTimeLength.short`, which
+formats January as `1`. `DateTimeLength.long` gives `January`.
+
+## Version
+
+Pinned to `1.0.0-alpha.2`. The stable releases `0.14.0` through `0.17.0` depend on `timezone ^0.10.1`
+while kalender depends on `timezone ^0.11.0`, so they cannot resolve together. The alpha moved to
+`timezone ^0.11.0`. intl4x also documents its API as still changing.
+
+## Testing
+
+intl4x returns a placeholder instead of formatting when it detects a test, unless the zone opts in:
+
+```dart
+runZoned(body, zoneValues: {#test.allowFormatting: true});
+```
+
+See `isInTest` in intl4x's `src/test_checker.dart`.

--- a/examples/intl4x/lib/main.dart
+++ b/examples/intl4x/lib/main.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:intl4x/datetime_format.dart' as intl4x;
+import 'package:intl4x/number_format.dart' as intl4x show NumberFormat;
+import 'package:kalender/kalender.dart';
+
+/// Renders a calendar whose every localized string comes from intl4x.
+///
+/// Kalender formats day names, month names and the overflow count with intl.
+/// Each of those has a builder, so supplying all six replaces intl at runtime
+/// without the package knowing. See [intl4xComponents].
+void main() => runApp(const IntlFourXApp());
+
+/// The locales offered by the picker.
+const _locales = [Locale('en'), Locale('de'), Locale('fr'), Locale('pt', 'BR'), Locale('ja')];
+
+/// Kalender passes locales as `dynamic`, so read it back and hand intl4x its own type.
+intl4x.Locale _localeOf(BuildContext context) {
+  final calendarLocale = context.calendarLocale;
+  return intl4x.Locale.parse(calendarLocale?.toString() ?? 'en');
+}
+
+/// intl4x has no weekday-only formatter. `DateTimeFormat.yearMonthDayWeekday`
+/// is the only route to a weekday and it returns the whole date, so the day
+/// names come from Flutter's own localizations instead.
+String _weekday(BuildContext context, DateTime date) {
+  final narrow = MaterialLocalizations.of(context).narrowWeekdays;
+  return narrow[date.weekday % DateTime.daysPerWeek];
+}
+
+String _month(BuildContext context, DateTime date) {
+  // The default length is short, which formats the month as a number.
+  return intl4x.DateTimeFormat.month(
+    locale: _localeOf(context),
+    length: intl4x.DateTimeLength.long,
+  ).format(date);
+}
+
+/// Every builder kalender would otherwise answer with intl.
+CalendarComponents intl4xComponents() {
+  return CalendarComponents(
+    overlayBuilders: OverlayBuilders(
+      multiDayPortalOverlayButtonStringBuilder: (context, hidden) {
+        return '+${intl4x.NumberFormat(locale: _localeOf(context)).format(hidden)}';
+      },
+    ),
+    multiDayComponents: const MultiDayComponents(
+      headerComponents: MultiDayHeaderComponents(dayHeaderStringBuilder: _weekday),
+    ),
+    monthComponents: const MonthComponents(
+      headerComponents: MonthHeaderComponents(weekDayHeaderStringBuilder: _weekday),
+    ),
+    scheduleComponents: ScheduleComponents(
+      leadingDateStringBuilder: _weekday,
+      monthItemBuilder: (context, monthRange) => ListTile(title: Text(_month(context, monthRange.start))),
+    ),
+  );
+}
+
+class IntlFourXApp extends StatefulWidget {
+  const IntlFourXApp({super.key});
+
+  @override
+  State<IntlFourXApp> createState() => _IntlFourXAppState();
+}
+
+class _IntlFourXAppState extends State<IntlFourXApp> {
+  final _eventsController = DefaultEventsController();
+  final _calendarController = CalendarController();
+  var _locale = _locales.first;
+
+  @override
+  void initState() {
+    super.initState();
+    final today = DateTime.now();
+    _eventsController.addEvents([
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(
+          start: DateTime(today.year, today.month, today.day, 9),
+          end: DateTime(today.year, today.month, today.day, 11),
+        ),
+      ),
+    ]);
+  }
+
+  @override
+  void dispose() {
+    _eventsController.dispose();
+    _calendarController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tiles = TileComponents(
+      tileBuilder: (context, event, tileRange) => Card(
+        margin: EdgeInsets.zero,
+        color: Theme.of(context).colorScheme.primaryContainer,
+        child: const SizedBox.expand(),
+      ),
+    );
+
+    return MaterialApp(
+      title: 'kalender with intl4x',
+      locale: _locale,
+      supportedLocales: _locales,
+      theme: ThemeData(colorSchemeSeed: Colors.teal, useMaterial3: true),
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Localized by intl4x'),
+          actions: [
+            DropdownButton<Locale>(
+              value: _locale,
+              onChanged: (value) => setState(() => _locale = value!),
+              items: [
+                for (final locale in _locales)
+                  DropdownMenuItem(value: locale, child: Text(locale.toLanguageTag())),
+              ],
+            ),
+            const SizedBox(width: 16),
+          ],
+        ),
+        body: CalendarView(
+          eventsController: _eventsController,
+          calendarController: _calendarController,
+          locale: _locale.toLanguageTag(),
+          components: intl4xComponents(),
+          viewConfiguration: MultiDayViewConfiguration.week(
+            displayRange: DateTimeRange(
+              start: DateTime.now().subtract(const Duration(days: 180)),
+              end: DateTime.now().add(const Duration(days: 180)),
+            ),
+          ),
+          header: CalendarHeader(multiDayTileComponents: tiles),
+          body: CalendarBody(multiDayTileComponents: tiles),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/intl4x/pubspec.yaml
+++ b/examples/intl4x/pubspec.yaml
@@ -1,0 +1,23 @@
+name: intl4x_example
+description: "Renders the calendar's day and month names with intl4x rather than intl."
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: ^3.6.1
+
+dependencies:
+  flutter:
+    sdk: flutter
+  kalender:
+    path: ../../../kalender/
+  # Pinned. The package documents its API as still changing.
+  intl4x: 1.0.0-alpha.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+
+flutter:
+  uses-material-design: true

--- a/examples/intl4x/test/intl4x_replaces_intl_test.dart
+++ b/examples/intl4x/test/intl4x_replaces_intl_test.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl4x_example/main.dart';
+import 'package:kalender/kalender.dart';
+
+/// Proves the builders replace intl rather than sitting alongside it.
+///
+/// `initializeDateFormatting()` is never called here. Without it intl throws for
+/// any locale other than `en_US`, so a calendar that renders in `de` is one
+/// whose day and month names did not come from intl.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+    // The schedule draws a month heading and a day row only where events exist.
+    eventsController.addEvent(
+      CalendarEvent(
+        dateTimeRange: DateTimeRange(start: DateTime(2025, 1, 6, 9), end: DateTime(2025, 1, 6, 10)),
+      ),
+    );
+  });
+
+  tearDown(() {
+    eventsController.dispose();
+    calendarController.dispose();
+  });
+
+  Widget schedule({CalendarComponents? components}) {
+    final tiles = ScheduleTileComponents(tileBuilder: (context, event, range) => const SizedBox());
+    return MaterialApp(
+      home: Scaffold(
+        body: CalendarView(
+          eventsController: eventsController,
+          calendarController: calendarController,
+          locale: 'de',
+          components: components,
+          viewConfiguration: ScheduleViewConfiguration.continuous(
+            displayRange: DateTimeRange(start: DateTime(2025), end: DateTime(2025, 3)),
+            initialDateTime: DateTime(2025),
+          ),
+          body: CalendarBody(scheduleTileComponents: tiles),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('the default builders need intl locale data', (tester) async {
+    await tester.pumpWidget(schedule());
+    await tester.pump();
+    expect(
+      tester.takeException(),
+      isNotNull,
+      reason: 'intl throws for "de" until initializeDateFormatting has run',
+    );
+  });
+
+  testWidgets('the intl4x builders render without it', (tester) async {
+    // intl4x returns a placeholder inside a test unless the zone opts in. See
+    // `isInTest` in its `test_checker.dart`.
+    await runZoned(
+      () async {
+        await tester.pumpWidget(schedule(components: intl4xComponents()));
+        await tester.pumpAndSettle();
+      },
+      zoneValues: {#test.allowFormatting: true},
+    );
+
+    expect(tester.takeException(), isNull, reason: 'nothing reached intl');
+    expect(find.text('Januar'), findsOneWidget, reason: 'the month heading came from intl4x');
+  });
+}


### PR DESCRIPTION
Kalender formats day names, month names and the overflow count with intl, at six call sites that each have a builder. `examples/intl4x` supplies all six and renders the calendar through intl4x instead.

The test shows the substitution is complete rather than partial. It never calls `initializeDateFormatting`, so intl throws for any locale but `en_US`. The default builders throw for `de`, the intl4x builders render it.

Three things the example documents, all found while building it:

intl4x `0.14.0` through `0.17.0` cannot resolve with kalender. They depend on `timezone ^0.10.1` where kalender depends on `^0.11.0`. Only the `1.0.0-alpha.2` prerelease moved to `^0.11.0`, so that is what the example pins.

intl4x has no weekday-only formatter. `DateTimeFormat.yearMonthDayWeekday` returns the whole date and `DisplayNames` covers languages, regions, scripts and currencies. The day headers use `MaterialLocalizations.narrowWeekdays`.

intl4x returns a placeholder instead of formatting when it detects a test, unless the zone sets `#test.allowFormatting`. That is only visible in its source.

Kalender keeps intl as its default. A calendar with no localized names out of the box is a regression, and intl4x documents its API as still changing.

Also adds the 0.29.0 roadmap section, covering the state layer as one `InheritedModel` on the `MediaQuery` pattern, `CalendarView.locale` becoming `Locale`, and this example. The gutter styles question moves to the holding section with no release attached.