### PR TITLE
Build the theme defaults from a palette

### DIFF
--- a/lib/src/theme/kalender_palette.dart
+++ b/lib/src/theme/kalender_palette.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+/// The values the calendar's default look is built from.
+///
+/// Six, which is everything `KalenderThemeData.defaults` reads from a theme.
+/// Holding them behind one type means the defaults themselves name no Material,
+/// so pointing them at another design system is a change to `fromTheme` rather
+/// than to each of the fourteen style classes.
+@immutable
+class KalenderPalette {
+  /// Hour lines, day separators, the month grid and the tooltip background.
+  final Color surface;
+
+  /// The schedule's highlight.
+  final Color accent;
+
+  /// The time indicator.
+  final Color error;
+
+  /// Day names, weekday headers and the schedule's dates.
+  final TextStyle? small;
+
+  /// Day numbers, week numbers and the overlay's text.
+  final TextStyle? medium;
+
+  /// The timeline's hour labels.
+  final TextStyle? label;
+
+  /// Creates a [KalenderPalette].
+  const KalenderPalette({
+    required this.surface,
+    required this.accent,
+    required this.error,
+    this.small,
+    this.medium,
+    this.label,
+  });
+
+  /// Maps a Material [ThemeData] onto the six.
+  ///
+  /// The only place the defaults touch Material. A core that does not depend on
+  /// it moves this one factory and leaves every style where it is.
+  factory KalenderPalette.fromTheme(ThemeData theme) {
+    return KalenderPalette(
+      surface: theme.colorScheme.surfaceContainerHighest,
+      accent: theme.colorScheme.primary,
+      error: theme.colorScheme.error,
+      small: theme.textTheme.bodySmall,
+      medium: theme.textTheme.bodyMedium,
+      label: theme.textTheme.labelMedium,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is KalenderPalette &&
+        other.surface == surface &&
+        other.accent == accent &&
+        other.error == error &&
+        other.small == small &&
+        other.medium == medium &&
+        other.label == label;
+  }
+
+  @override
+  int get hashCode => Object.hash(surface, accent, error, small, medium, label);
+}

--- a/lib/src/theme/kalender_theme.dart
+++ b/lib/src/theme/kalender_theme.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kalender/kalender.dart';
+import 'package:kalender/src/theme/kalender_palette.dart';
 
 /// The Material defaults for a [ThemeData], built once.
 ///
@@ -112,83 +113,84 @@ class KalenderThemeData extends ThemeExtension<KalenderThemeData> with Diagnosti
   static KalenderThemeData _defaultsFor(ThemeData theme) {
     final cached = _defaultsCache[theme];
     if (cached != null) return cached;
-    return _defaultsCache[theme] = _buildDefaults(theme);
+    return _defaultsCache[theme] = _buildDefaults(KalenderPalette.fromTheme(theme));
   }
 
-  static KalenderThemeData _buildDefaults(ThemeData theme) {
-    final colorScheme = theme.colorScheme;
-    final textTheme = theme.textTheme;
-
+  /// Builds the defaults from [palette].
+  ///
+  /// Names no Material beyond [Icons.close], which stage 4 replaces with an
+  /// owned or caller-supplied icon.
+  static KalenderThemeData _buildDefaults(KalenderPalette palette) {
     final tooltipDecoration = BoxDecoration(
-      color: colorScheme.surfaceContainerHighest,
+      color: palette.surface,
       borderRadius: BorderRadius.circular(8),
     );
 
     return KalenderThemeData(
       dayHeaderStyle: DayHeaderStyle(
-        textStyle: textTheme.bodySmall,
-        numberTextStyle: textTheme.bodyMedium,
+        textStyle: palette.small,
+        numberTextStyle: palette.medium,
         mainAxisAlignment: MainAxisAlignment.start,
       ),
       timelineStyle: TimelineStyle(
-        textStyle: textTheme.labelMedium,
+        textStyle: palette.label,
         textDirection: TextDirection.ltr,
         textPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 36),
         startDecoration: tooltipDecoration,
         endDecoration: tooltipDecoration,
       ),
       hourLinesStyle: HourLinesStyle(
-        color: colorScheme.surfaceContainerHighest,
+        color: palette.surface,
         thickness: 1,
         indent: 0,
         endIndent: 0,
       ),
       daySeparatorStyle: DaySeparatorStyle(
-        color: colorScheme.surfaceContainerHighest,
+        color: palette.surface,
         width: 1,
         topIndent: 0,
         bottomIndent: 0,
       ),
       timeIndicatorStyle: TimeIndicatorStyle(
-        lineColor: colorScheme.error,
+        lineColor: palette.error,
         thickness: 1,
         circleSize: const Size(10, 10),
       ),
       weekNumberStyle: WeekNumberStyle(
-        textStyle: textTheme.bodyMedium,
+        textStyle: palette.medium,
         tooltip: 'Week Number',
         padding: const EdgeInsets.symmetric(horizontal: 4),
       ),
       monthGridStyle: MonthGridStyle(
-        color: colorScheme.surfaceContainerHighest,
+        color: palette.surface,
         thickness: 0,
       ),
       monthDayHeaderStyle: MonthDayHeaderStyle(
-        numberTextStyle: textTheme.bodyMedium,
+        numberTextStyle: palette.medium,
         // Keeps the today highlight clear of the gridline above it and the
         // event tiles below it.
         margin: const EdgeInsets.symmetric(vertical: 2),
       ),
       weekDayHeaderStyle: WeekDayHeaderStyle(
-        textStyle: textTheme.bodySmall,
+        textStyle: palette.small,
         padding: const EdgeInsets.symmetric(vertical: 2),
       ),
       scheduleDateStyle: ScheduleDateStyle(
-        textStyle: textTheme.bodySmall,
-        numberTextStyle: textTheme.bodyMedium,
+        textStyle: palette.small,
+        numberTextStyle: palette.medium,
       ),
       scheduleTileHighlightStyle: ScheduleTileHighlightStyle(
-        decoration: BoxDecoration(color: colorScheme.primary.withAlpha(50)),
+        decoration: BoxDecoration(color: palette.accent.withAlpha(50)),
       ),
       multiDayOverlayStyle: MultiDayOverlayStyle(
         closeIcon: const Icon(Icons.close),
-        dateTextStyle: textTheme.bodyMedium,
+        dateTextStyle: palette.medium,
         headerPadding: const EdgeInsets.symmetric(vertical: 8),
         eventsPadding: const EdgeInsets.all(4),
         eventPadding: const EdgeInsets.symmetric(vertical: 2),
       ),
       multiDayPortalOverlayButtonStyle: MultiDayPortalOverlayButtonStyle(
-        textStyle: textTheme.bodyMedium,
+        textStyle: palette.medium,
         textPadding: const EdgeInsets.symmetric(horizontal: 4),
         textOverflow: TextOverflow.ellipsis,
       ),


### PR DESCRIPTION
Stage A3, the last of the non-breaking work. Internal only: no public API, no behaviour change, nothing in the changelog.

`_buildDefaults` is the single place the calendar's look is defined, and it read `ThemeData` directly. Everything it took from a theme turned out to be six values: `surfaceContainerHighest`, `primary`, `error`, `bodySmall`, `bodyMedium` and `labelMedium`. Those move behind an internal `KalenderPalette`, and `KalenderPalette.fromTheme` becomes the only place the defaults touch Material.

So the fourteen style classes are now defined against values kalender owns. Pointing them at another design system, or at a neutral default, is a change to one factory rather than to each style. That is what "prepare for a neutral core without shipping one" means in practice: the core still depends on Material and still looks exactly as it did.

`_buildDefaults` now names no Material beyond `Icons.close`, which the roadmap already assigns to stage 4.

Two things worth flagging:

The defaults cache is an `Expando`, so it keys on object identity. Keying it on a freshly built palette would have missed on every call and rebuilt the defaults each frame. `_defaultsFor` still takes and caches on `ThemeData`, and only `_buildDefaults` takes the palette.

`KalenderPalette` is deliberately not exported. Making it public plus a constructor that accepts one is a small additive change whenever someone asks for it.

Covered by the existing theme tests, which assert the defaults against `colorScheme` and pass unchanged, so the Material to palette to defaults chain is verified end to end.
