### PR TITLE
Import widgets rather than Material where Material is not needed

### DIFF
--- a/lib/src/calendar_body.dart
+++ b/lib/src/calendar_body.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 

--- a/lib/src/calendar_header.dart
+++ b/lib/src/calendar_header.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 

--- a/lib/src/layout_delegates/calendar_layout_delegate.dart
+++ b/lib/src/layout_delegates/calendar_layout_delegate.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 /// The calendar header when in use should be able to throw a drop shadow on the body.
 /// Ideally a [Column] widget would be used with the children as [body, header].

--- a/lib/src/layout_delegates/month_week_number_layout_delegate.dart
+++ b/lib/src/layout_delegates/month_week_number_layout_delegate.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 class MonthWeekNumberBodyLayoutDelegate extends MultiChildLayoutDelegate {
   final int? gutterId;

--- a/lib/src/models/components/components.dart
+++ b/lib/src/models/components/components.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/kalender_view.dart';
 import 'package:kalender/src/models/components/month_components.dart';
 import 'package:kalender/src/models/components/multi_day_components.dart';

--- a/lib/src/models/controllers/events_controller.dart
+++ b/lib/src/models/controllers/events_controller.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/models/calendar_events/calendar_event.dart';
 import 'package:kalender/src/models/calendar_events/multi_day_rule.dart';
 import 'package:kalender/src/models/controllers/events_controller/default_events_controller.dart';

--- a/lib/src/models/controllers/view_controller.dart
+++ b/lib/src/models/controllers/view_controller.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/mixins/calendar_navigation_functions.dart';
 

--- a/lib/src/models/controllers/view_controllers/month_view_controller.dart
+++ b/lib/src/models/controllers/view_controllers/month_view_controller.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 
 class MonthViewController extends ViewController {

--- a/lib/src/models/controllers/view_controllers/schedule_view_controller.dart
+++ b/lib/src/models/controllers/view_controllers/schedule_view_controller.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/mixins/schedule_map.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';

--- a/lib/src/models/mixins/calendar_navigation_functions.dart
+++ b/lib/src/models/mixins/calendar_navigation_functions.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/models/calendar_events/calendar_event.dart';
 
 mixin CalendarNavigationFunctions {

--- a/lib/src/models/navigation_triggers.dart
+++ b/lib/src/models/navigation_triggers.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 /// The configuration for the page triggers.
 ///

--- a/lib/src/models/providers/calendar_provider.dart
+++ b/lib/src/models/providers/calendar_provider.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 
 /// The [Components] widget provides the [CalendarComponents] to the widget tree.

--- a/lib/src/models/providers/gutter_widths.dart
+++ b/lib/src/models/providers/gutter_widths.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 
 /// The measured widths of the calendar's gutters.

--- a/lib/src/models/providers/kalender_scope.dart
+++ b/lib/src/models/providers/kalender_scope.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 

--- a/lib/src/widgets/components/day_header.dart
+++ b/lib/src/widgets/components/day_header.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
@@ -101,7 +101,7 @@ class DayHeaderStyle with Diagnosticable {
 
 /// A widget that displays the name of the day and the day number of the week.
 class DayHeader extends StatelessWidget {
-  /// Key applied to the [IconButton] when the date is today.
+  /// Key applied to the `IconButton` when the date is today.
   static const todayKey = ValueKey('DayHeader.today');
 
   /// The date that will be displayed in the [DayHeader].

--- a/lib/src/widgets/components/day_separator.dart
+++ b/lib/src/widgets/components/day_separator.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
 
 /// The day separator builder.

--- a/lib/src/widgets/components/hour_lines.dart
+++ b/lib/src/widgets/components/hour_lines.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 
 /// The hour lines builder.

--- a/lib/src/widgets/components/month_day_header.dart
+++ b/lib/src/widgets/components/month_day_header.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/internal_components/day_number.dart';
@@ -92,7 +92,7 @@ class MonthDayHeaderStyle with Diagnosticable {
 
 /// A widget that displays the day number.
 class MonthDayHeader extends StatelessWidget {
-  /// Key applied to the [IconButton] when the date is today.
+  /// Key applied to the `IconButton` when the date is today.
   static const todayKey = ValueKey('MonthDayHeader.today');
 
   final DateTime date;

--- a/lib/src/widgets/components/month_grid.dart
+++ b/lib/src/widgets/components/month_grid.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
 
 /// The month grid builder.

--- a/lib/src/widgets/components/multi_day_overlay_portal.dart
+++ b/lib/src/widgets/components/multi_day_overlay_portal.dart
@@ -1,5 +1,5 @@
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 
 /// A function that returns a [MultiDayOverlayPortal].

--- a/lib/src/widgets/components/schedule_date.dart
+++ b/lib/src/widgets/components/schedule_date.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
@@ -78,7 +78,7 @@ class ScheduleDateStyle with Diagnosticable {
 
 /// A widget that displays the name of the day and the day number of the week.
 class ScheduleDate extends StatelessWidget {
-  /// Key applied to the [IconButton] when the date is today.
+  /// Key applied to the `IconButton` when the date is today.
   static const todayKey = ValueKey('ScheduleDate.today');
 
   final InternalDateTime date;

--- a/lib/src/widgets/components/schedule_tile_highlight.dart
+++ b/lib/src/widgets/components/schedule_tile_highlight.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';
 

--- a/lib/src/widgets/components/time_indicator.dart
+++ b/lib/src/widgets/components/time_indicator.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 
 /// The time indicator builder.

--- a/lib/src/widgets/components/week_day_header.dart
+++ b/lib/src/widgets/components/week_day_header.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/theme/kalender_theme.dart';

--- a/lib/src/widgets/drag_targets/schedule_drag_target.dart
+++ b/lib/src/widgets/drag_targets/schedule_drag_target.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/calendar_events/draggable_event.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';

--- a/lib/src/widgets/draggable/new_draggable.dart
+++ b/lib/src/widgets/draggable/new_draggable.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 

--- a/lib/src/widgets/event_tiles/event_tile.dart
+++ b/lib/src/widgets/event_tiles/event_tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/event_tiles/resize_handle.dart';

--- a/lib/src/widgets/event_tiles/tile.dart
+++ b/lib/src/widgets/event_tiles/tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/extensions/internal_date_time_range.dart';
 import 'package:kalender/src/models/calendar_events/calendar_event.dart';
 import 'package:kalender/src/models/components/tile_components.dart';

--- a/lib/src/widgets/event_tiles/tile_draggable.dart
+++ b/lib/src/widgets/event_tiles/tile_draggable.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/models/calendar_events/calendar_event.dart';
 import 'package:kalender/src/models/calendar_events/draggable_event.dart';
 import 'package:kalender/src/models/calendar_interaction.dart';

--- a/lib/src/widgets/event_tiles/tile_gesture_detector.dart
+++ b/lib/src/widgets/event_tiles/tile_gesture_detector.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 
 /// The function that is called when the event is tapped.

--- a/lib/src/widgets/event_tiles/tiles/schedule_tile.dart
+++ b/lib/src/widgets/event_tiles/tiles/schedule_tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/models/calendar_callbacks.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/event_tiles/event_tile.dart';

--- a/lib/src/widgets/events_widgets/day_events_widget.dart
+++ b/lib/src/widgets/events_widgets/day_events_widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/event_tiles/tiles/day_tile.dart';

--- a/lib/src/widgets/events_widgets/multi_day_events_widget.dart
+++ b/lib/src/widgets/events_widgets/multi_day_events_widget.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/widgets/event_tiles/tiles/multi_day_tile.dart';

--- a/lib/src/widgets/internal_components/cursor_navigation_trigger.dart
+++ b/lib/src/widgets/internal_components/cursor_navigation_trigger.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 
 /// This widget uses a [DragTarget] to trigger navigation of the calendar.

--- a/lib/src/widgets/internal_components/expandable_page_view.dart
+++ b/lib/src/widgets/internal_components/expandable_page_view.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:linked_pageview/linked_pageview.dart';
 
 /// Thanks to https://gist.github.com/andrzejchm for https://gist.github.com/andrzejchm/02c1728b6f31a69fde2fb4e10b636060

--- a/lib/src/widgets/internal_components/multi_day_header_layout.dart
+++ b/lib/src/widgets/internal_components/multi_day_header_layout.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/models/providers/gutter_widths.dart';

--- a/lib/src/widgets/internal_components/page_clipper.dart
+++ b/lib/src/widgets/internal_components/page_clipper.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 /// A widget that clips the child widget a certain distance from the left.
 class PageClipWidget extends StatelessWidget {

--- a/lib/src/widgets/internal_components/pass_through_pointer.dart
+++ b/lib/src/widgets/internal_components/pass_through_pointer.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 
 /// A widget that allows all pointer events to passthrough.
 class PassThroughPointer extends SingleChildRenderObjectWidget {

--- a/lib/src/widgets/internal_components/time_indicator_positioner.dart
+++ b/lib/src/widgets/internal_components/time_indicator_positioner.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 

--- a/lib/src/widgets/internal_components/timeline_sizer.dart
+++ b/lib/src/widgets/internal_components/timeline_sizer.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/calendar_provider.dart';
 import 'package:kalender/src/models/providers/gutter_widths.dart';

--- a/lib/src/widgets/internal_components/week_day_headers.dart
+++ b/lib/src/widgets/internal_components/week_day_headers.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/extensions/internal_date_time.dart';
 
 /// A row of weekday headers for a week in the month view.

--- a/lib/src/widgets/schedule/schedule_header.dart
+++ b/lib/src/widgets/schedule/schedule_header.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 class ScheduleHeader extends StatelessWidget {
   const ScheduleHeader({super.key});


### PR DESCRIPTION
Stage 1 of taking the package off Material. Import lines only, no behaviour and no public API change.

Of the 89 files in `lib/` that imported `package:flutter/material.dart`, **42 did not need it** and now import `package:flutter/widgets.dart`. Membership was decided by the analyzer rather than by judgement: swap all 89, see which files fail, put Material back only in those.

The point is the measurement it leaves behind. A Material import in `lib/` now means the file genuinely needs Material, so the remaining coupling is visible in the import list rather than spread across a hundred files, and every later stage shrinks a list you can read.

Three files needed Material only for a `[IconButton]` doc link, so those became code spans instead of pulling the library back in.

`material.dart` re-exports `widgets.dart`, so these files only ever saw widgets-layer symbols through it, and kalender exports none of Flutter's libraries onward, so nothing reaches users differently. Analyzer clean, 1659 tests pass, doc snippets compile, the fix-data golden still passes.
