### PR TITLE
Fix the web demo header overflowing on long month names

### DIFF
--- a/examples/web_demo/lib/widgets/calendar/navigation_header.dart
+++ b/examples/web_demo/lib/widgets/calendar/navigation_header.dart
@@ -33,6 +33,9 @@ class NavigationHeader extends StatelessWidget {
         // On touch devices buttons are 44px; account for that when deciding
         // which elements to show so the Row never overflows.
         // Minimum widths (approx): date~80 + 2×nav~88 + loc~44 + view~44 + cfg~44 + spacing = ~315
+        // The full date label needs ~180 where the compact one takes ~80, so it
+        // only appears once it and the right-hand cluster both fit.
+        final compactDate = maxW < 560;
         final showNav = isTouch ? maxW >= 315 : maxW > 300;
         // Drop the location menu on very narrow mobile widths (< ~225px).
         final showLocation = !isTouch || maxW >= 225;
@@ -46,7 +49,7 @@ class NavigationHeader extends StatelessWidget {
               // navigating (which only changes its text) grows it into empty
               // space instead of pushing the buttons around. The navigation
               // controls live in the right-hand cluster.
-              HeaderDateButton(controller: controller, compact: maxW < 500),
+              HeaderDateButton(controller: controller, compact: compactDate),
               const Spacer(),
               if (showNav) ...[
                 IconButton(
@@ -285,9 +288,12 @@ class HeaderDateButton extends StatelessWidget {
                   children: [
                     Icon(Icons.calendar_month, color: context.colorScheme.primary),
                     const SizedBox(width: 8),
-                    Text(
-                      '$month $year',
-                      style: context.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                    Flexible(
+                      child: Text(
+                        '$month $year',
+                        overflow: TextOverflow.ellipsis,
+                        style: context.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                      ),
                     ),
                   ],
                 ),
@@ -295,7 +301,7 @@ class HeaderDateButton extends StatelessWidget {
 
         if (compact) return button;
         return ConstrainedBox(
-          constraints: const BoxConstraints(minWidth: 140),
+          constraints: const BoxConstraints(minWidth: 140, maxWidth: 240),
           child: button,
         );
       },


### PR DESCRIPTION
`analyze-examples (web_demo)` went red on 1 September and would have stayed red until March. The test pumps `MyApp` at `DateTime.now()`, and the header's date label renders the localized month name, so the result depends on the day the run happens. It fails for January, February, September, October, November and December, and passes for the other six.

Not a test artefact. The header's `LayoutBuilder` budgets the date label at `~80` in its own comment, but the widget it builds is a `ConstrainedBox(minWidth: 140)` around a button holding an icon, an 8px gap and `titleMedium` text, which needs roughly 180. The threshold `maxW < 500` therefore chose the full label at exactly the width where it does not fit, overflowing by 40 pixels. A real user on a window that size sees this for half the year.

The threshold moves to 560, the width the full label actually needs, and the label ellipsizes rather than overflowing so a locale with longer month names degrades instead of breaking.

Verified by substituting each month name in turn: all twelve pass, where six failed before. The ellipsis was checked separately at a 1600px surface with an over-long label, since at the test's width the header always takes the compact path.

The test still renders at `DateTime.now()` on purpose. It is what found this.
