### PR TITLE
refactor!: the locale is a Locale rather than a dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ See [MIGRATION.md](MIGRATION.md#v028x--v0290) for what to change.
 ### Breaking Changes
 
 - `GutterStyles` and `GutterStyles.timelineStyleOf` are removed. Resolve every style, including `timelineStyle` and `weekNumberStyle`, with `KalenderTheme.of(context)`.
+- `KalenderView.locale`, `KalenderScope.localeOf`, `BuildContext.calendarLocale` and the four localized methods on `DateTimeExtensions` take a `Locale` rather than a `dynamic`.
 
 ### Behavior Changes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,7 +4,7 @@ Each section covers one upgrade. Versions not listed below need no changes.
 
 | Upgrade | What changes |
 | --- | --- |
-| [v0.28.x → v0.29.0](#v028x--v0290) | `CalendarView` is renamed to `KalenderView`, with the old name kept as a typedef. `GutterStyles` is removed and every style resolves from `KalenderTheme`. The gutters share a measured width instead, and the month week number column has a fixed one. |
+| [v0.28.x → v0.29.0](#v028x--v0290) | `CalendarView` is renamed to `KalenderView`, with the old name kept as a typedef. `locale` takes a `Locale`. `GutterStyles` is removed and every style resolves from `KalenderTheme`. The gutters share a measured width instead, and the month week number column has a fixed one. |
 | [v0.27.x → v0.28.0](#v027x--v0280) | The free scroll band stops drawing a day past its display range. A schedule drop keeps the event's time of day. `FreeScrollFunctions` is removed. The tap callbacks drop their `RenderBox`. The `default*` constants take a `k` prefix. `WeekNumberStyle.visualDensity` becomes `buttonSize`. Two enums and typedefs are renamed. |
 | [v0.26.x → v0.27.0](#v026x--v0270) | Every builder takes a `BuildContext` and resolves its own styles. `TimeOfDayRange.isAllDay` is removed. |
 | [v0.25.x → v0.26.0](#v025x--v0260) | The deprecated style fields on `CalendarComponents` are removed, along with the containers reached through them. The three strategy fields become classes. `CalendarEvent.copyWith` becomes `copyWithData`. |
@@ -32,6 +32,35 @@ KalenderView(...)
 ```
 
 `CalendarViewState` becomes `KalenderViewState` the same way.
+
+### `locale` takes a `Locale`
+
+`KalenderView.locale` was a `dynamic`, so a mistyped string compiled and failed at
+run time. It is a `Locale` now, along with `KalenderScope.localeOf`,
+`BuildContext.calendarLocale` and the four localized methods on
+`DateTimeExtensions`.
+
+```dart
+// Before
+KalenderView(locale: 'af_ZA', ...)
+
+// After
+KalenderView(locale: const Locale('af', 'ZA'), ...)
+```
+
+`Localizations.localeOf(context)` gives you the app's locale if the calendar
+should follow it.
+
+intl takes a string, so a string builder reading the calendar's locale passes
+`toLanguageTag()`:
+
+```dart
+// Before
+dayHeaderStringBuilder: (context, date) => DateFormat.E(context.calendarLocale).format(date),
+
+// After
+dayHeaderStringBuilder: (context, date) => DateFormat.E(context.calendarLocale?.toLanguageTag()).format(date),
+```
 
 ### The gutters share a width, not a style
 

--- a/doc/timezones-and-locales.md
+++ b/doc/timezones-and-locales.md
@@ -18,12 +18,12 @@ void main() async {
 
 The function comes from `date_symbol_data_local.dart`, not from `intl.dart`. The intl package compiles in the `en_US` data only, so every other locale needs this call, including `en`. Without it, kalender throws an error naming the locale that failed and the call to add.
 
-`KalenderView` has a `locale` property that controls day/month name formatting.
+`KalenderView` has a `locale` property that controls day/month name formatting. It takes a `Locale`, and `Localizations.localeOf(context)` gives you the app's.
 
 <!-- snippet: expression -->
 ```dart
 KalenderView(
-  locale: 'af_ZA',
+  locale: const Locale('af', 'ZA'),
   eventsController: eventsController,
   calendarController: calendarController,
   viewConfiguration: viewConfiguration,
@@ -56,21 +56,21 @@ once for the whole app through [`KalenderThemeData`](appearance.md#theming).
 Every string the calendar writes can be replaced with a string builder on the
 matching `*Components` class. Each one receives the `BuildContext`, so it can read
 the calendar's own locale with `context.calendarLocale`, which is not necessarily
-the app's locale:
+the app's locale. intl takes a string, so pass `toLanguageTag()`:
 
 <!-- snippet: expression -->
 ```dart
 import 'package:intl/intl.dart';
 
 KalenderView(
-  locale: 'af_ZA',
+  locale: const Locale('af', 'ZA'),
   eventsController: eventsController,
   calendarController: calendarController,
   viewConfiguration: viewConfiguration,
   components: CalendarComponents(
     multiDayComponents: MultiDayComponents(
       headerComponents: MultiDayHeaderComponents(
-        dayHeaderStringBuilder: (context, date) => DateFormat.E(context.calendarLocale).format(date),
+        dayHeaderStringBuilder: (context, date) => DateFormat.E(context.calendarLocale?.toLanguageTag()).format(date),
       ),
     ),
     overlayBuilders: OverlayBuilders(

--- a/examples/intl4x/lib/main.dart
+++ b/examples/intl4x/lib/main.dart
@@ -122,7 +122,7 @@ class _IntlFourXAppState extends State<IntlFourXApp> {
         body: KalenderView(
           eventsController: _eventsController,
           calendarController: _calendarController,
-          locale: _locale.toLanguageTag(),
+          locale: _locale,
           components: intl4xComponents(),
           viewConfiguration: MultiDayViewConfiguration.week(
             displayRange: DateTimeRange(

--- a/examples/intl4x/test/intl4x_replaces_intl_test.dart
+++ b/examples/intl4x/test/intl4x_replaces_intl_test.dart
@@ -37,7 +37,7 @@ void main() {
         body: KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,
-          locale: 'de',
+          locale: const Locale('de'),
           components: components,
           viewConfiguration: ScheduleViewConfiguration.continuous(
             displayRange: DateTimeRange(start: DateTime(2025), end: DateTime(2025, 3)),

--- a/examples/web_demo/lib/widgets/calendar/calendar.dart
+++ b/examples/web_demo/lib/widgets/calendar/calendar.dart
@@ -63,7 +63,7 @@ class _CalendarContentState extends State<CalendarContent> {
                     context,
                     KalenderView(
                       location: context.location.value,
-                      locale: Localizations.localeOf(context).toLanguageTag(),
+                      locale: Localizations.localeOf(context),
                       calendarController: context.controller,
                       eventsController: context.eventsController,
                       viewConfiguration: context.configuration.viewConfiguration,

--- a/examples/web_demo/lib/widgets/calendar/navigation_header.dart
+++ b/examples/web_demo/lib/widgets/calendar/navigation_header.dart
@@ -252,10 +252,10 @@ class HeaderDateButton extends StatelessWidget {
         if (controller.viewController is MonthViewController) {
           final secondWeek = value.start.copyWith(day: value.start.day + 7);
           year = secondWeek.year;
-          month = secondWeek.monthNameLocalized(context.localeTag);
+          month = secondWeek.monthNameLocalized(Localizations.localeOf(context));
         } else {
           year = value.start.year;
-          month = value.start.monthNameLocalized(context.localeTag);
+          month = value.start.monthNameLocalized(Localizations.localeOf(context));
         }
 
         final button = FilledButton.tonal(

--- a/examples/web_demo/lib/widgets/configuration/editor_widgets.dart
+++ b/examples/web_demo/lib/widgets/configuration/editor_widgets.dart
@@ -52,7 +52,7 @@ class FirstDayOfWeekEditor extends StatelessWidget {
       value: firstDayOfWeek,
       items: const [1, 2, 3, 4, 5, 6, 7],
       onChanged: (value) => onChanged(value),
-      itemToString: (value) => DateTime(2024, 1, value).dayNameLocalized(context.localeTag),
+      itemToString: (value) => DateTime(2024, 1, value).dayNameLocalized(Localizations.localeOf(context)),
     );
   }
 }

--- a/lib/src/extensions/date_time.dart
+++ b/lib/src/extensions/date_time.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 
@@ -6,7 +8,7 @@ import 'package:intl/intl.dart';
 ///
 /// The format is built inside the guard because intl resolves its locale data lazily, so either the construction or
 /// the format call can fail.
-String _formatLocalized(DateFormat Function() format, DateTime date, dynamic locale) {
+String _formatLocalized(DateFormat Function() format, DateTime date, Locale? locale) {
   try {
     return format().format(date);
   } catch (error) {
@@ -47,40 +49,44 @@ extension DateTimeExtensions on DateTime {
   /// Example:
   /// ```dart
   /// final date = DateTime(2024, 1, 15); // Monday
-  /// print(date.dayNameLocalized('en')); // Output: "Monday"
-  /// print(date.dayNameLocalized('fr')); // Output: "lundi"
-  /// print(date.dayNameLocalized('es')); // Output: "lunes"
+  /// print(date.dayNameLocalized(const Locale('en'))); // Output: "Monday"
+  /// print(date.dayNameLocalized(const Locale('fr'))); // Output: "lundi"
+  /// print(date.dayNameLocalized(const Locale('es'))); // Output: "lunes"
   /// ```
-  String dayNameLocalized([dynamic locale]) => _formatLocalized(() => DateFormat.EEEE(locale), this, locale);
+  String dayNameLocalized([Locale? locale]) =>
+      _formatLocalized(() => DateFormat.EEEE(locale?.toLanguageTag()), this, locale);
 
   /// Gets the abbreviated day name in a specific locale.
   ///
   /// Example:
   /// ```dart
   /// final date = DateTime(2024, 1, 15); // Monday
-  /// print(date.dayNameShortLocalized('en')); // Output: "Mon"
-  /// print(date.dayNameShortLocalized('fr')); // Output: "lun"
+  /// print(date.dayNameShortLocalized(const Locale('en'))); // Output: "Mon"
+  /// print(date.dayNameShortLocalized(const Locale('fr'))); // Output: "lun"
   /// ```
-  String dayNameShortLocalized([dynamic locale]) => _formatLocalized(() => DateFormat.E(locale), this, locale);
+  String dayNameShortLocalized([Locale? locale]) =>
+      _formatLocalized(() => DateFormat.E(locale?.toLanguageTag()), this, locale);
 
   /// Gets the month name in a specific locale.
   ///
   /// Example:
   /// ```dart
   /// final date = DateTime(2024, 1, 15); // January
-  /// print(date.monthNameLocalized('en')); // Output: "January"
-  /// print(date.monthNameLocalized('fr')); // Output: "janvier"
-  /// print(date.monthNameLocalized('es')); // Output: "enero"
+  /// print(date.monthNameLocalized(const Locale('en'))); // Output: "January"
+  /// print(date.monthNameLocalized(const Locale('fr'))); // Output: "janvier"
+  /// print(date.monthNameLocalized(const Locale('es'))); // Output: "enero"
   /// ```
-  String monthNameLocalized([dynamic locale]) => _formatLocalized(() => DateFormat.MMMM(locale), this, locale);
+  String monthNameLocalized([Locale? locale]) =>
+      _formatLocalized(() => DateFormat.MMMM(locale?.toLanguageTag()), this, locale);
 
   /// Gets the abbreviated month name in a specific locale.
   ///
   /// Example:
   /// ```dart
   /// final date = DateTime(2024, 1, 15); // January
-  /// print(date.monthNameShortLocalized('en')); // Output: "Jan"
-  /// print(date.monthNameShortLocalized('fr')); // Output: "janv."
+  /// print(date.monthNameShortLocalized(const Locale('en'))); // Output: "Jan"
+  /// print(date.monthNameShortLocalized(const Locale('fr'))); // Output: "janv."
   /// ```
-  String monthNameShortLocalized([dynamic locale]) => _formatLocalized(() => DateFormat.MMM(locale), this, locale);
+  String monthNameShortLocalized([Locale? locale]) =>
+      _formatLocalized(() => DateFormat.MMM(locale?.toLanguageTag()), this, locale);
 }

--- a/lib/src/kalender_view.dart
+++ b/lib/src/kalender_view.dart
@@ -34,10 +34,10 @@ class KalenderView extends StatefulWidget {
   /// The body widget that will be displayed below the header.
   final Widget? body;
 
-  /// The locale used for internationalization ex. `en_US`, `de_DE`, etc.
+  /// The locale used for internationalization, for example `const Locale('en', 'US')`.
   ///
-  /// If not provided, a default locale be used.
-  final dynamic locale;
+  /// If not provided, intl's default locale is used.
+  final Locale? locale;
 
   /// The location of the calendar view. (from the timezone package)
   ///
@@ -78,7 +78,7 @@ class KalenderViewState extends State<KalenderView> {
   final Map<String, ViewSnapshot> _viewHistory = {};
   ViewSnapshot? _lastMultiDaySnapshot;
   // TODO: update this to be a valueNotifier.
-  late dynamic _locale = widget.locale;
+  late Locale? _locale = widget.locale;
   late final _location = ValueNotifier<Location?>(widget.location);
 
   @override

--- a/lib/src/models/components/string_builders.dart
+++ b/lib/src/models/components/string_builders.dart
@@ -27,5 +27,5 @@ extension CalendarLocale on BuildContext {
   /// This is the locale the calendar formats its own dates and times with, which
   /// is not necessarily the app's locale. Pass it to `intl`'s `DateFormat` or
   /// `NumberFormat`, or to the localized extensions on [DateTime].
-  dynamic get calendarLocale => LocaleProvider.of(this);
+  Locale? get calendarLocale => LocaleProvider.of(this);
 }

--- a/lib/src/models/providers/calendar_provider.dart
+++ b/lib/src/models/providers/calendar_provider.dart
@@ -57,13 +57,13 @@ class CalendarControllerProvider extends InheritedNotifier<CalendarController> {
 /// It does not have a type parameter so it can be used globally without type constraints.
 class LocaleProvider extends InheritedWidget {
   /// The locale used for internationalization.
-  final dynamic locale;
+  final Locale? locale;
 
   /// Creates a [LocaleProvider] with the specified locale.
   const LocaleProvider({super.key, required this.locale, required super.child});
 
   /// Gets the [LocaleProvider] from the context.
-  static dynamic of(BuildContext context) {
+  static Locale? of(BuildContext context) {
     final result = context.dependOnInheritedWidgetOfExactType<LocaleProvider>();
     assert(result != null, 'No LocaleProvider found.');
     return result!.locale;
@@ -201,7 +201,7 @@ extension ProviderContext on BuildContext {
   ValueNotifier<Size> get feedbackWidgetSizeNotifier => eventsController.feedbackWidgetSize;
 
   /// Retrieve the locale.
-  dynamic get locale => LocaleProvider.of(this);
+  Locale? get locale => LocaleProvider.of(this);
 
   /// Retrieve the [CalendarInteraction].
   CalendarInteraction get interaction => Interaction.of(this);

--- a/lib/src/models/providers/kalender_scope.dart
+++ b/lib/src/models/providers/kalender_scope.dart
@@ -38,7 +38,7 @@ abstract final class KalenderScope {
   /// This is `KalenderView.locale`, which is not necessarily the app's locale.
   /// Pass it to intl's `DateFormat` or `NumberFormat`, or to the localized
   /// extensions on [DateTime].
-  static dynamic localeOf(BuildContext context) => LocaleProvider.of(context);
+  static Locale? localeOf(BuildContext context) => LocaleProvider.of(context);
 
   /// The IANA location the calendar displays its events in, or null when it has none.
   static Location? locationOf(BuildContext context) => LocationProvider.of(context);

--- a/lib/src/widgets/components/multi_day_overlay_portal_button.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal_button.dart
@@ -112,7 +112,7 @@ class MultiDayPortalOverlayButton extends StatelessWidget {
   /// The default label: a plus sign and the count, with the number formatted for
   /// the calendar's locale so locales with their own numerals read correctly.
   static String defaultLabel(BuildContext context, int numberOfHiddenRows) {
-    return '+${NumberFormat.decimalPattern(context.locale).format(numberOfHiddenRows)}';
+    return '+${NumberFormat.decimalPattern(context.locale?.toLanguageTag()).format(numberOfHiddenRows)}';
   }
 
   /// Returns a [Key] for the button based on the date.

--- a/test/extensions/date_time_i18n_extensions_test.dart
+++ b/test/extensions/date_time_i18n_extensions_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:kalender/src/extensions/date_time.dart';
@@ -14,41 +16,41 @@ void main() {
     });
 
     test('dayNameLocalized with English locale', () {
-      expect(testDate.dayNameLocalized('en'), equals('Monday'));
+      expect(testDate.dayNameLocalized(const Locale('en')), equals('Monday'));
     });
 
     test('dayNameLocalized with French locale', () {
-      expect(testDate.dayNameLocalized('fr'), equals('lundi'));
+      expect(testDate.dayNameLocalized(const Locale('fr')), equals('lundi'));
     });
 
     test('dayNameShortLocalized with English locale', () {
-      expect(testDate.dayNameShortLocalized('en'), equals('Mon'));
+      expect(testDate.dayNameShortLocalized(const Locale('en')), equals('Mon'));
     });
 
     test('monthNameLocalized with English locale', () {
-      expect(testDate.monthNameLocalized('en'), equals('January'));
+      expect(testDate.monthNameLocalized(const Locale('en')), equals('January'));
     });
 
     test('monthNameLocalized with French locale', () {
-      expect(testDate.monthNameLocalized('fr'), equals('janvier'));
+      expect(testDate.monthNameLocalized(const Locale('fr')), equals('janvier'));
     });
 
     test('monthNameShortLocalized with English locale', () {
-      expect(testDate.monthNameShortLocalized('en'), equals('Jan'));
+      expect(testDate.monthNameShortLocalized(const Locale('en')), equals('Jan'));
     });
 
     test('different weekdays in different locales', () {
       final tuesday = DateTime(2024, 1, 16); // Tuesday
-      expect(tuesday.dayNameLocalized('en'), equals('Tuesday'));
-      expect(tuesday.dayNameLocalized('fr'), equals('mardi'));
-      expect(tuesday.dayNameLocalized('es'), equals('martes'));
+      expect(tuesday.dayNameLocalized(const Locale('en')), equals('Tuesday'));
+      expect(tuesday.dayNameLocalized(const Locale('fr')), equals('mardi'));
+      expect(tuesday.dayNameLocalized(const Locale('es')), equals('martes'));
     });
 
     test('different months in different locales', () {
       final february = DateTime(2024, 2, 15); // February
-      expect(february.monthNameLocalized('en'), equals('February'));
-      expect(february.monthNameLocalized('fr'), equals('février'));
-      expect(february.monthNameLocalized('es'), equals('febrero'));
+      expect(february.monthNameLocalized(const Locale('en')), equals('February'));
+      expect(february.monthNameLocalized(const Locale('fr')), equals('février'));
+      expect(february.monthNameLocalized(const Locale('es')), equals('febrero'));
     });
 
     test('monthNameLocalized covers every month in English', () {
@@ -67,7 +69,7 @@ void main() {
         'December',
       ];
       for (var month = 1; month <= 12; month++) {
-        expect(DateTime(2024, month, 15).monthNameLocalized('en'), equals(expected[month - 1]));
+        expect(DateTime(2024, month, 15).monthNameLocalized(const Locale('en')), equals(expected[month - 1]));
       }
     });
 
@@ -77,7 +79,7 @@ void main() {
       for (var i = 0; i < 7; i++) {
         final date = DateTime(2024, 1, 15 + i);
         expect(date.weekday, equals(i + 1));
-        expect(date.dayNameLocalized('en'), equals(expected[i]));
+        expect(date.dayNameLocalized(const Locale('en')), equals(expected[i]));
       }
     });
   });

--- a/test/extensions/uninitialized_locale_test.dart
+++ b/test/extensions/uninitialized_locale_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kalender/kalender_extensions.dart';
@@ -12,7 +14,7 @@ void main() {
     test('reports the missing setup call instead of intl\'s bare exception', () {
       FlutterError? thrown;
       try {
-        date.dayNameLocalized('de');
+        date.dayNameLocalized(const Locale('de'));
       } on FlutterError catch (error) {
         thrown = error;
       }
@@ -25,16 +27,16 @@ void main() {
     });
 
     test('covers every localized name builder', () {
-      expect(() => date.dayNameLocalized('fr'), throwsA(isA<FlutterError>()));
-      expect(() => date.dayNameShortLocalized('fr'), throwsA(isA<FlutterError>()));
-      expect(() => date.monthNameLocalized('fr'), throwsA(isA<FlutterError>()));
-      expect(() => date.monthNameShortLocalized('fr'), throwsA(isA<FlutterError>()));
+      expect(() => date.dayNameLocalized(const Locale('fr')), throwsA(isA<FlutterError>()));
+      expect(() => date.dayNameShortLocalized(const Locale('fr')), throwsA(isA<FlutterError>()));
+      expect(() => date.monthNameLocalized(const Locale('fr')), throwsA(isA<FlutterError>()));
+      expect(() => date.monthNameShortLocalized(const Locale('fr')), throwsA(isA<FlutterError>()));
     });
 
     test('"en" needs the call even though "en_US" does not', () {
       // intl compiles in en_US only, so the bare language tag is not covered.
-      expect(() => date.dayNameLocalized('en'), throwsA(isA<FlutterError>()));
-      expect(date.dayNameLocalized('en_US'), 'Wednesday');
+      expect(() => date.dayNameLocalized(const Locale('en')), throwsA(isA<FlutterError>()));
+      expect(date.dayNameLocalized(const Locale('en', 'US')), 'Wednesday');
     });
 
     test('the default locale still works without any setup', () {

--- a/test/models/kalender_scope_test.dart
+++ b/test/models/kalender_scope_test.dart
@@ -27,7 +27,7 @@ void main() {
       KalenderView(
         eventsController: eventsController,
         calendarController: calendarController,
-        locale: 'de',
+        locale: const Locale('de'),
         viewConfiguration: MultiDayViewConfiguration.singleDay(displayRange: year2025DisplayRange),
         components: CalendarComponents(
           multiDayComponents: MultiDayComponents(

--- a/test/utilities.dart
+++ b/test/utilities.dart
@@ -108,7 +108,7 @@ class TestProvider extends StatelessWidget {
   final ValueNotifier<CalendarInteraction>? interaction;
   final ValueNotifier<CalendarSnapping>? snapping;
   final ValueNotifier<double>? heightPerMinute;
-  final dynamic locale;
+  final Locale? locale;
   final Location? location;
 
   const TestProvider({

--- a/test/widgets/day_name_abbreviation_test.dart
+++ b/test/widgets/day_name_abbreviation_test.dart
@@ -14,8 +14,8 @@ void main() {
   // three letters of its full name in several locales.
   final wednesday = InternalDateTime(2025, 1, 15);
 
-  Future<void> pumpScheduleDate(WidgetTester tester, dynamic locale) async {
-    await initializeDateFormatting('$locale');
+  Future<void> pumpScheduleDate(WidgetTester tester, Locale locale) async {
+    await initializeDateFormatting(locale.toLanguageTag());
     await pumpAndSettleWithMaterialApp(
       tester,
       TestProvider(
@@ -29,21 +29,21 @@ void main() {
   }
 
   testWidgets('uses the locale\'s own abbreviation, not the first three letters', (tester) async {
-    await pumpScheduleDate(tester, 'de');
+    await pumpScheduleDate(tester, const Locale('de'));
 
     expect(find.text('Mi'), findsOneWidget);
     expect(find.text('Mit'), findsNothing, reason: 'Mittwoch cut at three characters is not how German abbreviates it');
   });
 
   testWidgets('English is unchanged, which is why this went unnoticed', (tester) async {
-    await pumpScheduleDate(tester, 'en');
+    await pumpScheduleDate(tester, const Locale('en'));
 
     expect(find.text('Wed'), findsOneWidget);
   });
 
   testWidgets('keeps abbreviations that are not three characters long', (tester) async {
     // Russian abbreviates Wednesday to two characters, and the cut produced three.
-    await pumpScheduleDate(tester, 'ru');
+    await pumpScheduleDate(tester, const Locale('ru'));
 
     expect(find.text('ср'), findsOneWidget);
     expect(find.text('сре'), findsNothing);
@@ -57,7 +57,7 @@ void main() {
         calendarController: CalendarController(),
         eventsController: DefaultEventsController(),
         tileComponents: TileComponents(tileBuilder: (context, event, tileRange) => const SizedBox()),
-        locale: 'de',
+        locale: const Locale('de'),
         child: Column(children: [ScheduleDate(date: wednesday), DayHeader(date: wednesday)]),
       ),
     );

--- a/test/widgets/timeline_alignment_test.dart
+++ b/test/widgets/timeline_alignment_test.dart
@@ -27,7 +27,7 @@ void main() {
     CalendarComponents? components,
     KalenderThemeData? theme,
     TextDirection textDirection = TextDirection.ltr,
-    dynamic locale,
+    Locale? locale,
   }) async {
     final view = KalenderView(
       eventsController: eventsController,
@@ -148,7 +148,7 @@ void main() {
     await pumpWeek(
       tester,
       components: withTimelineStringBuilder((context, time) => '${context.calendarLocale}'),
-      locale: 'de_DE',
+      locale: const Locale('de', 'DE'),
     );
 
     expect(labelAt(tester, 1), 'de_DE');


### PR DESCRIPTION
`KalenderView.locale` was a `dynamic`, so a mistyped locale string compiled and failed at run time. It is a `Locale` now, along with `KalenderScope.localeOf`, `BuildContext.calendarLocale` and the four localized methods on `DateTimeExtensions`.

`Locale` comes from `dart:ui` rather than Material, it carries value equality, and an app holding `Localizations.localeOf(context)` already has one. Where intl takes a string the call site passes `toLanguageTag()`. `Intl.canonicalizedLocale` rewrites the separator, so the hyphen form resolves to the same data as intl's underscore form, and `sr_Latn`, the only locale in intl's date data with a script subtag, is left untouched.

Breaking for anyone passing a `String`, and for anyone assigning `calendarLocale` to a non-nullable `String`, since the implicit downcast a `dynamic` allowed becomes a compile error.

This is the last open item in the 0.29.0 roadmap section.