### PR TITLE
Release 0.29.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.29.0
+version: 0.29.1
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
Bumps the version so the tag can publish. The release carries one change that reaches the archive: `lib/fix_data/`, so `dart fix --apply` performs the `CalendarView` to `KalenderView` rename for users before 0.30.0 removes the typedefs.

Verified from a fresh consumer project depending on kalender by path: a file using `CalendarView` and `GlobalKey<CalendarViewState>` took four fixes and analyzed clean afterwards.

The timeline fix for #491 is held back to 0.30.0.
