### PR TITLE
State which versions the migration fixes cover

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,9 +13,12 @@ dart fix --dry-run              # preview
 dart fix --apply                # apply
 ```
 
-It is safe to run across several versions at once. The fixes ship with the version
-you upgraded to and describe the older members, so a jump from an old release
-applies every rename in between.
+Fixes cover changes made in 0.29.0 and later. Upgrading from anything earlier is
+by hand, since those renames were never given fix data. Inside the covered range
+it is safe to run across several versions at once, because the fixes ship with the
+version you upgraded to and describe the members it replaced.
+
+Coverage only grows forward: every rename from here on ships with one.
 
 What it does not do:
 


### PR DESCRIPTION
The guide shipped in 0.29.1 claims a `dart fix` run "applies every rename in between" when jumping from an old release. That was written while back-filling fixes for 0.24.0 through 0.28.0 was still under consideration. We decided against it, and the sentence was never revisited.

The only fix data that exists covers the 0.29.0 `CalendarView` rename, so someone upgrading from 0.24.0 would have one rename applied and be told the rest were handled.

Now says fixes cover 0.29.0 and later, that earlier upgrades are by hand, and that coverage only grows forward since every rename from here on ships with one.
