### PR TITLE
Release 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ See [MIGRATION.md](MIGRATION.md#v028x--v0290) for what to change.
 
 ### Fixes
 
+- The month week number column mirrors in right-to-left layouts, where it drew opposite the space the header reserved.
 - The timeline gutter is measured once rather than at each of the three places that read it.
 - A custom `timelineWidth` builder receives one range rather than the view's range in the body and `TimeOfDayRange.allDay()` in the header and the drag overlay.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,7 +146,7 @@ What an app cannot reach comes to two things rather than ten: the drag or gestur
 
 **`FreeScrollFunctions` is removed, and removing it fixed a defect.** Its TODO asked whether `DayIndexCalculator` could replace it. The two were the same code but for one line, and that line rounded the end of the display range up to the next midnight even when it already fell on one, so a range already ending at midnight gained a day and the band drew a column outside it. Every other calculator guards that end with a conditional. The default range ends at midnight, as does any range written the usual way, so most free scroll calendars had it. `MultiDayViewConfiguration.type` is included in `==` and `hashCode` by the same change, since the calculator's runtime type was what told a free scroll configuration apart from a single day one.
 
-### 0.29.0, the state layer, previewed in 0.29.0-dev.1
+### 0.29.0, the state layer, done
 
 **The state layer becomes public, as one model rather than five widgets.** Composability's first piece, and the gate on [#215](https://github.com/werner-scholtz/kalender/issues/215), [#89](https://github.com/werner-scholtz/kalender/issues/89), [#262](https://github.com/werner-scholtz/kalender/issues/262), [#40](https://github.com/werner-scholtz/kalender/issues/40) and [#264](https://github.com/werner-scholtz/kalender/issues/264). The coverage gate it waited on is met.
 

--- a/lib/src/layout_delegates/month_week_number_layout_delegate.dart
+++ b/lib/src/layout_delegates/month_week_number_layout_delegate.dart
@@ -6,18 +6,23 @@ class MonthWeekNumberBodyLayoutDelegate extends MultiChildLayoutDelegate {
   final int gridId;
   final int contentId;
 
+  /// The side the gutter leads from.
+  final TextDirection textDirection;
+
   MonthWeekNumberBodyLayoutDelegate({
     required this.gutterId,
     this.backgroundId,
     required this.gridId,
     required this.contentId,
+    required this.textDirection,
   });
 
   @override
   void performLayout(Size size) {
     var gutterWidth = 0.0;
+    final hasGutter = gutterId != null && hasChild(gutterId!);
 
-    if (gutterId != null && hasChild(gutterId!)) {
+    if (hasGutter) {
       final gutterSize = layoutChild(
         gutterId!,
         BoxConstraints(
@@ -28,24 +33,30 @@ class MonthWeekNumberBodyLayoutDelegate extends MultiChildLayoutDelegate {
         ),
       );
       gutterWidth = gutterSize.width;
-      positionChild(gutterId!, Offset.zero);
     }
 
-    final contentConstraints =
-        BoxConstraints.tight(Size((size.width - gutterWidth).clamp(0.0, size.width), size.height));
+    final contentWidth = (size.width - gutterWidth).clamp(0.0, size.width);
+    // The month header lays its spacer out in a Row, which mirrors on its own.
+    final rightToLeft = textDirection == TextDirection.rtl;
+    final gutterOffset = rightToLeft ? Offset(contentWidth, 0) : Offset.zero;
+    final contentOffset = rightToLeft ? Offset.zero : Offset(gutterWidth, 0);
+
+    if (hasGutter) positionChild(gutterId!, gutterOffset);
+
+    final contentConstraints = BoxConstraints.tight(Size(contentWidth, size.height));
 
     // The background occupies the same rect as the content but is painted first,
     // so it sits below the grid lines and the day content.
     if (backgroundId != null && hasChild(backgroundId!)) {
       layoutChild(backgroundId!, contentConstraints);
-      positionChild(backgroundId!, Offset(gutterWidth, 0));
+      positionChild(backgroundId!, contentOffset);
     }
 
     layoutChild(gridId, contentConstraints);
-    positionChild(gridId, Offset(gutterWidth, 0));
+    positionChild(gridId, contentOffset);
 
     layoutChild(contentId, contentConstraints);
-    positionChild(contentId, Offset(gutterWidth, 0));
+    positionChild(contentId, contentOffset);
   }
 
   @override
@@ -53,7 +64,8 @@ class MonthWeekNumberBodyLayoutDelegate extends MultiChildLayoutDelegate {
     return gutterId != oldDelegate.gutterId ||
         backgroundId != oldDelegate.backgroundId ||
         gridId != oldDelegate.gridId ||
-        contentId != oldDelegate.contentId;
+        contentId != oldDelegate.contentId ||
+        textDirection != oldDelegate.textDirection;
   }
 }
 

--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -99,6 +99,7 @@ class MonthBody extends StatelessWidget {
             backgroundId: background != null ? 3 : null,
             gridId: 1,
             contentId: 2,
+            textDirection: Directionality.of(context),
           ),
           children: [
             if (showWeekNumbers)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.29.0-dev.1
+version: 0.29.0
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:

--- a/test/widgets/gutter_width_test.dart
+++ b/test/widgets/gutter_width_test.dart
@@ -97,6 +97,21 @@ void main() {
       expect(spacerWidth(tester), 90);
     });
 
+    // The header lays its spacer out in a Row, which mirrors on its own, while the
+    // body positions the gutter through a layout delegate.
+    for (final direction in TextDirection.values) {
+      testWidgets('the gutter and the spacer sit on the same side in $direction', (tester) async {
+        await pumpAndSettleWithMaterialApp(
+          tester,
+          Directionality(textDirection: direction, child: plain(month())),
+        );
+        expect(
+          tester.getRect(find.byType(MonthWeekNumberGutter)).left,
+          moreOrLessEquals(tester.getRect(find.byType(MonthWeekNumberSpacer)).left, epsilon: 0.5),
+        );
+      });
+    }
+
     testWidgets('a button size above the calendar widens the column', (tester) async {
       await pumpAndSettleWithMaterialApp(
         tester,


### PR DESCRIPTION
Fixes one bug found while checking the release, then bumps the version.

In a right-to-left month view the week number column drew on the left while the space the header reserves for it sat on the right, so the day columns of the two halves did not line up. `MonthHeader` lays its spacer out in a `Row`, which mirrors on its own, while `MonthWeekNumberBodyLayoutDelegate` positioned the gutter at `Offset.zero` unconditionally. The delegate takes a `TextDirection` now and mirrors both offsets. It predates 0.29.0 and is not exported, so only the changelog entry is needed.

`MonthWeekNumberHeaderLayoutDelegate` in the same file has no usages and is left alone rather than widen this PR.
