### PR TITLE
refactor: CalendarView is renamed to KalenderView

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Kalender is a Flutter calendar widget package providing four views: **MultiDay** (day/week), **Month**, **Schedule**, and a generic **CalendarView** orchestrator. The library is pre-1.0 and actively developed.
+Kalender is a Flutter calendar widget package providing four views: **MultiDay** (day/week), **Month**, **Schedule**, and a generic **KalenderView** orchestrator. The library is pre-1.0 and actively developed.
 
 - **SDK constraints**: Dart `>=3.0.0 <4.0.0`, Flutter `>=3.22.0`
 - **Key dependencies**: `intl`, `timezone`, `collection`, `linked_pageview`, `scrollable_positioned_list`
@@ -26,7 +26,7 @@ Kalender is a Flutter calendar widget package providing four views: **MultiDay**
 | `lib/src/extensions/` | Internal DateTime/TimeOfDay utilities (DST-safe wall-clock arithmetic) |
 | `lib/src/calendar_body.dart` | Top-level body widget that delegates to the correct view |
 | `lib/src/calendar_header.dart` | Top-level header widget |
-| `lib/src/calendar_view.dart` | Main CalendarView orchestrator widget |
+| `lib/src/calendar_view.dart` | Main KalenderView orchestrator widget |
 | `test/` | Unit and widget tests (mirrors `lib/src/` structure) |
 | `test/utilities.dart` | Shared test helpers: `TestProvider`, `wrapWithMaterialApp`, `testWithTimeZones`, `WidgetTesterUtils` |
 | `doc/` | The user-facing guides, indexed by `doc/README.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See [MIGRATION.md](MIGRATION.md#v028x--v0290) for what to change.
 - The gutters share the width the calendar measured rather than the style it measured from, so a `KalenderTheme` scoped inside the header or the body restyles a gutter without resizing it.
 - The month week number column has a fixed width. It sized itself to the widest label it drew, so the column changed width as you paged and the day columns moved with it.
 
+### Deprecations
+
+- `CalendarView` is renamed to `KalenderView`, and `CalendarViewState` to `KalenderViewState`. The old names are typedefs to the new ones, so existing code compiles and builds the same widget, and will be removed in 0.30.0.
+
 ### Features
 
 - `KalenderScope` reads the state of the calendar a widget is built inside: `eventsControllerOf`, `calendarControllerOf`, `localeOf`, `locationOf`, `componentsOf`, `callbacksOf`, `interactionOf`, `snappingOf`, `tileComponentsOf`, `heightPerMinuteOf` and `multiDayRuleOf`, with `maybeOf` forms for the two controllers. Each accessor depends on one value, and every one returns the nearest, so a custom component in the header reads the header's interaction rather than the body's.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,7 +4,7 @@ Each section covers one upgrade. Versions not listed below need no changes.
 
 | Upgrade | What changes |
 | --- | --- |
-| [v0.28.x → v0.29.0](#v028x--v0290) | `GutterStyles` is removed and every style resolves from `KalenderTheme`. The gutters share a measured width instead, and the month week number column has a fixed one. |
+| [v0.28.x → v0.29.0](#v028x--v0290) | `CalendarView` is renamed to `KalenderView`, with the old name kept as a typedef. `GutterStyles` is removed and every style resolves from `KalenderTheme`. The gutters share a measured width instead, and the month week number column has a fixed one. |
 | [v0.27.x → v0.28.0](#v027x--v0280) | The free scroll band stops drawing a day past its display range. A schedule drop keeps the event's time of day. `FreeScrollFunctions` is removed. The tap callbacks drop their `RenderBox`. The `default*` constants take a `k` prefix. `WeekNumberStyle.visualDensity` becomes `buttonSize`. Two enums and typedefs are renamed. |
 | [v0.26.x → v0.27.0](#v026x--v0270) | Every builder takes a `BuildContext` and resolves its own styles. `TimeOfDayRange.isAllDay` is removed. |
 | [v0.25.x → v0.26.0](#v025x--v0260) | The deprecated style fields on `CalendarComponents` are removed, along with the containers reached through them. The three strategy fields become classes. `CalendarEvent.copyWith` becomes `copyWithData`. |
@@ -17,6 +17,21 @@ Each section covers one upgrade. Versions not listed below need no changes.
 | [v0.15.x → v0.16.0](#v015x--v0160) | `CalendarEvent` is no longer generic and event ids become `String`. |
 
 ## v0.28.x → v0.29.0
+
+### `CalendarView` is renamed to `KalenderView`
+
+Nothing breaks yet. `CalendarView` is a typedef to `KalenderView`, so it keeps
+compiling and keeps building the same widget, and it is removed in 0.30.0.
+
+```dart
+// Before
+CalendarView(...)
+
+// After
+KalenderView(...)
+```
+
+`CalendarViewState` becomes `KalenderViewState` the same way.
 
 ### The gutters share a width, not a style
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ class _MyCalendarState extends State<MyCalendar> {
 
   @override
   Widget build(BuildContext context) {
-    return CalendarView(
+    return KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: MultiDayViewConfiguration.week(

--- a/doc/appearance.md
+++ b/doc/appearance.md
@@ -276,7 +276,7 @@ KalenderTheme(
   data: const KalenderThemeData(
     hourLinesStyle: HourLinesStyle(thickness: 2),
   ),
-  child: CalendarView(
+  child: KalenderView(
     eventsController: DefaultEventsController(),
     calendarController: CalendarController(),
     viewConfiguration: MultiDayViewConfiguration.week(),
@@ -332,7 +332,7 @@ KalenderThemeData(
 
 ## Appearance / Custom Components
 
-Pass a `CalendarComponents` object to `CalendarView` to override the default widget builders.
+Pass a `CalendarComponents` object to `KalenderView` to override the default widget builders.
 
 > [!NOTE]
 > `CalendarComponents` carries builders only. Styles live on `KalenderThemeData`:

--- a/doc/controllers-and-callbacks.md
+++ b/doc/controllers-and-callbacks.md
@@ -32,7 +32,7 @@ Convert with `InternalDateTimeRange.fromDateTimeRange(range)`.
 
 ### CalendarController
 
-[`CalendarController`](https://pub.dev/documentation/kalender/latest/kalender/CalendarController-class.html) drives a single `CalendarView` widget.
+[`CalendarController`](https://pub.dev/documentation/kalender/latest/kalender/CalendarController-class.html) drives a single `KalenderView` widget.
 
 **State notifiers:**
 
@@ -163,7 +163,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
           ],
         ),
         Expanded(
-          child: CalendarView(
+          child: KalenderView(
             eventsController: eventsController,
             calendarController: calendarController,
             viewConfiguration: viewConfiguration,
@@ -187,7 +187,7 @@ The [basic example](../examples/example) has a fuller version of this toolbar.
 
 ## Callbacks
 
-Pass a `CalendarCallbacks` to `CalendarView` to react to user interactions.
+Pass a `CalendarCallbacks` to `KalenderView` to react to user interactions.
 
 <!-- snippet: expression -->
 ```dart

--- a/doc/events.md
+++ b/doc/events.md
@@ -111,7 +111,7 @@ TileComponents(
 
 Use `onEventCreate` to intercept the bare `CalendarEvent` created by a gesture and return a fully typed instance:
 
-Pass this as `CalendarView.callbacks`:
+Pass this as `KalenderView.callbacks`:
 
 <!-- snippet: expression -->
 ```dart

--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -120,4 +120,4 @@ class ZoomableCalendar extends StatelessWidget {
 }
 ```
 
-Wrap your `CalendarView` with this widget to enable Ctrl+scroll zooming.
+Wrap your `KalenderView` with this widget to enable Ctrl+scroll zooming.

--- a/doc/timezones-and-locales.md
+++ b/doc/timezones-and-locales.md
@@ -18,11 +18,11 @@ void main() async {
 
 The function comes from `date_symbol_data_local.dart`, not from `intl.dart`. The intl package compiles in the `en_US` data only, so every other locale needs this call, including `en`. Without it, kalender throws an error naming the locale that failed and the call to add.
 
-`CalendarView` has a `locale` property that controls day/month name formatting.
+`KalenderView` has a `locale` property that controls day/month name formatting.
 
 <!-- snippet: expression -->
 ```dart
-CalendarView(
+KalenderView(
   locale: 'af_ZA',
   eventsController: eventsController,
   calendarController: calendarController,
@@ -48,7 +48,7 @@ MaterialApp(
 )
 ```
 
-It can be set either way: on a single `CalendarView` through `CalendarComponents`, or
+It can be set either way: on a single `KalenderView` through `CalendarComponents`, or
 once for the whole app through [`KalenderThemeData`](appearance.md#theming).
 
 ### Custom text
@@ -62,7 +62,7 @@ the app's locale:
 ```dart
 import 'package:intl/intl.dart';
 
-CalendarView(
+KalenderView(
   locale: 'af_ZA',
   eventsController: eventsController,
   calendarController: calendarController,
@@ -103,13 +103,13 @@ MultiDayBodyComponents(
 
 ## Location
 
-`CalendarView` accepts a `Location` from the [timezone](https://pub.dev/packages/timezone) package. The `CalendarEvent` constructor automatically converts `dateTimeRange` values to UTC, so events are always stored in UTC internally and converted to the given location for display.
+`KalenderView` accepts a `Location` from the [timezone](https://pub.dev/packages/timezone) package. The `CalendarEvent` constructor automatically converts `dateTimeRange` values to UTC, so events are always stored in UTC internally and converted to the given location for display.
 
 <!-- snippet: expression -->
 ```dart
 import 'package:timezone/timezone.dart' as tz;
 
-CalendarView(
+KalenderView(
   location: tz.getLocation('America/New_York'),
   eventsController: eventsController,
   calendarController: calendarController,
@@ -155,7 +155,7 @@ When events come from an `.ics` file, a device calendar, or an API, map each sou
 
 - **Floating time** (no zone, common in `.ics`): decide which zone it should mean, usually the calendar's `location`, and build a `TZDateTime` there.
 
-Then set `CalendarView(location:)` to the zone the calendar should display in. The [ics example](../examples/ics) shows this end to end.
+Then set `KalenderView(location:)` to the zone the calendar should display in. The [ics example](../examples/ics) shows this end to end.
 
 ### Now Callback
 

--- a/doc/views.md
+++ b/doc/views.md
@@ -8,7 +8,7 @@ switch away from it. For what the user can do inside a view, see
 
 ## Switching between views
 
-Switch between views by passing a different `ViewConfiguration` to `CalendarView`. What carries over on a switch is controlled per dimension:
+Switch between views by passing a different `ViewConfiguration` to `KalenderView`. What carries over on a switch is controlled per dimension:
 
 - **Date** (all views): `dateTransition`. Use `DateTransition.carryFocus` (default, follows your current date) or `DateTransition.restorePerView` (each view reopens its own last date, matched by `name`).
 - **Scroll & zoom** (multi-day views): `scrollTransition` / `zoomTransition`. Use `preserve` (default), `reset`, or `restorePerView`.

--- a/example/README.md
+++ b/example/README.md
@@ -43,7 +43,7 @@ class _MyCalendarState extends State<MyCalendar> {
 
   @override
   Widget build(BuildContext context) {
-    return CalendarView(
+    return KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: MultiDayViewConfiguration.week(

--- a/examples/advanced_example/lib/main.dart
+++ b/examples/advanced_example/lib/main.dart
@@ -112,7 +112,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: CalendarView(
+      body: KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: _viewConfiguration,

--- a/examples/advanced_example/test/widget_test.dart
+++ b/examples/advanced_example/test/widget_test.dart
@@ -8,7 +8,7 @@ void main() {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
 
-    expect(find.byType(CalendarView), findsOneWidget);
+    expect(find.byType(KalenderView), findsOneWidget);
     expect(find.byType(PeopleWidget), findsOneWidget);
   });
 

--- a/examples/example/lib/main.dart
+++ b/examples/example/lib/main.dart
@@ -147,7 +147,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: CalendarView(
+      body: KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: viewConfiguration,

--- a/examples/example/test/widget_test.dart
+++ b/examples/example/test/widget_test.dart
@@ -8,7 +8,7 @@ void main() {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
 
-    expect(find.byType(CalendarView), findsOneWidget);
+    expect(find.byType(KalenderView), findsOneWidget);
     expect(find.byIcon(Icons.today), findsOneWidget);
   });
 

--- a/examples/ics/lib/main.dart
+++ b/examples/ics/lib/main.dart
@@ -133,7 +133,7 @@ class _HomePageState extends State<HomePage> {
           const SizedBox(width: 8),
         ],
       ),
-      body: CalendarView(
+      body: KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: viewConfiguration,

--- a/examples/ics/test/widget_test.dart
+++ b/examples/ics/test/widget_test.dart
@@ -119,6 +119,6 @@ void main() {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
 
-    expect(find.byType(CalendarView), findsOneWidget);
+    expect(find.byType(KalenderView), findsOneWidget);
   });
 }

--- a/examples/intl4x/lib/main.dart
+++ b/examples/intl4x/lib/main.dart
@@ -119,7 +119,7 @@ class _IntlFourXAppState extends State<IntlFourXApp> {
             const SizedBox(width: 16),
           ],
         ),
-        body: CalendarView(
+        body: KalenderView(
           eventsController: _eventsController,
           calendarController: _calendarController,
           locale: _locale.toLanguageTag(),

--- a/examples/intl4x/test/intl4x_replaces_intl_test.dart
+++ b/examples/intl4x/test/intl4x_replaces_intl_test.dart
@@ -34,7 +34,7 @@ void main() {
     final tiles = ScheduleTileComponents(tileBuilder: (context, event, range) => const SizedBox());
     return MaterialApp(
       home: Scaffold(
-        body: CalendarView(
+        body: KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           locale: 'de',

--- a/examples/recurrence/lib/main.dart
+++ b/examples/recurrence/lib/main.dart
@@ -60,7 +60,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: CalendarView(
+      body: KalenderView(
         eventsController: controller.controller,
         calendarController: calendarController,
         viewConfiguration: viewConfiguration,

--- a/examples/riverpod/lib/main.dart
+++ b/examples/riverpod/lib/main.dart
@@ -60,7 +60,7 @@ class HomeScreen extends ConsumerWidget {
     final selected = ref.watch(selectedViewProvider);
 
     return Scaffold(
-      body: CalendarView(
+      body: KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: selected,

--- a/examples/riverpod/test/widget_test.dart
+++ b/examples/riverpod/test/widget_test.dart
@@ -9,7 +9,7 @@ void main() {
     await tester.pumpWidget(const ProviderScope(child: MyApp()));
     await tester.pumpAndSettle();
 
-    expect(find.byType(CalendarView), findsOneWidget);
+    expect(find.byType(KalenderView), findsOneWidget);
     expect(find.byType(DropdownMenu<ViewConfiguration>), findsOneWidget);
   });
 

--- a/examples/testing/lib/main.dart
+++ b/examples/testing/lib/main.dart
@@ -44,7 +44,7 @@ class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: CalendarView(
+      body: KalenderView(
         eventsController: config.eventsController,
         calendarController: config.calendarController,
         viewConfiguration: config.viewConfiguration,

--- a/examples/web_demo/AGENTS.md
+++ b/examples/web_demo/AGENTS.md
@@ -45,7 +45,7 @@ flutter build web --release --wasm --base-href /kalender/
 
 ### UI composition
 
-- `lib/widgets/calendar/calendar.dart` is the main composition point for `CalendarView`, `CalendarHeader`, `CalendarBody`, overlay behavior, tile components, and the configuration panel.
+- `lib/widgets/calendar/calendar.dart` is the main composition point for `KalenderView`, `CalendarHeader`, `CalendarBody`, overlay behavior, tile components, and the configuration panel.
 - `lib/widgets/toolbar/` contains app-level controls such as theme, locale, text direction, warnings, and view type selection.
 - `lib/widgets/configuration/` contains the editors for runtime calendar customization.
 - `lib/widgets/calendar/` contains demo-specific calendar chrome and tile rendering; keep package internals in `kalender` and demo presentation concerns here.

--- a/examples/web_demo/README.md
+++ b/examples/web_demo/README.md
@@ -29,7 +29,7 @@ to `main` whose commit message contains `web demo`.
 ## Layout
 
 - `lib/main.dart` — bootstrap, app-wide theme/locale/direction, the shared events controller.
-- `lib/widgets/calendar/` — the `CalendarView` composition and demo tile/overlay chrome.
+- `lib/widgets/calendar/` — the `KalenderView` composition and demo tile/overlay chrome.
 - `lib/widgets/toolbar/` and `lib/widgets/configuration/` — the app controls and runtime editors.
 - `lib/l10n/` — the ARB translation files.
 

--- a/examples/web_demo/lib/widgets/calendar/calendar.dart
+++ b/examples/web_demo/lib/widgets/calendar/calendar.dart
@@ -61,7 +61,7 @@ class _CalendarContentState extends State<CalendarContent> {
                   ]),
                   builder: (context, _) => _scope(
                     context,
-                    CalendarView(
+                    KalenderView(
                       location: context.location.value,
                       locale: Localizations.localeOf(context).toLanguageTag(),
                       calendarController: context.controller,

--- a/examples/web_demo/test/widget_test.dart
+++ b/examples/web_demo/test/widget_test.dart
@@ -17,7 +17,7 @@ void main() {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
 
-    expect(find.byType(CalendarView), findsWidgets);
+    expect(find.byType(KalenderView), findsWidgets);
     expect(find.byType(ThemeButton), findsOneWidget);
     expect(find.byType(LocaleDropdown), findsOneWidget);
   });

--- a/lib/kalender.dart
+++ b/lib/kalender.dart
@@ -6,7 +6,7 @@ export 'package:kalender/src/calendar_body.dart';
 export 'package:kalender/src/calendar_header.dart';
 
 /// Widgets
-export 'package:kalender/src/calendar_view.dart';
+export 'package:kalender/src/kalender_view.dart';
 
 /// Enumerations
 export 'package:kalender/src/enumerations.dart';

--- a/lib/src/calendar_body.dart
+++ b/lib/src/calendar_body.dart
@@ -6,7 +6,7 @@ import 'package:kalender/src/models/providers/calendar_provider.dart';
 class CalendarBody extends StatefulWidget {
   /// The callbacks used by the [CalendarBody].
   ///
-  /// This provides a way to override the [CalendarCallbacks] passed to the [CalendarView].
+  /// This provides a way to override the [CalendarCallbacks] passed to the [KalenderView].
   final CalendarCallbacks? callbacks;
 
   /// The tile components used by the [MultiDayBody].

--- a/lib/src/calendar_header.dart
+++ b/lib/src/calendar_header.dart
@@ -5,7 +5,7 @@ import 'package:kalender/src/models/providers/calendar_provider.dart';
 class CalendarHeader extends StatefulWidget {
   /// The callbacks used by the [CalendarBody].
   ///
-  /// This provides a way to override the [CalendarCallbacks] passed to the [CalendarView].
+  /// This provides a way to override the [CalendarCallbacks] passed to the [KalenderView].
   final CalendarCallbacks? callbacks;
 
   /// MultiDay

--- a/lib/src/kalender_view.dart
+++ b/lib/src/kalender_view.dart
@@ -4,7 +4,7 @@ import 'package:kalender/src/layout_delegates/calendar_layout_delegate.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/models/providers/gutter_widths.dart';
 
-class CalendarView extends StatefulWidget {
+class KalenderView extends StatefulWidget {
   /// The [EventsController] that will be used to populate the events in the calendar view.
   final EventsController eventsController;
 
@@ -14,7 +14,7 @@ class CalendarView extends StatefulWidget {
   /// The [ViewConfiguration] that will be used to render the calendar view.
   final ViewConfiguration viewConfiguration;
 
-  /// The [CalendarCallbacks] used by the [CalendarView]
+  /// The [CalendarCallbacks] used by the [KalenderView]
   final CalendarCallbacks? callbacks;
 
   /// The components and styles used by the calendar.
@@ -44,11 +44,11 @@ class CalendarView extends StatefulWidget {
   /// If not provided, the default location will be used.
   final Location? location;
 
-  /// Creates a [CalendarView] widget.
+  /// Creates a [KalenderView] widget.
   ///
   /// This widget creates a [ViewController] based on the [viewConfiguration].
   /// It then attaches the [ViewController] to the [calendarController].
-  const CalendarView({
+  const KalenderView({
     super.key,
     required this.eventsController,
     required this.calendarController,
@@ -62,11 +62,11 @@ class CalendarView extends StatefulWidget {
   });
 
   @override
-  State<CalendarView> createState() => CalendarViewState();
+  State<KalenderView> createState() => KalenderViewState();
 }
 
-class CalendarViewState extends State<CalendarView> {
-  /// The [ViewController] that will be used by the children of the [CalendarView].
+class KalenderViewState extends State<KalenderView> {
+  /// The [ViewController] that will be used by the children of the [KalenderView].
   late ViewController _viewController;
 
   /// A snapshot of what each view last displayed, keyed by its configuration
@@ -95,7 +95,7 @@ class CalendarViewState extends State<CalendarView> {
   }
 
   @override
-  void didUpdateWidget(covariant CalendarView oldWidget) {
+  void didUpdateWidget(covariant KalenderView oldWidget) {
     super.didUpdateWidget(oldWidget);
 
     final didChangeLocale = _locale != widget.locale;
@@ -339,3 +339,14 @@ class CalendarViewState extends State<CalendarView> {
     );
   }
 }
+
+/// The previous name of [KalenderView].
+///
+/// `CalendarView(...)` still constructs a [KalenderView], since this is the same
+/// type under its old name.
+@Deprecated('Renamed to KalenderView. Will be removed in 0.30.0.')
+typedef CalendarView = KalenderView;
+
+/// The previous name of [KalenderViewState].
+@Deprecated('Renamed to KalenderViewState. Will be removed in 0.30.0.')
+typedef CalendarViewState = KalenderViewState;

--- a/lib/src/models/calendar_callbacks.dart
+++ b/lib/src/models/calendar_callbacks.dart
@@ -4,9 +4,9 @@ import 'package:kalender/src/models/calendar_events/draggable_event.dart';
 import 'package:kalender/src/widgets/drag_targets/horizontal_drag_target.dart';
 import 'package:kalender/src/widgets/drag_targets/vertical_drag_target.dart';
 
-/// The callbacks used by the [CalendarView].
+/// The callbacks used by the [KalenderView].
 ///
-/// - These callbacks are used to notify the parent widget of events that occur in the [CalendarView].
+/// - These callbacks are used to notify the parent widget of events that occur in the [KalenderView].
 class CalendarCallbacks {
   /// The callback for when an event is tapped.
   ///
@@ -107,7 +107,7 @@ class CalendarCallbacks {
   /// When overriding this please see [HorizontalDragTarget.onWillAcceptWithDetails] for default behavior.
   final OnWillAcceptWithDetailsHorizontal? onWillAcceptWithDetailsHorizontal;
 
-  /// Creates a set of callbacks for the [CalendarView].
+  /// Creates a set of callbacks for the [KalenderView].
   const CalendarCallbacks({
     this.onEventTapped,
     this.onEventTappedWithDetail,

--- a/lib/src/models/components/components.dart
+++ b/lib/src/models/components/components.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:kalender/src/calendar_view.dart';
+import 'package:kalender/src/kalender_view.dart';
 import 'package:kalender/src/models/components/month_components.dart';
 import 'package:kalender/src/models/components/multi_day_components.dart';
 import 'package:kalender/src/models/components/schedule_components.dart';
@@ -9,7 +9,7 @@ import 'package:kalender/src/widgets/components/multi_day_overlay.dart';
 import 'package:kalender/src/widgets/components/multi_day_overlay_portal.dart';
 import 'package:kalender/src/widgets/components/multi_day_overlay_portal_button.dart';
 
-/// A class holding the widget builders used by the [CalendarView].
+/// A class holding the widget builders used by the [KalenderView].
 ///
 /// Provide your own widgets with [multiDayComponents], [monthComponents] and
 /// [scheduleComponents]. Styling goes through [KalenderThemeData] for the whole

--- a/lib/src/models/components/string_builders.dart
+++ b/lib/src/models/components/string_builders.dart
@@ -22,7 +22,7 @@ typedef HiddenEventCountStringBuilder = String Function(BuildContext context, in
 
 /// Gives a string builder access to the locale of the calendar it is building for.
 extension CalendarLocale on BuildContext {
-  /// The locale of the enclosing calendar, as passed to `CalendarView.locale`.
+  /// The locale of the enclosing calendar, as passed to `KalenderView.locale`.
   ///
   /// This is the locale the calendar formats its own dates and times with, which
   /// is not necessarily the app's locale. Pass it to `intl`'s `DateFormat` or

--- a/lib/src/models/controllers/calendar_controller.dart
+++ b/lib/src/models/controllers/calendar_controller.dart
@@ -1,16 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:kalender/src/calendar_view.dart';
 import 'package:kalender/src/extensions/internal_date_time_range.dart';
-
+import 'package:kalender/src/kalender_view.dart';
 import 'package:kalender/src/models/calendar_events/calendar_event.dart';
 import 'package:kalender/src/models/controllers/view_controller.dart';
 import 'package:kalender/src/models/mixins/calendar_navigation_functions.dart';
 import 'package:kalender/src/models/mixins/new_event.dart';
 
-/// The [CalendarController] is used to controller a single [CalendarView].
-/// It provides some useful functions for navigating the [CalendarView].
+/// The [CalendarController] is used to controller a single [KalenderView].
+/// It provides some useful functions for navigating the [KalenderView].
 ///
-/// The [CalendarView] attaches itself to the [CalendarController] by calling [attach].
+/// The [KalenderView] attaches itself to the [CalendarController] by calling [attach].
 /// And detaches itself by calling [detach].
 ///
 class CalendarController extends ChangeNotifier with CalendarNavigationFunctions, NewEvent {

--- a/lib/src/models/mixins/event_tile_utils.dart
+++ b/lib/src/models/mixins/event_tile_utils.dart
@@ -37,7 +37,7 @@ mixin EventTileUtils {
 
 /// A mixin that provides useful utilities for day-based event tiles.
 ///
-/// This mixin is intended to be used with widgets that are descendants of a [CalendarView]
+/// This mixin is intended to be used with widgets that are descendants of a [KalenderView]
 /// specifically for widgets built by [TileComponents.tileBuilder] in a day-based view.
 ///
 /// Example usage:

--- a/lib/src/models/providers/calendar_provider.dart
+++ b/lib/src/models/providers/calendar_provider.dart
@@ -41,7 +41,7 @@ class EventsControllerProvider extends InheritedWidget {
   }
 }
 
-/// The [CalendarControllerProvider] is used to provide the [CalendarController] to the [CalendarView]'s descendants.
+/// The [CalendarControllerProvider] is used to provide the [CalendarController] to the [KalenderView]'s descendants.
 class CalendarControllerProvider extends InheritedNotifier<CalendarController> {
   const CalendarControllerProvider({super.key, required super.notifier, required super.child});
 

--- a/lib/src/models/providers/gutter_widths.dart
+++ b/lib/src/models/providers/gutter_widths.dart
@@ -5,7 +5,7 @@ import 'package:kalender/kalender.dart';
 ///
 /// The month week number column and the multi-day timeline are each drawn in the
 /// body and reserved again as a spacer in the header, so their day columns line
-/// up only while the two agree. [CalendarView] measures each once and publishes
+/// up only while the two agree. [KalenderView] measures each once and publishes
 /// the number here, which is what both halves read.
 ///
 /// Only the width is shared. Everything that paints a gutter resolves its style
@@ -27,7 +27,7 @@ class GutterWidths extends InheritedWidget {
 
   /// The [GutterWidths] above [context], or null when there is none.
   ///
-  /// Null where a component widget is built outside a [CalendarView], which the
+  /// Null where a component widget is built outside a [KalenderView], which the
   /// tests and the doc snippets do.
   static GutterWidths? maybeOf(BuildContext context) {
     return context.dependOnInheritedWidgetOfExactType<GutterWidths>();

--- a/lib/src/models/providers/kalender_scope.dart
+++ b/lib/src/models/providers/kalender_scope.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
-/// Reads the state of the [CalendarView] a widget is built inside.
+/// Reads the state of the [KalenderView] a widget is built inside.
 ///
 /// A custom component receives a [BuildContext] and reads what it needs from it,
 /// the way `MediaQuery.sizeOf` and `Theme.of` are read. Each accessor depends on
@@ -14,13 +14,13 @@ import 'package:kalender/src/models/providers/calendar_provider.dart';
 /// [tileComponentsOf] can differ between the header and the body, since
 /// [CalendarHeader] and [CalendarBody] each take their own.
 ///
-/// The `of` form throws where there is no [CalendarView] above the context. The
+/// The `of` form throws where there is no [KalenderView] above the context. The
 /// `maybeOf` form returns null there instead.
 abstract final class KalenderScope {
   /// The [EventsController] driving the calendar.
   static EventsController eventsControllerOf(BuildContext context) => EventsControllerProvider.of(context);
 
-  /// The [EventsController] driving the calendar, or null outside a [CalendarView].
+  /// The [EventsController] driving the calendar, or null outside a [KalenderView].
   static EventsController? maybeEventsControllerOf(BuildContext context) {
     return context.dependOnInheritedWidgetOfExactType<EventsControllerProvider>()?.eventsController;
   }
@@ -28,14 +28,14 @@ abstract final class KalenderScope {
   /// The [CalendarController] driving the calendar.
   static CalendarController calendarControllerOf(BuildContext context) => CalendarControllerProvider.of(context);
 
-  /// The [CalendarController] driving the calendar, or null outside a [CalendarView].
+  /// The [CalendarController] driving the calendar, or null outside a [KalenderView].
   static CalendarController? maybeCalendarControllerOf(BuildContext context) {
     return context.dependOnInheritedWidgetOfExactType<CalendarControllerProvider>()?.notifier;
   }
 
   /// The locale the calendar formats its own dates and times with.
   ///
-  /// This is `CalendarView.locale`, which is not necessarily the app's locale.
+  /// This is `KalenderView.locale`, which is not necessarily the app's locale.
   /// Pass it to intl's `DateFormat` or `NumberFormat`, or to the localized
   /// extensions on [DateTime].
   static dynamic localeOf(BuildContext context) => LocaleProvider.of(context);

--- a/lib/src/theme/kalender_theme.dart
+++ b/lib/src/theme/kalender_theme.dart
@@ -369,7 +369,7 @@ class KalenderThemeData extends ThemeExtension<KalenderThemeData> with Diagnosti
 /// ```dart
 /// KalenderTheme(
 ///   data: const KalenderThemeData(hourLinesStyle: HourLinesStyle(thickness: 2)),
-///   child: CalendarView(...),
+///   child: KalenderView(...),
 /// )
 /// ```
 ///

--- a/lib/src/widgets/internal_components/month_week_number_gutter.dart
+++ b/lib/src/widgets/internal_components/month_week_number_gutter.dart
@@ -18,7 +18,7 @@ WeekNumberStyle _resolveStyle(BuildContext context) {
 /// The width the calendar measured for the week number column.
 ///
 /// Falls back to measuring where there is no [GutterWidths], which is the case
-/// outside a [CalendarView].
+/// outside a [KalenderView].
 double _width(BuildContext context) {
   return GutterWidths.maybeOf(context)?.weekNumber ??
       context.components.monthComponents.bodyComponents.buildWeekNumberWidth(context);

--- a/lib/src/widgets/multi_day/multi_day_body.dart
+++ b/lib/src/widgets/multi_day/multi_day_body.dart
@@ -31,7 +31,7 @@ class MultiDayBody extends StatelessWidget {
   ///
   /// This widget is used to display events in a day/week view format.
   ///
-  /// This widget is intended to be the body of a [CalendarView].
+  /// This widget is intended to be the body of a [KalenderView].
   const MultiDayBody({
     super.key,
     this.configuration,

--- a/test/configuration/calendar_view_configuration_changes_test.dart
+++ b/test/configuration/calendar_view_configuration_changes_test.dart
@@ -18,7 +18,7 @@ void main() {
     calendarViewKey = GlobalKey();
   });
 
-  /// Helper to pump a CalendarView with the given config and optional body.
+  /// Helper to pump a KalenderView with the given config and optional body.
   Future<void> pumpCalendarView(
     WidgetTester tester, {
     required ViewConfiguration config,
@@ -26,7 +26,7 @@ void main() {
   }) async {
     await pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         key: calendarViewKey,
         eventsController: eventsController,
         calendarController: calendarController,
@@ -669,7 +669,7 @@ void main() {
       final reported = <TimeOfDay>[];
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           key: calendarViewKey,
           eventsController: eventsController,
           calendarController: calendarController,
@@ -686,7 +686,7 @@ void main() {
 
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           key: calendarViewKey,
           eventsController: eventsController,
           calendarController: calendarController,

--- a/test/configuration/view_configuration_multi_day_rule_test.dart
+++ b/test/configuration/view_configuration_multi_day_rule_test.dart
@@ -64,7 +64,7 @@ void main() {
     );
 
     Widget build(MultiDayViewConfiguration configuration) {
-      return CalendarView(
+      return KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: configuration,

--- a/test/configuration/view_configuration_test.dart
+++ b/test/configuration/view_configuration_test.dart
@@ -462,7 +462,7 @@ extension ViewControllerUtilities on WidgetTester {
   }) async {
     await pumpAndSettleWithMaterialApp(
       this,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: controller,
         viewConfiguration: viewConfiguration,

--- a/test/configuration/week_number_of_days_test.dart
+++ b/test/configuration/week_number_of_days_test.dart
@@ -110,7 +110,7 @@ void main() {
     Future<void> pumpWeek(WidgetTester tester, int numberOfDays) {
       return pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: DefaultEventsController(),
           calendarController: CalendarController(),
           viewConfiguration: MultiDayViewConfiguration.week(

--- a/test/interactions/calendar_callback_test.dart
+++ b/test/interactions/calendar_callback_test.dart
@@ -39,7 +39,7 @@ void main() {
   }) async {
     await pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.singleDay(
@@ -61,7 +61,7 @@ void main() {
   }) async {
     await pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -626,7 +626,7 @@ void main() {
   }) async {
     await pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.singleDay(
@@ -647,7 +647,7 @@ void main() {
   }) async {
     await pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MonthViewConfiguration.singleMonth(

--- a/test/interactions/drag_target_edge_cases_test.dart
+++ b/test/interactions/drag_target_edge_cases_test.dart
@@ -26,7 +26,7 @@ Future<dynamic> _pumpWeekView(
 }) async {
   await pumpAndSettleWithMaterialApp(
     tester,
-    CalendarView(
+    KalenderView(
       eventsController: eventsController ?? DefaultEventsController(),
       calendarController: CalendarController(),
       viewConfiguration: MultiDayViewConfiguration.week(
@@ -192,7 +192,7 @@ void main() {
   //    method reads viewController from the live controller)
   // ────────────────────────────────────────────────────────────────────────────
   group('VerticalDragTarget.onWillAcceptWithDetails', () {
-    CalendarView weekCalendarView(CalendarController controller) => CalendarView(
+    KalenderView weekCalendarView(CalendarController controller) => KalenderView(
           eventsController: DefaultEventsController(),
           calendarController: controller,
           viewConfiguration: MultiDayViewConfiguration.week(
@@ -269,7 +269,7 @@ void main() {
       final controller = CalendarController();
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: DefaultEventsController(),
           calendarController: controller,
           viewConfiguration: MultiDayViewConfiguration.week(
@@ -438,7 +438,7 @@ void main() {
     Future<void> pumpMonthView(WidgetTester tester) async {
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: DefaultEventsController(),
           calendarController: CalendarController(),
           viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -513,7 +513,7 @@ void main() {
     Future<dynamic> pumpMonthState(WidgetTester tester, {EventsController? ec}) async {
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: ec ?? DefaultEventsController(),
           calendarController: CalendarController(),
           viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -621,7 +621,7 @@ void main() {
 
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: ec,
           calendarController: controller,
           viewConfiguration: MultiDayViewConfiguration.week(
@@ -673,7 +673,7 @@ void main() {
 
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: ec,
           calendarController: controller,
           viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -725,7 +725,7 @@ void main() {
 
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: ec,
           calendarController: CalendarController(),
           viewConfiguration: ScheduleViewConfiguration.continuous(
@@ -742,7 +742,7 @@ void main() {
     testWidgets('paginated schedule view renders without exception', (tester) async {
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: DefaultEventsController(),
           calendarController: CalendarController(),
           viewConfiguration: ScheduleViewConfiguration.paginated(

--- a/test/interactions/interaction_test.dart
+++ b/test/interactions/interaction_test.dart
@@ -73,7 +73,7 @@ void main() {
 
   Future<void> pumpMultiDayView(WidgetTester tester) => pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: MultiDayViewConfiguration.singleDay(
@@ -88,7 +88,7 @@ void main() {
 
   Future<void> pumpMonthView(WidgetTester tester) => pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -102,7 +102,7 @@ void main() {
 
   Future<void> pumpScheduleView(WidgetTester tester) => pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: ScheduleViewConfiguration.continuous(displayRange: year2025DisplayRange),
@@ -113,7 +113,7 @@ void main() {
 
   Future<void> pumpImpreciseMultiDayView(WidgetTester tester) => pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: MultiDayViewConfiguration.singleDay(
@@ -128,7 +128,7 @@ void main() {
 
   Future<void> pumpImpreciseMonthView(WidgetTester tester) => pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -142,7 +142,7 @@ void main() {
 
   Future<void> pumpAutoMultiDayView(WidgetTester tester) => pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: MultiDayViewConfiguration.singleDay(

--- a/test/models/component_container_equality_test.dart
+++ b/test/models/component_container_equality_test.dart
@@ -111,7 +111,7 @@ void main() {
           home: StatefulBuilder(
             builder: (context, setState) {
               rebuild = setState;
-              return CalendarView(
+              return KalenderView(
                 eventsController: DefaultEventsController(),
                 calendarController: CalendarController(),
                 viewConfiguration: MultiDayViewConfiguration.week(),

--- a/test/models/kalender_scope_test.dart
+++ b/test/models/kalender_scope_test.dart
@@ -24,7 +24,7 @@ void main() {
     final tiles = TileComponents(tileBuilder: (context, event, range) => const SizedBox());
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         locale: 'de',
@@ -60,7 +60,7 @@ void main() {
     final tiles = TileComponents(tileBuilder: (context, event, range) => const SizedBox());
     await pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.singleDay(displayRange: year2025DisplayRange),

--- a/test/models/kalender_view_alias_test.dart
+++ b/test/models/kalender_view_alias_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+/// `CalendarView` is the previous name of [KalenderView], kept as a typedef so
+/// existing code keeps compiling and keeps building the same widget.
+void main() {
+  testWidgets('the old name builds the new widget', (tester) async {
+    final eventsController = DefaultEventsController();
+    final calendarController = CalendarController();
+    addTearDown(() {
+      eventsController.dispose();
+      calendarController.dispose();
+    });
+
+    // ignore: deprecated_member_use_from_same_package
+    final view = CalendarView(
+      eventsController: eventsController,
+      calendarController: calendarController,
+      viewConfiguration: MultiDayViewConfiguration.singleDay(displayRange: year2025DisplayRange),
+      body: CalendarBody(
+        multiDayTileComponents: TileComponents(tileBuilder: (context, event, range) => const SizedBox()),
+      ),
+    );
+
+    expect(view, isA<KalenderView>());
+    await pumpAndSettleWithMaterialApp(tester, view);
+    expect(find.byType(KalenderView), findsOneWidget);
+  });
+}

--- a/test/widgets/body_builder_context_test.dart
+++ b/test/widgets/body_builder_context_test.dart
@@ -22,7 +22,7 @@ void main() {
     CalendarComponents? components,
     KalenderThemeData? theme,
   }) async {
-    final view = CalendarView(
+    final view = KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: MultiDayViewConfiguration.week(

--- a/test/widgets/calendar_snapping_update_test.dart
+++ b/test/widgets/calendar_snapping_update_test.dart
@@ -20,7 +20,7 @@ void main() {
   });
 
   Widget buildCalendar(CalendarSnapping snapping) {
-    return CalendarView(
+    return KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: MultiDayViewConfiguration.week(

--- a/test/widgets/day_events_culling_test.dart
+++ b/test/widgets/day_events_culling_test.dart
@@ -8,7 +8,7 @@ import '../utilities.dart';
 // whose time band is within the visible scroll window (plus an overscan margin)
 // are built.
 //
-// These use a real CalendarView so the vertical scroll view is attached and the
+// These use a real KalenderView so the vertical scroll view is attached and the
 // culling actually runs. Without an attached scroll view the column falls back
 // to building every event, and neither behaviour below could be observed.
 void main() {
@@ -42,7 +42,7 @@ void main() {
     );
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.singleDay(

--- a/test/widgets/drag_move_coalescing_test.dart
+++ b/test/widgets/drag_move_coalescing_test.dart
@@ -33,7 +33,7 @@ void main() {
   Future<void> pumpCalendar(WidgetTester tester) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: viewConfiguration,

--- a/test/widgets/event_all_day_test.dart
+++ b/test/widgets/event_all_day_test.dart
@@ -35,7 +35,7 @@ void main() {
   Future<void> pumpWeek(WidgetTester tester, MultiDayRule rule, {CalendarCallbacks? callbacks}) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         callbacks: callbacks,
@@ -90,7 +90,7 @@ void main() {
     );
 
     final original = eventsController.byId(id)!;
-    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+    final dayWidth = tester.getSize(find.byType(KalenderView)).width / 7;
 
     final gesture = await tester.startGesture(tester.getCenter(find.byKey(MultiDayEventTile.tileKey(id))));
     await tester.pump(const Duration(milliseconds: 100));

--- a/test/widgets/frame_cache_text_direction_test.dart
+++ b/test/widgets/frame_cache_text_direction_test.dart
@@ -37,7 +37,7 @@ void main() {
   Widget build(TextDirection textDirection) {
     return Directionality(
       textDirection: textDirection,
-      child: CalendarView(
+      child: KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: configuration,

--- a/test/widgets/free_scroll_band_test.dart
+++ b/test/widgets/free_scroll_band_test.dart
@@ -28,7 +28,7 @@ void main() {
   Future<void> pumpFreeScroll(WidgetTester tester) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.freeScroll(
@@ -56,7 +56,7 @@ void main() {
     await pumpFreeScroll(tester);
 
     final tile = find.byKey(MultiDayEventTile.tileKey(id));
-    final calWidth = tester.getSize(find.byType(CalendarView)).width;
+    final calWidth = tester.getSize(find.byType(KalenderView)).width;
 
     expect(tile, findsOneWidget, reason: 'the multi-day event should be a single continuous tile');
     final tileWidth = tester.getSize(tile).width;
@@ -101,7 +101,7 @@ void main() {
 
     await pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.freeScroll(

--- a/test/widgets/free_scroll_cache_invalidation_test.dart
+++ b/test/widgets/free_scroll_cache_invalidation_test.dart
@@ -33,7 +33,7 @@ void main() {
   Future<void> pumpFreeScroll(WidgetTester tester) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.freeScroll(

--- a/test/widgets/free_scroll_header_test.dart
+++ b/test/widgets/free_scroll_header_test.dart
@@ -43,7 +43,7 @@ void main() {
     ]);
   }
 
-  Widget freeScrollView({DateTime? initialDate}) => CalendarView(
+  Widget freeScrollView({DateTime? initialDate}) => KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.freeScroll(

--- a/test/widgets/free_scroll_interaction_test.dart
+++ b/test/widgets/free_scroll_interaction_test.dart
@@ -35,7 +35,7 @@ void main() {
   Future<void> pumpFreeScroll(WidgetTester tester, CalendarCallbacks callbacks) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.freeScroll(
@@ -111,7 +111,7 @@ void main() {
     expect(changedAfter, isNull);
 
     // Drag the tile one day to the right.
-    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+    final dayWidth = tester.getSize(find.byType(KalenderView)).width / 7;
     await tester.drag(tile, Offset(dayWidth, 0));
     await tester.pumpAndSettle();
 

--- a/test/widgets/free_scroll_overflow_test.dart
+++ b/test/widgets/free_scroll_overflow_test.dart
@@ -27,7 +27,7 @@ void main() {
   Future<void> pumpFreeScroll(WidgetTester tester) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.freeScroll(

--- a/test/widgets/free_scroll_rtl_test.dart
+++ b/test/widgets/free_scroll_rtl_test.dart
@@ -28,7 +28,7 @@ void main() {
       tester,
       Directionality(
         textDirection: direction,
-        child: CalendarView(
+        child: KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: MultiDayViewConfiguration.freeScroll(
@@ -55,7 +55,7 @@ void main() {
 
     final tile = find.byKey(MultiDayEventTile.tileKey(id));
     expect(tile, findsOneWidget, reason: 'the multi-day event should be a single continuous tile in RTL');
-    final calWidth = tester.getSize(find.byType(CalendarView)).width;
+    final calWidth = tester.getSize(find.byType(KalenderView)).width;
     expect(tester.getSize(tile).width, greaterThan(calWidth * 0.22));
   });
 
@@ -67,7 +67,7 @@ void main() {
     final id = eventsController.addEvent(event);
 
     await pump(tester, TextDirection.ltr);
-    final calRect = tester.getRect(find.byType(CalendarView));
+    final calRect = tester.getRect(find.byType(KalenderView));
     final ltrCenter = tester.getCenter(find.byKey(MultiDayEventTile.tileKey(id)));
 
     // Rebuild fresh in RTL.

--- a/test/widgets/gutter_width_test.dart
+++ b/test/widgets/gutter_width_test.dart
@@ -7,7 +7,7 @@ import 'package:kalender/src/widgets/internal_components/timeline_sizer.dart';
 import '../utilities.dart';
 
 /// The month week number column and the multi-day timeline are each drawn in the
-/// body and reserved again in the header. [CalendarView] measures each once and
+/// body and reserved again in the header. [KalenderView] measures each once and
 /// publishes the number, so the two halves cannot be given different widths.
 ///
 /// Only the width is shared. A scoped [KalenderTheme] restyles what is drawn,
@@ -30,7 +30,7 @@ void main() {
 
   /// A calendar whose body is scoped to [bodyTheme] while the header is not.
   Widget splitTheme(ViewConfiguration configuration, KalenderThemeData bodyTheme) {
-    return CalendarView(
+    return KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: configuration,
@@ -40,7 +40,7 @@ void main() {
   }
 
   Widget plain(ViewConfiguration configuration, {KalenderThemeData? theme}) {
-    final view = CalendarView(
+    final view = KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: configuration,
@@ -79,7 +79,7 @@ void main() {
     testWidgets('a width builder above the calendar reaches both halves', (tester) async {
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: month(),
@@ -156,7 +156,7 @@ void main() {
       _timelineWidthCalls = 0;
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: week(),

--- a/test/widgets/header_month_builder_context_test.dart
+++ b/test/widgets/header_month_builder_context_test.dart
@@ -23,7 +23,7 @@ void main() {
     CalendarComponents? components,
     KalenderThemeData? theme,
   }) async {
-    final view = CalendarView(
+    final view = KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: viewConfiguration,

--- a/test/widgets/month_body_event_padding_test.dart
+++ b/test/widgets/month_body_event_padding_test.dart
@@ -44,7 +44,7 @@ void main() {
 
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: MonthViewConfiguration.singleMonth(

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -42,7 +42,7 @@ void main() {
       CalendarComponents? components,
       KalenderThemeData? theme,
     }) {
-      final view = CalendarView(
+      final view = KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -178,7 +178,7 @@ void main() {
     testWidgets('renders a month when the displayRange spans a single month', (tester) async {
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -350,7 +350,7 @@ void main() {
     // 0), which is the exact condition that used to produce the spurious buttons.
     //
     // Unlike the MultiDayEventLayoutWidget-level tests in
-    // test/layout/multi_day_event_layout_test.dart, these drive the full CalendarView
+    // test/layout/multi_day_event_layout_test.dart, these drive the full KalenderView
     // month path so MonthBody itself derives the max from the cell height.
     // ---------------------------------------------------------------------------
 
@@ -359,7 +359,7 @@ void main() {
 
     Future<void> pumpShortCellMonthView(WidgetTester tester, DateTime initialDateTime) => pumpAndSettleWithMaterialApp(
           tester,
-          CalendarView(
+          KalenderView(
             eventsController: eventsController,
             calendarController: calendarController,
             viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -415,14 +415,14 @@ void main() {
     //
     // The generics were removed in 0.16.0, so the crash is structurally impossible.
     // These tests lock that in at the exact layer the reporter hit: a custom
-    // strategy wired through MonthBodyConfiguration in a full CalendarView month
+    // strategy wired through MonthBodyConfiguration in a full KalenderView month
     // view.
     group('custom multiDayLayoutStrategy (#235)', () {
       late _RecordingStrategy strategy;
 
       Future<void> pumpWithCustomFrame(WidgetTester tester, DateTime initialDateTime) => pumpAndSettleWithMaterialApp(
             tester,
-            CalendarView(
+            KalenderView(
               eventsController: eventsController,
               calendarController: calendarController,
               viewConfiguration: MonthViewConfiguration.singleMonth(

--- a/test/widgets/month_event_focus_test.dart
+++ b/test/widgets/month_event_focus_test.dart
@@ -26,7 +26,7 @@ void main() {
 
     await pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MonthViewConfiguration.singleMonth(

--- a/test/widgets/month_rtl_overflow_test.dart
+++ b/test/widgets/month_rtl_overflow_test.dart
@@ -77,7 +77,7 @@ void main() {
         tester,
         Directionality(
           textDirection: textDirection,
-          child: CalendarView(
+          child: KalenderView(
             eventsController: eventsController,
             calendarController: CalendarController(),
             viewConfiguration: MonthViewConfiguration.singleMonth(

--- a/test/widgets/multi_day_body_test.dart
+++ b/test/widgets/multi_day_body_test.dart
@@ -89,7 +89,7 @@ void main() {
       ) =>
           pumpAndSettleWithMaterialApp(
             tester,
-            CalendarView(
+            KalenderView(
               eventsController: eventsController,
               calendarController: calendarController,
               viewConfiguration: viewConfiguration,
@@ -271,7 +271,7 @@ void main() {
       ) =>
           pumpAndSettleWithMaterialApp(
             tester,
-            CalendarView(
+            KalenderView(
               eventsController: eventsController,
               calendarController: calendarController,
               viewConfiguration: viewConfiguration,
@@ -365,7 +365,7 @@ void main() {
         testWidgets('Day Separator - ${viewConfiguration.name}', (tester) async {
           await pumpAndSettleWithMaterialApp(
             tester,
-            CalendarView(
+            KalenderView(
               eventsController: eventsController,
               calendarController: calendarController,
               viewConfiguration: viewConfiguration,

--- a/test/widgets/multi_day_drag_over_body_test.dart
+++ b/test/widgets/multi_day_drag_over_body_test.dart
@@ -37,7 +37,7 @@ void main() {
   Future<void> pumpWeek(WidgetTester tester, {CalendarCallbacks? callbacks}) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         callbacks: callbacks,
@@ -59,7 +59,7 @@ void main() {
     expect(tile, findsOneWidget, reason: 'the multi-day tile should render in the header');
 
     final originalStart = eventsController.byId(eventId)!.start;
-    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+    final dayWidth = tester.getSize(find.byType(KalenderView)).width / 7;
 
     // Pick the tile up, then move well below the header, into the body.
     final gesture = await tester.startGesture(tester.getCenter(tile));
@@ -87,7 +87,7 @@ void main() {
     await pumpWeek(tester);
 
     final original = eventsController.byId(eventId)!;
-    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+    final dayWidth = tester.getSize(find.byType(KalenderView)).width / 7;
 
     final gesture = await tester.startGesture(tester.getCenter(find.byKey(MultiDayEventTile.tileKey(eventId))));
     await tester.pump(const Duration(milliseconds: 100));
@@ -116,7 +116,7 @@ void main() {
     await pumpWeek(tester, callbacks: CalendarCallbacks(onEventChanged: (_, updated) => changed = updated));
 
     final originalStart = eventsController.byId(eventId)!.start;
-    final dayWidth = tester.getSize(find.byType(CalendarView)).width / 7;
+    final dayWidth = tester.getSize(find.byType(KalenderView)).width / 7;
 
     final gesture = await tester.startGesture(tester.getCenter(find.byKey(MultiDayEventTile.tileKey(eventId))));
     await tester.pump(const Duration(milliseconds: 100));

--- a/test/widgets/multi_day_rule_on_view_test.dart
+++ b/test/widgets/multi_day_rule_on_view_test.dart
@@ -39,7 +39,7 @@ void main() {
   Future<void> pumpWeek(WidgetTester tester, MultiDayRule rule) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.week(

--- a/test/widgets/overlay_portal_builder_test.dart
+++ b/test/widgets/overlay_portal_builder_test.dart
@@ -33,7 +33,7 @@ void main() {
     final calendarController = CalendarController();
     addTearDown(calendarController.dispose);
 
-    final view = CalendarView(
+    final view = KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -171,7 +171,7 @@ void main() {
       tester,
       KalenderTheme(
         data: const KalenderThemeData(multiDayOverlayStyle: MultiDayOverlayStyle(width: 321)),
-        child: CalendarView(
+        child: KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: MonthViewConfiguration.singleMonth(

--- a/test/widgets/overlay_style_precedence_test.dart
+++ b/test/widgets/overlay_style_precedence_test.dart
@@ -59,7 +59,7 @@ void main() {
     }) {
       // 29 Jan 2025 sits in the last row of a 5-row January.
       final eventsController = controllerWithOverflowOn(DateTime.utc(2025, 1, 29));
-      final view = CalendarView(
+      final view = KalenderView(
         eventsController: eventsController,
         calendarController: CalendarController(),
         viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -113,7 +113,7 @@ void main() {
       KalenderThemeData? theme,
     }) {
       final day = DateTime.utc(2025, 1, 15);
-      final view = CalendarView(
+      final view = KalenderView(
         eventsController: controllerWithOverflowOn(day),
         calendarController: CalendarController(),
         viewConfiguration: MultiDayViewConfiguration.week(

--- a/test/widgets/overlay_style_test.dart
+++ b/test/widgets/overlay_style_test.dart
@@ -33,7 +33,7 @@ void main() {
       );
     }
 
-    final view = CalendarView(
+    final view = KalenderView(
       eventsController: eventsController,
       calendarController: CalendarController(),
       viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -257,7 +257,7 @@ void main() {
       final text = tester.widget<Text>(
         find.descendant(of: find.byKey(MultiDayOverlay.getOverlayCardKey(day)), matching: find.text('15')),
       );
-      final expected = Theme.of(tester.element(find.byType(CalendarView))).textTheme.bodyMedium;
+      final expected = Theme.of(tester.element(find.byType(KalenderView))).textTheme.bodyMedium;
       expect(text.style, expected, reason: 'the M3 default should reach the date');
     });
 

--- a/test/widgets/overlay_test.dart
+++ b/test/widgets/overlay_test.dart
@@ -53,7 +53,7 @@ void main() {
 
         await pumpAndSettleWithMaterialApp(
           tester,
-          CalendarView(
+          KalenderView(
             eventsController: eventsController,
             calendarController: calendarController,
             viewConfiguration: viewConfiguration,
@@ -87,7 +87,7 @@ void main() {
 
           final topLeft = tester.getTopLeft(overlayCard);
           final bottomRight = tester.getBottomRight(overlayCard);
-          final calendarRect = tester.getRect(find.byType(CalendarView));
+          final calendarRect = tester.getRect(find.byType(KalenderView));
 
           expect(topLeft.dx >= calendarRect.left && topLeft.dy >= calendarRect.top, isTrue);
           expect(bottomRight.dx <= calendarRect.right && bottomRight.dy <= calendarRect.bottom, isTrue);
@@ -153,7 +153,7 @@ void main() {
 
       await pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: CalendarController(),
           viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -173,7 +173,7 @@ void main() {
       final card = find.byKey(MultiDayOverlay.getOverlayCardKey(day));
       expect(card, findsOne);
 
-      return (card: tester.getRect(card), view: tester.getRect(find.byType(CalendarView)));
+      return (card: tester.getRect(card), view: tester.getRect(find.byType(KalenderView)));
     }
 
     // January 2025 lays out as 5 rows (Mon 30 Dec - Sun 2 Feb), so the 29th

--- a/test/widgets/overlay_tile_builder_test.dart
+++ b/test/widgets/overlay_tile_builder_test.dart
@@ -28,7 +28,7 @@ void main() {
 
     await pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.week(),

--- a/test/widgets/page_boundary_test.dart
+++ b/test/widgets/page_boundary_test.dart
@@ -22,7 +22,7 @@ void main() {
   Future<void> pump(WidgetTester tester, ViewConfiguration config) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: config,

--- a/test/widgets/page_navigation_test.dart
+++ b/test/widgets/page_navigation_test.dart
@@ -29,7 +29,7 @@ void main() {
     Future<void> pump(WidgetTester tester, ViewConfiguration config) {
       return pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: config,

--- a/test/widgets/page_trigger_test.dart
+++ b/test/widgets/page_trigger_test.dart
@@ -37,7 +37,7 @@ void main() {
   Future<void> pumpWeek(WidgetTester tester) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.week(

--- a/test/widgets/resize_handle_finder_test.dart
+++ b/test/widgets/resize_handle_finder_test.dart
@@ -41,7 +41,7 @@ void main() {
   Future<void> pumpDay(WidgetTester tester) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.singleDay(

--- a/test/widgets/resize_handle_positioner_test.dart
+++ b/test/widgets/resize_handle_positioner_test.dart
@@ -39,7 +39,7 @@ void main() {
       tester,
       KalenderTheme(
         data: const KalenderThemeData(daySeparatorStyle: DaySeparatorStyle(color: Color(0xFF00FF00))),
-        child: CalendarView(
+        child: KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: MultiDayViewConfiguration.singleDay(

--- a/test/widgets/resize_handle_style_test.dart
+++ b/test/widgets/resize_handle_style_test.dart
@@ -31,7 +31,7 @@ void main() {
   });
 
   Future<void> pumpDay(WidgetTester tester, {ResizeHandleStyle? style, InputMode mode = InputMode.precise}) {
-    final view = CalendarView(
+    final view = KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: MultiDayViewConfiguration.singleDay(

--- a/test/widgets/schedule/schedule_body_test.dart
+++ b/test/widgets/schedule/schedule_body_test.dart
@@ -32,7 +32,7 @@ void main() {
         ),
       );
 
-  CalendarView buildSchedule({
+  KalenderView buildSchedule({
     EmptyDayBehavior emptyDay = EmptyDayBehavior.showOnlyToday,
     double leadingWidth = kDefaultScheduleLeadingWidth,
     NowCallback? nowCallback,
@@ -40,7 +40,7 @@ void main() {
     Location? location,
     CalendarComponents? components,
   }) {
-    return CalendarView(
+    return KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       location: location,

--- a/test/widgets/schedule/schedule_drag_target_test.dart
+++ b/test/widgets/schedule/schedule_drag_target_test.dart
@@ -40,7 +40,7 @@ void main() {
   }) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         callbacks: callbacks,
@@ -185,7 +185,7 @@ void main() {
       await pumpSchedule(tester);
 
       final before = firstVisibleIndex();
-      final size = tester.getSize(find.byType(CalendarView));
+      final size = tester.getSize(find.byType(KalenderView));
       final gesture = await holdAt(
         tester,
         find.byKey(ScheduleEventTile.tileKey(id)),
@@ -211,7 +211,7 @@ void main() {
       final gesture = await holdAt(
         tester,
         find.byKey(ScheduleEventTile.tileKey(id)),
-        Offset(tester.getSize(find.byType(CalendarView)).width / 2, 4),
+        Offset(tester.getSize(find.byType(KalenderView)).width / 2, 4),
       );
 
       expect(firstVisibleIndex(), lessThan(before), reason: 'the top edge should scroll the list back');

--- a/test/widgets/scroll_trigger_test.dart
+++ b/test/widgets/scroll_trigger_test.dart
@@ -37,7 +37,7 @@ void main() {
   Future<void> pumpWeek(WidgetTester tester, int hour) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.week(

--- a/test/widgets/string_builders_test.dart
+++ b/test/widgets/string_builders_test.dart
@@ -23,7 +23,7 @@ void main() {
   }) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController ?? DefaultEventsController(),
         calendarController: CalendarController(),
         viewConfiguration: viewConfiguration,
@@ -181,7 +181,7 @@ void main() {
         tester,
         Directionality(
           textDirection: textDirection,
-          child: CalendarView(
+          child: KalenderView(
             eventsController: controllerWithOverflowOn(day),
             calendarController: CalendarController(),
             viewConfiguration: MultiDayViewConfiguration.week(

--- a/test/widgets/time_indicator_calendar_view_test.dart
+++ b/test/widgets/time_indicator_calendar_view_test.dart
@@ -6,7 +6,7 @@ import 'package:kalender/src/widgets/internal_components/time_indicator_position
 import '../utilities.dart';
 
 /// End-to-end regression coverage for the time indicator inside a real
-/// [CalendarView], targeting the manifestations reported in
+/// [KalenderView], targeting the manifestations reported in
 /// https://github.com/werner-scholtz/kalender/issues/261 (a follow-up to the
 /// `isSameDay` timezone bug in #254):
 ///
@@ -15,7 +15,7 @@ import '../utilities.dart';
 ///   * the indicator not showing up at all on the correct day.
 ///
 /// The isolated positioner widgets are already covered elsewhere; these tests
-/// exercise the layer users actually hit — a full `CalendarView` + `CalendarBody`
+/// exercise the layer users actually hit — a full `KalenderView` + `CalendarBody`
 /// where the real `TimeIndicator` is positioned by `TimeIndicatorPositioner`.
 ///
 /// A `nowCallback` fixes "today" so the assertions are deterministic regardless
@@ -41,7 +41,7 @@ void main() {
   ) =>
       pumpAndSettleWithMaterialApp(
         tester,
-        CalendarView(
+        KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
           viewConfiguration: viewConfiguration,
@@ -49,7 +49,7 @@ void main() {
         ),
       );
 
-  group('TimeIndicator in CalendarView (#261)', () {
+  group('TimeIndicator in KalenderView (#261)', () {
     // For each weekday, "today" is fixed to that day at noon (well within the
     // default time-of-day range so the indicator is drawn). The indicator must
     // render exactly once and sit in that weekday's column — never on another.

--- a/test/widgets/timeline_alignment_test.dart
+++ b/test/widgets/timeline_alignment_test.dart
@@ -29,7 +29,7 @@ void main() {
     TextDirection textDirection = TextDirection.ltr,
     dynamic locale,
   }) async {
-    final view = CalendarView(
+    final view = KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: MultiDayViewConfiguration.week(

--- a/test/widgets/timeline_label_position_test.dart
+++ b/test/widgets/timeline_label_position_test.dart
@@ -28,7 +28,7 @@ void main() {
   Future<void> pumpDay(WidgetTester tester, TimeOfDayRange timeOfDayRange) {
     return pumpAndSettleWithMaterialApp(
       tester,
-      CalendarView(
+      KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
         viewConfiguration: MultiDayViewConfiguration.singleDay(

--- a/test/widgets/today_highlight_test.dart
+++ b/test/widgets/today_highlight_test.dart
@@ -7,7 +7,7 @@ import 'package:timezone/timezone.dart';
 import '../utilities.dart';
 
 /// End-to-end regression coverage for "today" highlighting in a real
-/// [CalendarView], targeting the timezone bug reported in:
+/// [KalenderView], targeting the timezone bug reported in:
 ///
 ///   * #254 — `isSameDay` produced wrong results for non-UTC timezones,
 ///   * #251 — wrong current-date highlighting (e.g. Dec 24 highlighted Dec 23),
@@ -16,7 +16,7 @@ import '../utilities.dart';
 ///
 /// The root cause was fixed by the `InternalDateTime` + `NowCallback` refactor in
 /// `0.18.0`. The isolated component checks live in `now_callback_is_today_test.dart`;
-/// these exercise the layer users actually hit — a full `CalendarView` — and are
+/// these exercise the layer users actually hit — a full `KalenderView` — and are
 /// run across the timezone matrix (`tool/test_timezones_linux.dart`) to cover the
 /// non-UTC / near-midnight condition that made the original bug visible.
 void main() {
@@ -33,7 +33,7 @@ void main() {
         matching: find.text('$day'),
       );
 
-  group('Today highlighting in CalendarView (#254 #248 #251)', () {
+  group('Today highlighting in KalenderView (#254 #248 #251)', () {
     // ── Month view ──────────────────────────────────────────────────────────
     group('MonthView', () {
       Future<void> pumpMonth(
@@ -43,7 +43,7 @@ void main() {
       }) =>
           pumpAndSettleWithMaterialApp(
             tester,
-            CalendarView(
+            KalenderView(
               eventsController: eventsController,
               calendarController: calendarController,
               viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -99,7 +99,7 @@ void main() {
         final received = <DateTime>[];
         await pumpAndSettleWithMaterialApp(
           tester,
-          CalendarView(
+          KalenderView(
             eventsController: eventsController,
             calendarController: calendarController,
             viewConfiguration: MonthViewConfiguration.singleMonth(
@@ -137,7 +137,7 @@ void main() {
 
         await pumpAndSettleWithMaterialApp(
           tester,
-          CalendarView(
+          KalenderView(
             eventsController: eventsController,
             calendarController: calendarController,
             location: newYork,
@@ -179,7 +179,7 @@ void main() {
       }) =>
           pumpAndSettleWithMaterialApp(
             tester,
-            CalendarView(
+            KalenderView(
               eventsController: eventsController,
               calendarController: calendarController,
               viewConfiguration: MultiDayViewConfiguration.week(

--- a/test/widgets/view_configuration_callbacks_test.dart
+++ b/test/widgets/view_configuration_callbacks_test.dart
@@ -27,7 +27,7 @@ void main() {
   });
 
   Widget build(ViewConfiguration configuration) {
-    return CalendarView(
+    return KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: configuration,

--- a/test/widgets/view_configuration_identity_test.dart
+++ b/test/widgets/view_configuration_identity_test.dart
@@ -47,7 +47,7 @@ void main() {
       );
 
   Widget build(ViewConfiguration configuration) {
-    return CalendarView(
+    return KalenderView(
       eventsController: eventsController,
       calendarController: calendarController,
       viewConfiguration: configuration,


### PR DESCRIPTION
Stacked on #489. The package is `kalender` and the widget an app places was `CalendarView`, which reads oddly next to `KalenderScope`.

Nothing breaks. `CalendarView` is a typedef to `KalenderView`, so existing code compiles unchanged and builds the same widget, and `is CalendarView` still holds because it is the same type. `CalendarViewState` becomes `KalenderViewState` the same way. Both old names are deprecated and go in 0.30.0.

The proof is that the whole suite passed on the alias before I renamed anything in the tests: 1650 tests still writing `CalendarView` against a package that no longer defines the class. `kalender_view_alias_test.dart` keeps one case exercising it deliberately.

The package, its tests, the guides and the examples all move to `KalenderView`, so the docs teach the current name. The web demo's own `CalendarScope` was renamed to `DemoScope` in #489, since it collided with the accessor.

`KalenderScope` is the accessor's final name, changed from `CalendarScope` in #489 for the same reason.