### PR TITLE
feat: package:kalender/material.dart converts to and from Material's types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See [MIGRATION.md](MIGRATION.md#v029x--v0300) for what to change.
 
 - `DateTimeExtensions.timeLocalized` formats the time of day for a locale, with `use24HourFormat` to force `HH:mm`.
 - `PageIndexCalculator.month` and `MonthIndexCalculator.fromRange` build a month calculator from a range.
+- `package:kalender/material.dart` converts `KalenderDateTimeRange` and `KalenderTime` to and from Material's `DateTimeRange` and `TimeOfDay`.
 
 ### Fixes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -126,11 +126,19 @@ locale instead. The am/pm helpers `period`, `hourOfPeriod` and `periodOffset` ar
 gone with the `DayPeriod` enum, so a page that needs them compares `hour` against 12.
 
 Calls into Material's own API still take Material's type, so convert at that
-boundary:
+boundary. `package:kalender/material.dart` carries the conversions both ways, for
+the time and the range:
 
 ```dart
-MaterialLocalizations.of(context).formatTimeOfDay(TimeOfDay(hour: t.hour, minute: t.minute))
+import 'package:kalender/material.dart';
+
+final picked = await showTimePicker(context: context, initialTime: time.toTimeOfDay());
+final time = picked?.toKalenderTime();
 ```
+
+It is a separate entry point, so importing `package:kalender/kalender.dart` alone
+still names no Material type. `toDateTimeRange` and `toKalenderDateTimeRange` do
+the same for the range.
 
 ### `TimeOfDayRange` is renamed to `KalenderTimeRange`
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -84,6 +84,17 @@ Event copyWithData({required DateTimeRange dateTimeRange}) => ...
 Event copyWithData({required KalenderDateTimeRange dateTimeRange}) => ...
 ```
 
+A range handed back by a Material API is converted rather than rewritten.
+`package:kalender/material.dart` carries `toKalenderDateTimeRange` for that
+direction, and `toDateTimeRange` for the other:
+
+```dart
+import 'package:kalender/material.dart';
+
+final picked = await showDateRangePicker(context: context, firstDate: first, lastDate: last);
+final range = picked?.toKalenderDateTimeRange();
+```
+
 ### `InternalDateTimeRange` is its own class
 
 It used to extend `DateTimeRange`, which is how it reached Material. It now carries
@@ -137,8 +148,7 @@ final time = picked?.toKalenderTime();
 ```
 
 It is a separate entry point, so importing `package:kalender/kalender.dart` alone
-still names no Material type. `toDateTimeRange` and `toKalenderDateTimeRange` do
-the same for the range.
+still names no Material type.
 
 ### `TimeOfDayRange` is renamed to `KalenderTimeRange`
 

--- a/lib/material.dart
+++ b/lib/material.dart
@@ -1,0 +1,41 @@
+/// Conversions between kalender's value types and the ones in
+/// `package:flutter/material.dart`.
+///
+/// Import this alongside `package:kalender/kalender.dart` where an app hands
+/// kalender values to a Material API, or the other way round:
+///
+/// ```dart
+/// final picked = await showTimePicker(context: context, initialTime: time.toTimeOfDay());
+/// final time = picked?.toKalenderTime();
+/// ```
+///
+/// It is a separate entry point so that importing `package:kalender/kalender.dart`
+/// does not name a Material type.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:kalender/kalender.dart';
+
+/// Converts a [KalenderDateTimeRange] to Material's [DateTimeRange].
+extension KalenderDateTimeRangeMaterial on KalenderDateTimeRange {
+  /// This range as a Material [DateTimeRange].
+  DateTimeRange<DateTime> toDateTimeRange() => DateTimeRange<DateTime>(start: start, end: end);
+}
+
+/// Converts Material's [DateTimeRange] to a [KalenderDateTimeRange].
+extension MaterialDateTimeRangeKalender<T extends DateTime> on DateTimeRange<T> {
+  /// This range as a [KalenderDateTimeRange].
+  KalenderDateTimeRange toKalenderDateTimeRange() => KalenderDateTimeRange(start: start, end: end);
+}
+
+/// Converts a [KalenderTime] to Material's [TimeOfDay].
+extension KalenderTimeMaterial on KalenderTime {
+  /// This time as a Material [TimeOfDay].
+  TimeOfDay toTimeOfDay() => TimeOfDay(hour: hour, minute: minute);
+}
+
+/// Converts Material's [TimeOfDay] to a [KalenderTime].
+extension MaterialTimeOfDayKalender on TimeOfDay {
+  /// This time as a [KalenderTime].
+  KalenderTime toKalenderTime() => KalenderTime(hour: hour, minute: minute);
+}

--- a/test/material_interop_test.dart
+++ b/test/material_interop_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kalender/kalender.dart';
+import 'package:kalender/material.dart';
+
+void main() {
+  group('date range', () {
+    final start = DateTime.utc(2026, 3, 1, 9);
+    final end = DateTime.utc(2026, 3, 1, 17);
+
+    test('converts to Material and back', () {
+      final range = KalenderDateTimeRange(start: start, end: end);
+      final material = range.toDateTimeRange();
+
+      expect(material.start, start);
+      expect(material.end, end);
+      expect(material.toKalenderDateTimeRange(), range);
+    });
+
+    test('converts a Material range that carries a subtype', () {
+      final material = DateTimeRange<DateTime>(start: start, end: end);
+      expect(material.toKalenderDateTimeRange(), KalenderDateTimeRange(start: start, end: end));
+    });
+  });
+
+  group('time of day', () {
+    test('converts to Material and back', () {
+      const time = KalenderTime(hour: 7, minute: 30);
+      final material = time.toTimeOfDay();
+
+      expect(material.hour, 7);
+      expect(material.minute, 30);
+      expect(material.toKalenderTime(), time);
+    });
+
+    test('midnight survives the round trip', () {
+      const time = KalenderTime(hour: 0, minute: 0);
+      expect(time.toTimeOfDay().toKalenderTime(), time);
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #506.

Now that no kalender signature names a Material type, an app that hands kalender values to a Material API needs a conversion at that boundary. `showTimePicker` and `MaterialLocalizations.formatTimeOfDay` are the two that come up.

```dart
import 'package:kalender/material.dart';

final picked = await showTimePicker(context: context, initialTime: time.toTimeOfDay());
final time = picked?.toKalenderTime();
```

Four extensions, both directions, for the range and the time. A separate entry point, so importing `package:kalender/kalender.dart` alone still names no Material type and an app that never touches Material never pays for it. `kalender_extensions.dart` is the precedent.

The range conversion is generic over `DateTimeRange<T extends DateTime>`, so a `DateTimeRange<TZDateTime>` converts too.

Refs #491.
