### PR TITLE
Label the timeline without MaterialLocalizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.30.0
+
+### Features
+
+- `DateTimeExtensions.timeLocalized` formats the time of day for a locale, with `use24HourFormat` to force `HH:mm`.
+
+### Fixes
+
+- The timeline labels its hours with `intl` where the app installs no `MaterialLocalizations`, rather than throwing. ([#491](https://github.com/werner-scholtz/kalender/issues/491))
+
 ## 0.29.1
 
 ### Features

--- a/examples/material_ui/README.md
+++ b/examples/material_ui/README.md
@@ -6,27 +6,24 @@ Runs the calendar inside an app that has migrated to the standalone
 
 The package still imports `package:flutter/material.dart`. Those are two
 separate sets of classes with the same names, so an app on `material_ui` hits
-three problems. This example shows each one and what to do about it.
+three problems. This example shows each one and what to do about it. The first
+is fixed in the package, the other two are not.
 
-## 1. The timeline throws at runtime
+## 1. The timeline used to throw at runtime
 
-`TimeOfDay.format` resolves `MaterialLocalizations`, and a `material_ui`
-`MaterialApp` installs its own, not the ones the package looks up:
+Fixed. `TimeOfDay.format` resolved `MaterialLocalizations`, which a `material_ui`
+`MaterialApp` does not install, so the calendar threw:
 
 ```
 No MaterialLocalizations found.
-Builder widgets require MaterialLocalizations to be provided by a Localizations widget ancestor.
 ```
 
-Wrap the app in `MaterialUiCompatibilityBridge`, which maps the theme and
-installs the delegates the package expects:
+The calendar now formats its hour labels with `intl` against the locale it was
+given whenever those localizations are absent, so this needs nothing from you.
+An app that does install them keeps the labels it had.
 
-```dart
-MaterialApp(
-  builder: (context, child) => MaterialUiCompatibilityBridge(child: child!),
-  ...
-)
-```
+`MaterialUiCompatibilityBridge` is still worth having for the theme, see 3 below,
+but the calendar renders without it.
 
 ## 2. `DateTimeRange` and `TimeOfDay` do not compile
 

--- a/examples/material_ui/test/widget_test.dart
+++ b/examples/material_ui/test/widget_test.dart
@@ -4,9 +4,10 @@ import 'package:kalender/kalender.dart';
 import 'package:material_ui/material_ui.dart';
 
 void main() {
-  testWidgets('without the bridge the timeline cannot resolve MaterialLocalizations', (tester) async {
+  testWidgets('the calendar renders without the bridge', (tester) async {
     await tester.pumpWidget(_app(bridge: false));
-    expect(tester.takeException(), isA<FlutterError>());
+    expect(tester.takeException(), isNull);
+    expect(find.byType(CalendarBody), findsOneWidget);
   });
 
   testWidgets('with the bridge the calendar renders', (tester) async {

--- a/lib/src/extensions/date_time.dart
+++ b/lib/src/extensions/date_time.dart
@@ -89,4 +89,20 @@ extension DateTimeExtensions on DateTime {
   /// ```
   String monthNameShortLocalized([Locale? locale]) =>
       _formatLocalized(() => DateFormat.MMM(locale?.toLanguageTag()), this, locale);
+
+  /// Gets the time of day in a specific locale.
+  ///
+  /// [use24HourFormat] forces `HH:mm`. Otherwise the locale decides, which is
+  /// what intl resolves for `jm`.
+  ///
+  /// Example:
+  /// ```dart
+  /// final time = DateTime(2024, 1, 15, 17, 30);
+  /// print(time.timeLocalized(locale: const Locale('en', 'US'))); // Output: "5:30 PM"
+  /// print(time.timeLocalized(locale: const Locale('de'))); // Output: "17:30"
+  /// ```
+  String timeLocalized({Locale? locale, bool use24HourFormat = false}) {
+    final tag = locale?.toLanguageTag();
+    return _formatLocalized(() => use24HourFormat ? DateFormat.Hm(tag) : DateFormat.jm(tag), this, locale);
+  }
 }

--- a/lib/src/widgets/components/time_line.dart
+++ b/lib/src/widgets/components/time_line.dart
@@ -5,6 +5,21 @@ import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
+/// The label for [time].
+///
+/// `MaterialLocalizations` decides the format where the app installs them, which
+/// keeps a Material app's timeline byte for byte what it was. An app on the
+/// standalone `material_ui` package installs its own, not these, so there the
+/// format comes from intl and the calendar's locale.
+String _formatTime(BuildContext context, TimeOfDay time) {
+  final use24HourFormat = MediaQuery.alwaysUse24HourFormatOf(context);
+  final material = Localizations.of<MaterialLocalizations>(context, MaterialLocalizations);
+  if (material != null) return material.formatTimeOfDay(time, alwaysUse24HourFormat: use24HourFormat);
+
+  final locale = context.dependOnInheritedWidgetOfExactType<LocaleProvider>()?.locale;
+  return time.toDateTime(DateTime.utc(2000)).timeLocalized(locale: locale, use24HourFormat: use24HourFormat);
+}
+
 /// The time line builder.
 ///
 /// The [heightPerMinute] is the height of each minute.
@@ -76,7 +91,7 @@ double defaultTimelineWidth(BuildContext context, TimeOfDayRange timeOfDayRange)
   for (var hour = 0; hour < TimeOfDay.hoursPerDay; hour++) {
     for (final minute in minutes) {
       final time = TimeOfDay(hour: hour, minute: minute);
-      final text = stringBuilder?.call(context, time) ?? time.format(context);
+      final text = stringBuilder?.call(context, time) ?? _formatTime(context, time);
       painter.text = TextSpan(text: text, style: textStyle);
       painter.layout();
       if (painter.width > widest) widest = painter.width;
@@ -237,7 +252,7 @@ mixin TimeLineUtils {
   /// The label shown for [time].
   String timelineString(BuildContext context, TimeOfDay time) {
     final stringBuilder = context.components.multiDayComponents.bodyComponents.timelineStringBuilder;
-    return stringBuilder?.call(context, time) ?? time.format(context);
+    return stringBuilder?.call(context, time) ?? _formatTime(context, time);
   }
 
   /// The [TextStyle] that will be used for the text.

--- a/test/widgets/timeline_time_format_test.dart
+++ b/test/widgets/timeline_time_format_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:kalender/kalender.dart';
+
+import '../utilities.dart';
+
+/// The timeline labels its hours with `MaterialLocalizations` where the app
+/// installs them, and with intl where it does not.
+///
+/// The second path is what an app on the standalone `material_ui` package hits,
+/// which used to throw `No MaterialLocalizations found`. See issue #491.
+void main() {
+  late DefaultEventsController eventsController;
+  late CalendarController calendarController;
+
+  setUpAll(initializeDateFormatting);
+
+  setUp(() {
+    eventsController = DefaultEventsController();
+    calendarController = CalendarController();
+  });
+
+  tearDown(() {
+    calendarController.dispose();
+    eventsController.dispose();
+  });
+
+  final tiles = TileComponents(tileBuilder: (context, event, range) => const SizedBox());
+
+  /// A calendar with no Material ancestor at all, so no `MaterialLocalizations`.
+  /// The overlay is what the drag targets need and `MaterialApp` would provide.
+  Widget withoutMaterial(Locale locale, Widget child) => WidgetsApp(
+        color: const Color(0xFF000000),
+        locale: locale,
+        builder: (context, _) => Overlay(
+          initialEntries: [OverlayEntry(builder: (context) => child)],
+        ),
+      );
+
+  Widget calendar(Locale locale) => KalenderView(
+        eventsController: eventsController,
+        calendarController: calendarController,
+        locale: locale,
+        viewConfiguration: MultiDayViewConfiguration.week(displayRange: year2025DisplayRange),
+        body: CalendarBody(multiDayTileComponents: tiles),
+      );
+
+  String labelAt(WidgetTester tester, int hour) {
+    return tester.widget<Text>(find.byKey(TimeLine.getTimeKey(hour, 0)).first).data!;
+  }
+
+  testWidgets('an app without MaterialLocalizations renders rather than throwing', (tester) async {
+    await tester.pumpWidget(withoutMaterial(const Locale('de'), calendar(const Locale('de'))));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(labelAt(tester, 9), '09:00', reason: 'intl formatted it for the calendar\'s locale');
+  });
+
+  testWidgets('the calendar locale decides the intl format', (tester) async {
+    await tester.pumpWidget(withoutMaterial(const Locale('en'), calendar(const Locale('en'))));
+    await tester.pumpAndSettle();
+
+    // intl writes a narrow no-break space before the marker where Material uses
+    // a plain one, so compare on the parts rather than the separator.
+    expect(labelAt(tester, 9), startsWith('9:00'));
+    expect(labelAt(tester, 9), endsWith('AM'));
+  });
+
+  // MaterialLocalizations wins wherever they are installed, so an app that works
+  // today keeps the labels it has. DefaultMaterialLocalizations covers en only,
+  // so a German calendar inside a MaterialApp still labels in English, which is
+  // exactly what it did before this change.
+  testWidgets('MaterialLocalizations still decide the format when present', (tester) async {
+    await pumpAndSettleWithMaterialApp(tester, calendar(const Locale('de')));
+
+    expect(labelAt(tester, 9), '9:00 AM');
+  });
+}


### PR DESCRIPTION
Closes #491. `TimeOfDay.format` resolves `MaterialLocalizations`, which an app on the standalone `material_ui` package does not install, so the calendar threw `No MaterialLocalizations found` before drawing anything.

The label now comes from `MaterialLocalizations` wherever the app installs them and from `intl` where it does not, using the locale the calendar was given. `Localizations.of<MaterialLocalizations>` returns null rather than asserting, which is what makes the choice possible.

Deliberately a fallback rather than a swap. I compared the two across the 82 locales Flutter ships: 37 format identically, 1 differs only in whitespace, and **44 differ**. Most are leading zeros, in both directions (`ru` `9:05` against `09:05`, `cs` `09:05` against `9:05`), and about ten are substantive: `zh` moves from `上午 9:05` to `09:05`, `ml` and `gu` move the other way from 24-hour to 12-hour, `bg` and `sq` gain a marker intl appends. Even `en` differs, invisibly, because intl writes a narrow no-break space before `AM` where Material writes a plain one.

Changing how half the supported locales render is a decision worth taking on its own terms, not a side effect of fixing a crash. An app that works today keeps its labels byte for byte.

`DateTimeExtensions.timeLocalized` is public alongside the four existing localized names, since a custom `timelineStringBuilder` wants the same formatter.

The `material_ui` example loses one of its three documented breaks. Its test asserted that the timeline throws without the bridge, and that assertion now fails, so it is inverted to assert the calendar renders. The bridge still earns its place for the theme.
