### PR TITLE
refactor!: CalendarEvent takes start and end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ See [MIGRATION.md](MIGRATION.md#v029x--v0300) for what to change.
 - `TimeOfDayExtension` is removed. `toInternalDateTime` and `toDateTime` are methods on `KalenderTime`.
 - `InternalDateTimeRange` no longer extends `DateTimeRange`, and `forLocation` returns a `KalenderDateTimeRange`.
 - `InternalDateTimeRange.overlaps` takes an `InternalDateTimeRange`, and `InternalDateTimeRange.fromDateTimeRange` takes a `KalenderDateTimeRange`.
+- `CalendarEvent` and `CalendarEvent.copyWithData` take `start` and `end` rather than `dateTimeRange`.
 - `PageIndexCalculator` and its subclasses take `start` and `end` rather than `dateTimeRange`.
 - `DragTargetUtils.calculateDateTimeRangeFromStart` and `calculateDateTimeRangeFromEnd` take an `InternalDateTimeRange`.
 - `EventTileUtils.eventRangeOnDate` returns an `InternalDateTimeRange`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -167,6 +167,54 @@ KalenderTimeRange(start: KalenderTime(hour: 8, minute: 0), end: KalenderTime(hou
 `toInternalDateTime` and `toDateTime` are methods on `KalenderTime`, so the calls
 are unchanged and only the type they are called on differs.
 
+### `CalendarEvent` takes `start` and `end`
+
+The event always stored two UTC instants. The constructor took a range and pulled
+it apart immediately, so it takes the two values now.
+
+```dart
+// Before
+CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end))
+
+// After
+CalendarEvent(start: start, end: end)
+```
+
+`dateTimeRange` survives as a getter, so `event.dateTimeRange` still returns a
+`KalenderDateTimeRange`. `event.start` and `event.end` are usually what you want.
+
+**Every subclass changes by hand.** `copyWithData` carries `@mustBeOverridden`, and
+a fix rewrites call sites rather than the declarations in your own code, so the
+compiler points at each one:
+
+```dart
+// Before
+class Event extends CalendarEvent {
+  Event({super.id, required super.dateTimeRange, required this.title});
+  final String title;
+
+  @override
+  Event copyWithData({required KalenderDateTimeRange dateTimeRange}) {
+    return Event(dateTimeRange: dateTimeRange, title: title);
+  }
+}
+
+// After
+class Event extends CalendarEvent {
+  Event({super.id, required super.start, required super.end, required this.title});
+  final String title;
+
+  @override
+  Event copyWithData({required DateTime start, required DateTime end}) {
+    return Event(start: start, end: end, title: title);
+  }
+}
+```
+
+`withDateTimeRange` is unchanged and still takes a `KalenderDateTimeRange`. It is
+`@nonVirtual`, so it is called rather than overridden, and every caller already
+holds a whole range.
+
 ### `PageIndexCalculator` takes `start` and `end`
 
 Every subclass unpacked the range into two values and converted each separately, so

--- a/benchmark/fixtures.dart
+++ b/benchmark/fixtures.dart
@@ -26,7 +26,7 @@ List<CalendarEvent> generateDayEvents({
       final hour = 6 + (e % 12);
       final startTime = DateTime.utc(date.year, date.month, date.day, hour);
       final endTime = startTime.add(Duration(minutes: 30 + (e % 4) * 30));
-      events.add(CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: startTime, end: endTime)));
+      events.add(CalendarEvent(start: startTime, end: endTime));
     }
   }
   return events;
@@ -45,7 +45,7 @@ List<CalendarEvent> generateMultiDayEvents({
     final span = 1 + (i % 5);
     final startTime = DateTime.utc(start.year, start.month, start.day + offset);
     final endTime = DateTime.utc(start.year, start.month, start.day + offset + span);
-    events.add(CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: startTime, end: endTime)));
+    events.add(CalendarEvent(start: startTime, end: endTime));
   }
   return events;
 }

--- a/doc/controllers-and-callbacks.md
+++ b/doc/controllers-and-callbacks.md
@@ -210,12 +210,14 @@ CalendarCallbacks(
   // Called before the calendar creates a new event from a gesture.
   // Return your concrete Event subclass here.
   onEventCreate: (event) {
-    return Event(dateTimeRange: event.dateTimeRange, title: 'New Event');
+    return Event(start: event.start,
+      end: event.end, title: 'New Event');
   },
 
   // Same as onEventCreate but includes gesture detail (position, renderBox).
   onEventCreateWithDetail: (event, detail) {
-    return Event(dateTimeRange: event.dateTimeRange, title: 'New Event');
+    return Event(start: event.start,
+      end: event.end, title: 'New Event');
   },
 
   // Called after a new event has been committed. Add it to your controller here.

--- a/doc/events.md
+++ b/doc/events.md
@@ -19,7 +19,8 @@ class Event extends CalendarEvent {
 
   Event({
     super.id,
-    required super.dateTimeRange,
+    required super.start,
+    required super.end,
     required this.title,
     this.description,
     this.color,
@@ -32,16 +33,18 @@ class Event extends CalendarEvent {
   // and resize, then restores id, interaction, multiDayRule and isAllDay
   // itself, so none of those are listed here.
   @override
-  Event copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return Event(dateTimeRange: dateTimeRange, title: title, description: description, color: color);
+  Event copyWithData({required DateTime start, required DateTime end}) {
+    return Event(start: start,
+      end: end, title: title, description: description, color: color);
   }
 
   // A copy method of your own. It is not an override, so it takes whatever
   // parameters suit you. carryOver keeps the copy's identity and rule.
-  Event copyWith({KalenderDateTimeRange? dateTimeRange, String? title, String? description, Color? color}) {
+  Event copyWith({DateTime? start, DateTime? end, String? title, String? description, Color? color}) {
     return carryOver(
       Event(
-        dateTimeRange: dateTimeRange ?? this.dateTimeRange,
+        start: start ?? this.start,
+        end: end ?? this.end,
         title: title ?? this.title,
         description: description ?? this.description,
         color: color ?? this.color,
@@ -117,7 +120,8 @@ Pass this as `KalenderView.callbacks`:
 ```dart
 CalendarCallbacks(
   onEventCreate: (event) => Event(
-    dateTimeRange: event.dateTimeRange,
+    start: event.start,
+      end: event.end,
     title: 'New Event',
     color: Colors.blue,
   ),
@@ -135,7 +139,7 @@ An event that is all-day by nature rather than by duration says so directly, and
 
 <!-- snippet: expression -->
 ```dart
-CalendarEvent(dateTimeRange: range, isAllDay: true)
+CalendarEvent(start: range.start, end: range.end, isAllDay: true)
 ```
 
 This puts it in the header lane whatever its duration, which no `MultiDayRule` can express for an event lasting an hour. The date range is left alone, so an app wanting midnight to midnight supplies it. `isAllDay` defaults to false, where the rules below apply as before.
@@ -145,7 +149,8 @@ A single event can override the calendar's rule:
 <!-- snippet: expression -->
 ```dart
 CalendarEvent(
-  dateTimeRange: range,
+  start: range.start,
+  end: range.end,
   multiDayRule: const MultiDayRule.calendarDays(),
 )
 ```

--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -63,7 +63,8 @@ forbids stays forbidden even where the calendar allows it.
 <!-- snippet: expression -->
 ```dart
 CalendarEvent(
-  dateTimeRange: range,
+  start: range.start,
+  end: range.end,
   // Movable, but its start and end are fixed.
   interaction: EventInteraction(
     allowStartResize: false,

--- a/doc/timezones-and-locales.md
+++ b/doc/timezones-and-locales.md
@@ -149,7 +149,7 @@ When events come from an `.ics` file, a device calendar, or an API, map each sou
 
   final start = tz.TZDateTime(tz.getLocation('Europe/London'), 2025, 1, 6, 9);
   final event = CalendarEvent(
-    dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(const Duration(hours: 1))),
+    start: start, end: start.add(const Duration(hours: 1)),
   );
   ```
 

--- a/examples/advanced_example/lib/layout_strategy.dart
+++ b/examples/advanced_example/lib/layout_strategy.dart
@@ -36,8 +36,7 @@ class PeopleLayoutStrategy extends EventLayoutStrategy {
   }
 
   @override
-  bool operator ==(Object other) =>
-      other is PeopleLayoutStrategy && listEquals(other.people, people);
+  bool operator ==(Object other) => other is PeopleLayoutStrategy && listEquals(other.people, people);
 
   @override
   int get hashCode => Object.hashAll(people);
@@ -59,19 +58,14 @@ class CustomSideBySideLayoutDelegate extends EventLayoutDelegate {
   });
 
   @override
-  List<CalendarEvent> sortEvents(Iterable<CalendarEvent> events) =>
-      events.toList();
+  List<CalendarEvent> sortEvents(Iterable<CalendarEvent> events) => events.toList();
 
   @override
-  List<VerticalLayoutData> sortVerticalLayoutData(
-    List<VerticalLayoutData> layoutData,
-  ) {
+  List<VerticalLayoutData> sortVerticalLayoutData(List<VerticalLayoutData> layoutData) {
     // Sort the data from top to bottom.
     // If the top values are equal compare the bottom
     return layoutData..sort((a, b) {
-      return a.top.compareTo(b.top) == 0
-          ? b.bottom.compareTo(a.bottom)
-          : a.top.compareTo(b.top);
+      return a.top.compareTo(b.top) == 0 ? b.bottom.compareTo(a.bottom) : a.top.compareTo(b.top);
     });
   }
 
@@ -105,29 +99,17 @@ class CustomSideBySideLayoutDelegate extends EventLayoutDelegate {
     for (final (i, person) in people.indexed) {
       final group = horizontalGroups[person] ?? [];
       final position = Offset(i * space.width, 0);
-      final rectForGroup = Rect.fromLTWH(
-        position.dx,
-        position.dy,
-        space.width,
-        space.height,
-      );
+      final rectForGroup = Rect.fromLTWH(position.dx, position.dy, space.width, space.height);
       performGroupLayout(group, rectForGroup);
     }
   }
 
   /// Performs the layout for a group of events.
-  void performGroupLayout(
-    List<HorizontalGroupData> horizontalGroups,
-    Rect rect,
-  ) {
+  void performGroupLayout(List<HorizontalGroupData> horizontalGroups, Rect rect) {
     for (var i = 0; i < horizontalGroups.length; i++) {
       final group = horizontalGroups.elementAt(i);
       final verticalLayoutData = group.verticalLayoutData
-        ..sort(
-          (a, b) => b.height.compareTo(a.height) == 0
-              ? b.top.compareTo(a.top)
-              : b.height.compareTo(a.height),
-        );
+        ..sort((a, b) => b.height.compareTo(a.height) == 0 ? b.top.compareTo(a.top) : b.height.compareTo(a.height));
 
       final numberOfEvents = verticalLayoutData.length;
       final longest = findLongestChain(verticalLayoutData);
@@ -148,8 +130,7 @@ class CustomSideBySideLayoutDelegate extends EventLayoutDelegate {
         // Calculate the x offset of the tile.
         double tileXOffset;
         if (lastOverlapLeft != null) {
-          tileXOffset =
-              tiles[lastOverlapLeft.id]!.dx + tileWidths[lastOverlapLeft.id]!;
+          tileXOffset = tiles[lastOverlapLeft.id]!.dx + tileWidths[lastOverlapLeft.id]!;
         } else {
           // Use the left edge of the rectangle as a base if there are no overlaps to the left.
           tileXOffset = rect.left + (childWidth * overlapsLeft.length);
@@ -157,9 +138,7 @@ class CustomSideBySideLayoutDelegate extends EventLayoutDelegate {
 
         // Find the overlaps to the right of the tile.
         final tilesToRight = verticalLayoutData.getRange(i + 1, numberOfEvents);
-        final overlapsRight = tilesToRight
-            .where((e) => e.overlaps(data))
-            .toList();
+        final overlapsRight = tilesToRight.where((e) => e.overlaps(data)).toList();
 
         // Calculate the width of the tile.
         var tileWidth = childWidth;
@@ -169,10 +148,7 @@ class CustomSideBySideLayoutDelegate extends EventLayoutDelegate {
         }
 
         // Layout the tile.
-        layoutChild(
-          id,
-          BoxConstraints.tightFor(width: tileWidth, height: data.height),
-        );
+        layoutChild(id, BoxConstraints.tightFor(width: tileWidth, height: data.height));
 
         tiles[id] = Offset(tileXOffset, data.top);
         tileWidths[id] = tileWidth;

--- a/examples/advanced_example/lib/main.dart
+++ b/examples/advanced_example/lib/main.dart
@@ -15,7 +15,8 @@ class Event extends CalendarEvent {
 
   Event({
     super.id,
-    required super.dateTimeRange,
+    required super.start,
+    required super.end,
     required this.title,
     required this.person,
     super.interaction,
@@ -30,7 +31,8 @@ class Event extends CalendarEvent {
     final tapLocation = detail.localOffset;
     final person = people[tapLocation.dx ~/ (dayWidth / people.length)];
     return Event(
-      dateTimeRange: calendarEvent.dateTimeRange,
+      start: calendarEvent.start,
+      end: calendarEvent.end,
       title: 'New Event',
       person: person,
       interaction: calendarEvent.interaction,
@@ -38,17 +40,14 @@ class Event extends CalendarEvent {
   }
 
   @override
-  Event copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return Event(dateTimeRange: dateTimeRange, title: title, person: person);
+  Event copyWithData({required DateTime start, required DateTime end}) {
+    return Event(start: start, end: end, title: title, person: person);
   }
 
   @override
   operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is Event &&
-        other.title == title &&
-        other.person == person &&
-        other.dateTimeRange == dateTimeRange;
+    return other is Event && other.title == title && other.person == person && other.dateTimeRange == dateTimeRange;
   }
 
   @override
@@ -80,9 +79,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Advanced Example',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
+      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple)),
       home: const MyHomePage(),
     );
   }
@@ -95,10 +92,7 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
-const people = [
-  Person(name: "Person A", color: Colors.blue),
-  Person(name: "Person B", color: Colors.amber),
-];
+const people = [Person(name: "Person A", color: Colors.blue), Person(name: "Person B", color: Colors.amber)];
 
 class _MyHomePageState extends State<MyHomePage> {
   final eventsController = DefaultEventsController();
@@ -118,14 +112,11 @@ class _MyHomePageState extends State<MyHomePage> {
         viewConfiguration: _viewConfiguration,
         components: CalendarComponents(),
         callbacks: CalendarCallbacks(
-          onEventTapped: (event) =>
-              calendarController.selectEvent(event),
+          onEventTapped: (event) => calendarController.selectEvent(event),
           onEventCreateWithDetail: Event.fromDetail,
           onEventCreated: (event) => eventsController.addEvent(event),
-          onEventChanged: (event, updatedEvent) => eventsController.updateEvent(
-            event: event,
-            updatedEvent: updatedEvent,
-          ),
+          onEventChanged: (event, updatedEvent) =>
+              eventsController.updateEvent(event: event, updatedEvent: updatedEvent),
         ),
         header: Column(
           children: [
@@ -149,11 +140,7 @@ class _MyHomePageState extends State<MyHomePage> {
               ],
             ),
             const SizedBox(height: 8),
-            CalendarHeader(
-              multiDayHeaderConfiguration: MultiDayHeaderConfiguration(
-                showTiles: false,
-              ),
-            ),
+            CalendarHeader(multiDayHeaderConfiguration: MultiDayHeaderConfiguration(showTiles: false)),
             const Divider(),
             PeopleWidget(viewConfiguration: _viewConfiguration),
             const Divider(),
@@ -165,9 +152,7 @@ class _MyHomePageState extends State<MyHomePage> {
             multiDayTileComponents: tileComponents,
             monthTileComponents: multiDayTileComponents,
             scheduleTileComponents: scheduleTileComponents,
-            multiDayBodyConfiguration: MultiDayBodyConfiguration(
-              eventLayoutStrategy: PeopleLayoutStrategy(people),
-            ),
+            multiDayBodyConfiguration: MultiDayBodyConfiguration(eventLayoutStrategy: PeopleLayoutStrategy(people)),
           ),
         ),
       ),
@@ -183,19 +168,13 @@ class PeopleWidget extends StatelessWidget {
     return Row(
       children: [
         // Needed for proper spacing — matches the body's timeline gutter width.
-        SizedBox(
-          width: defaultTimelineWidth(context, KalenderTimeRange.allDay()),
-        ),
+        SizedBox(width: defaultTimelineWidth(context, KalenderTimeRange.allDay())),
         ...List.generate(
           viewConfiguration.numberOfDays,
           (index) => Expanded(
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: people
-                  .map(
-                    (person) => Expanded(child: PersonWidget(person: person)),
-                  )
-                  .toList(growable: false),
+              children: people.map((person) => Expanded(child: PersonWidget(person: person))).toList(growable: false),
             ),
           ),
         ),

--- a/examples/advanced_example/lib/tiles.dart
+++ b/examples/advanced_example/lib/tiles.dart
@@ -32,27 +32,17 @@ ScheduleTileComponents get scheduleTileComponents {
 abstract class BaseEventTile extends StatelessWidget {
   final Event event;
   final KalenderDateTimeRange tileRange;
-  const BaseEventTile({
-    super.key,
-    required this.event,
-    required this.tileRange,
-  });
+  const BaseEventTile({super.key, required this.event, required this.tileRange});
 
   Color get color => event.person.color;
-  Color textColor(Color color) =>
-      color.computeLuminance() > 0.5 ? Colors.black : Colors.white;
+  Color textColor(Color color) => color.computeLuminance() > 0.5 ? Colors.black : Colors.white;
 
   bool get continuesAfter => event.dateTimeRange.end.isAfter(tileRange.end);
-  bool get continuesBefore =>
-      event.dateTimeRange.start.isBefore(tileRange.start);
-  String title(BuildContext context) =>
-      "${event.person.toString()}: ${event.title} (${event.id})";
+  bool get continuesBefore => event.dateTimeRange.start.isBefore(tileRange.start);
+  String title(BuildContext context) => "${event.person.toString()}: ${event.title} (${event.id})";
 
   static BorderRadius defaultBorderRadius = BorderRadius.circular(8);
-  BoxDecoration get decoration => BoxDecoration(
-    color: color.withAlpha(150),
-    borderRadius: defaultBorderRadius,
-  );
+  BoxDecoration get decoration => BoxDecoration(color: color.withAlpha(150), borderRadius: defaultBorderRadius);
 }
 
 class EventTile extends BaseEventTile {
@@ -76,21 +66,12 @@ class EventTile extends BaseEventTile {
 }
 
 class MultiDayEventTile extends BaseEventTile {
-  const MultiDayEventTile({
-    super.key,
-    required super.event,
-    required super.tileRange,
-  });
-  static MultiDayEventTile builder(
-    BuildContext context,
-    CalendarEvent event,
-    KalenderDateTimeRange tileRange,
-  ) {
+  const MultiDayEventTile({super.key, required super.event, required super.tileRange});
+  static MultiDayEventTile builder(BuildContext context, CalendarEvent event, KalenderDateTimeRange tileRange) {
     return MultiDayEventTile(event: event as Event, tileRange: tileRange);
   }
 
-  EdgeInsets get padding =>
-      const EdgeInsets.symmetric(vertical: 1, horizontal: 4);
+  EdgeInsets get padding => const EdgeInsets.symmetric(vertical: 1, horizontal: 4);
 
   static Key getKey(String id) => Key('MultiDayEventTile-$id');
 
@@ -112,22 +93,13 @@ class MultiDayEventTile extends BaseEventTile {
 }
 
 class OverlayEventTile extends BaseEventTile {
-  const OverlayEventTile({
-    super.key,
-    required super.event,
-    required super.tileRange,
-  });
+  const OverlayEventTile({super.key, required super.event, required super.tileRange});
 
-  static OverlayEventTile builder(
-    BuildContext context,
-    CalendarEvent event,
-    KalenderDateTimeRange tileRange,
-  ) {
+  static OverlayEventTile builder(BuildContext context, CalendarEvent event, KalenderDateTimeRange tileRange) {
     return OverlayEventTile(event: event as Event, tileRange: tileRange);
   }
 
-  EdgeInsets get padding =>
-      const EdgeInsets.symmetric(vertical: 1, horizontal: 4);
+  EdgeInsets get padding => const EdgeInsets.symmetric(vertical: 1, horizontal: 4);
 
   @override
   Widget build(BuildContext context) {
@@ -137,29 +109,15 @@ class OverlayEventTile extends BaseEventTile {
           left: continuesBefore ? 20 : 0,
           right: continuesAfter ? 20 : 0,
           child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: color.withAlpha(150),
-              borderRadius: BorderRadius.circular(8),
-            ),
+            decoration: BoxDecoration(color: color.withAlpha(150), borderRadius: BorderRadius.circular(8)),
             child: Padding(
               padding: padding,
-              child: Text(
-                title(context),
-                style: TextStyle(color: textColor(color)),
-              ),
+              child: Text(title(context), style: TextStyle(color: textColor(color))),
             ),
           ),
         ),
-        if (continuesAfter)
-          const Align(
-            alignment: Alignment.centerRight,
-            child: Icon(Icons.chevron_right),
-          ),
-        if (continuesBefore)
-          const Align(
-            alignment: Alignment.centerLeft,
-            child: Icon(Icons.chevron_left),
-          ),
+        if (continuesAfter) const Align(alignment: Alignment.centerRight, child: Icon(Icons.chevron_right)),
+        if (continuesBefore) const Align(alignment: Alignment.centerLeft, child: Icon(Icons.chevron_left)),
       ],
     );
   }
@@ -168,16 +126,9 @@ class OverlayEventTile extends BaseEventTile {
 class FeedbackTile extends StatelessWidget {
   final Event event;
   final Size dropTargetWidgetSize;
-  const FeedbackTile({
-    super.key,
-    required this.event,
-    required this.dropTargetWidgetSize,
-  });
+  const FeedbackTile({super.key, required this.event, required this.dropTargetWidgetSize});
   static FeedbackTile builder(BuildContext context, CalendarEvent event, Size dropTargetWidgetSize) {
-    return FeedbackTile(
-      event: event as Event,
-      dropTargetWidgetSize: dropTargetWidgetSize,
-    );
+    return FeedbackTile(event: event as Event, dropTargetWidgetSize: dropTargetWidgetSize);
   }
 
   @override

--- a/examples/advanced_example/lib/zoom.dart
+++ b/examples/advanced_example/lib/zoom.dart
@@ -8,19 +8,12 @@ import 'package:kalender/kalender.dart';
 class ZoomDetector extends StatelessWidget {
   final Widget child;
   final CalendarController controller;
-  const ZoomDetector({
-    super.key,
-    required this.child,
-    required this.controller,
-  });
+  const ZoomDetector({super.key, required this.child, required this.controller});
 
   @override
   Widget build(BuildContext context) {
     return switch (defaultTargetPlatform) {
-      TargetPlatform.iOS || TargetPlatform.android => MobileZoomDetector(
-        controller: controller,
-        child: child,
-      ),
+      TargetPlatform.iOS || TargetPlatform.android => MobileZoomDetector(controller: controller, child: child),
       _ => DesktopZoomDetector(controller: controller, child: child),
     };
   }
@@ -51,12 +44,10 @@ mixin ZoomUtils {
   }
 
   /// The [ScrollController] of the calendar.
-  ScrollController? get scrollController =>
-      multiDayViewController?.scrollController;
+  ScrollController? get scrollController => multiDayViewController?.scrollController;
 
   /// The [ValueNotifier] that holds the height per minute of the calendar.
-  ValueNotifier<double>? get heightPerMinute =>
-      multiDayViewController?.heightPerMinute;
+  ValueNotifier<double>? get heightPerMinute => multiDayViewController?.heightPerMinute;
 
   /// The [ValueNotifier] that holds the state of the control key.
   ValueNotifier<bool> lock = ValueNotifier(false);
@@ -100,26 +91,20 @@ mixin ZoomUtils {
   }
 
   ScrollBehavior scrollBehavior(bool lock) {
-    return (lock ? const ScrollBehaviorNever() : const MaterialScrollBehavior())
-        .copyWith(scrollbars: false);
+    return (lock ? const ScrollBehaviorNever() : const MaterialScrollBehavior()).copyWith(scrollbars: false);
   }
 }
 
 class DesktopZoomDetector extends StatefulWidget {
   final Widget child;
   final CalendarController controller;
-  const DesktopZoomDetector({
-    super.key,
-    required this.child,
-    required this.controller,
-  });
+  const DesktopZoomDetector({super.key, required this.child, required this.controller});
 
   @override
   State<DesktopZoomDetector> createState() => _DesktopZoomDetectorState();
 }
 
-class _DesktopZoomDetectorState extends State<DesktopZoomDetector>
-    with ZoomUtils {
+class _DesktopZoomDetectorState extends State<DesktopZoomDetector> with ZoomUtils {
   @override
   CalendarController get controller => widget.controller;
 
@@ -168,10 +153,7 @@ class _DesktopZoomDetectorState extends State<DesktopZoomDetector>
       onPointerPanZoomEnd: (_) => lock.value = false,
       child: ValueListenableBuilder(
         valueListenable: lock,
-        builder: (context, value, _) => ScrollConfiguration(
-          behavior: scrollBehavior(value),
-          child: widget.child,
-        ),
+        builder: (context, value, _) => ScrollConfiguration(behavior: scrollBehavior(value), child: widget.child),
       ),
     );
   }
@@ -180,18 +162,13 @@ class _DesktopZoomDetectorState extends State<DesktopZoomDetector>
 class MobileZoomDetector extends StatefulWidget {
   final Widget child;
   final CalendarController controller;
-  const MobileZoomDetector({
-    super.key,
-    required this.child,
-    required this.controller,
-  });
+  const MobileZoomDetector({super.key, required this.child, required this.controller});
 
   @override
   State<MobileZoomDetector> createState() => _MobileZoomDetectorState();
 }
 
-class _MobileZoomDetectorState extends State<MobileZoomDetector>
-    with ZoomUtils {
+class _MobileZoomDetectorState extends State<MobileZoomDetector> with ZoomUtils {
   @override
   CalendarController get controller => widget.controller;
 
@@ -201,25 +178,25 @@ class _MobileZoomDetectorState extends State<MobileZoomDetector>
   Widget build(BuildContext context) {
     return RawGestureDetector(
       gestures: {
-        AllowMultipleGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<
-              AllowMultipleGestureRecognizer
-            >(AllowMultipleGestureRecognizer.new, (instance) {
-              instance.onStart = (details) {
-                yOffset = details.localFocalPoint.dy;
-                _previousScale = 0;
-                if (details.pointerCount <= 1) return;
-              };
-              instance.onUpdate = (details) {
-                if (details.pointerCount <= 1) return;
-                final height = heightPerMinute?.value;
-                if (height == null) return;
-                final delta = -(_previousScale - log(details.verticalScale));
-                _previousScale = log(details.verticalScale);
-                final newHeight = height + delta;
-                update(height, newHeight);
-              };
-            }),
+        AllowMultipleGestureRecognizer: GestureRecognizerFactoryWithHandlers<AllowMultipleGestureRecognizer>(
+          AllowMultipleGestureRecognizer.new,
+          (instance) {
+            instance.onStart = (details) {
+              yOffset = details.localFocalPoint.dy;
+              _previousScale = 0;
+              if (details.pointerCount <= 1) return;
+            };
+            instance.onUpdate = (details) {
+              if (details.pointerCount <= 1) return;
+              final height = heightPerMinute?.value;
+              if (height == null) return;
+              final delta = -(_previousScale - log(details.verticalScale));
+              _previousScale = log(details.verticalScale);
+              final newHeight = height + delta;
+              update(height, newHeight);
+            };
+          },
+        ),
       },
       child: widget.child,
     );
@@ -230,8 +207,7 @@ class ScrollBehaviorNever extends ScrollBehavior {
   const ScrollBehaviorNever();
 
   @override
-  ScrollPhysics getScrollPhysics(BuildContext context) =>
-      const NeverScrollableScrollPhysics();
+  ScrollPhysics getScrollPhysics(BuildContext context) => const NeverScrollableScrollPhysics();
 }
 
 class AllowMultipleGestureRecognizer extends ScaleGestureRecognizer {

--- a/examples/doc_snippets/lib/preamble.dart
+++ b/examples/doc_snippets/lib/preamble.dart
@@ -12,7 +12,8 @@ import 'package:timezone/timezone.dart' as tz;
 class Event extends CalendarEvent {
   Event({
     super.id,
-    required super.dateTimeRange,
+    required super.start,
+    required super.end,
     required this.title,
     this.description,
     this.color,
@@ -26,14 +27,15 @@ class Event extends CalendarEvent {
   final Color? color;
 
   @override
-  Event copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return Event(dateTimeRange: dateTimeRange, title: title, description: description, color: color);
+  Event copyWithData({required DateTime start, required DateTime end}) {
+    return Event(start: start, end: end, title: title, description: description, color: color);
   }
 
-  Event copyWith({KalenderDateTimeRange? dateTimeRange, String? title, String? description, Color? color}) {
+  Event copyWith({DateTime? start, DateTime? end, String? title, String? description, Color? color}) {
     return carryOver(
       Event(
-        dateTimeRange: dateTimeRange ?? this.dateTimeRange,
+        start: start ?? this.start,
+        end: end ?? this.end,
         title: title ?? this.title,
         description: description ?? this.description,
         color: color ?? this.color,
@@ -72,7 +74,6 @@ final calendarController = CalendarController();
 final viewConfiguration = MultiDayViewConfiguration.week();
 
 final location = tz.getLocation('Etc/UTC');
-final range =
-    KalenderDateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2025, 1, 2));
-final event = CalendarEvent(dateTimeRange: range);
+final range = KalenderDateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2025, 1, 2));
+final event = CalendarEvent(start: range.start, end: range.end);
 const someId = 'an-event-id';

--- a/examples/example/lib/main.dart
+++ b/examples/example/lib/main.dart
@@ -39,7 +39,8 @@ class MyApp extends StatelessWidget {
 class Event extends CalendarEvent {
   Event({
     super.id,
-    required super.dateTimeRange,
+    required super.start,
+    required super.end,
     required this.title,
     this.color,
     super.interaction,
@@ -52,8 +53,8 @@ class Event extends CalendarEvent {
   // Rebuilds only what this class adds. The id, the interaction config and the
   // rule are restored by CalendarEvent afterwards.
   @override
-  Event copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return Event(dateTimeRange: dateTimeRange, title: title, color: color);
+  Event copyWithData({required DateTime start, required DateTime end}) {
+    return Event(start: start, end: end, title: title, color: color);
   }
 
   @override
@@ -110,34 +111,26 @@ class _MyHomePageState extends State<MyHomePage> {
     final today = DateTime(now.year, now.month, now.day);
     eventsController.addEvents([
       Event(
-        dateTimeRange: KalenderDateTimeRange(
-          start: today.add(const Duration(hours: 9)),
-          end: today.add(const Duration(hours: 10, minutes: 30)),
-        ),
+        start: today.add(const Duration(hours: 9)),
+        end: today.add(const Duration(hours: 10, minutes: 30)),
         title: 'Team Standup',
         color: Colors.blue,
       ),
       Event(
-        dateTimeRange: KalenderDateTimeRange(
-          start: today.add(const Duration(hours: 13)),
-          end: today.add(const Duration(hours: 14)),
-        ),
+        start: today.add(const Duration(hours: 13)),
+        end: today.add(const Duration(hours: 14)),
         title: 'Lunch Meeting',
         color: Colors.green,
       ),
       Event(
-        dateTimeRange: KalenderDateTimeRange(
-          start: today.add(const Duration(days: 1, hours: 10)),
-          end: today.add(const Duration(days: 1, hours: 12)),
-        ),
+        start: today.add(const Duration(days: 1, hours: 10)),
+        end: today.add(const Duration(days: 1, hours: 12)),
         title: 'Workshop',
         color: Colors.orange,
       ),
       Event(
-        dateTimeRange: KalenderDateTimeRange(
-          start: today,
-          end: today.add(const Duration(days: 3)),
-        ),
+        start: today,
+        end: today.add(const Duration(days: 3)),
         title: 'Conference',
         color: Colors.purple,
       ),
@@ -155,7 +148,7 @@ class _MyHomePageState extends State<MyHomePage> {
           onEventTapped: (event) => calendarController.selectEvent(event),
           onEventCreate: (event) {
             // Give newly created events a default title.
-            return Event(dateTimeRange: event.dateTimeRange, title: 'New Event');
+            return Event(start: event.start, end: event.end, title: 'New Event');
           },
           onEventCreated: (event) => eventsController.addEvent(event),
           onEventChanged: (event, updatedEvent) => eventsController.updateEvent(

--- a/examples/example/lib/tiles.dart
+++ b/examples/example/lib/tiles.dart
@@ -21,7 +21,8 @@ class EventTile extends StatelessWidget {
 
   final CalendarEvent event;
 
-  static EventTile builder(BuildContext context, CalendarEvent event, KalenderDateTimeRange tileRange) => EventTile(event: event);
+  static EventTile builder(BuildContext context, CalendarEvent event, KalenderDateTimeRange tileRange) =>
+      EventTile(event: event);
 
   @override
   Widget build(BuildContext context) {
@@ -109,7 +110,8 @@ class ScheduleEventTile extends StatelessWidget {
 
   final CalendarEvent event;
 
-  static ScheduleEventTile builder(BuildContext context, CalendarEvent event, KalenderDateTimeRange tileRange) => ScheduleEventTile(event: event);
+  static ScheduleEventTile builder(BuildContext context, CalendarEvent event, KalenderDateTimeRange tileRange) =>
+      ScheduleEventTile(event: event);
 
   @override
   Widget build(BuildContext context) {

--- a/examples/ics/lib/ics_calendar.dart
+++ b/examples/ics/lib/ics_calendar.dart
@@ -133,7 +133,8 @@ DateTimeProperty _dateProperty(String name, DateTime date) {
 
 IcsEvent _event(IcsSource source, DateTime start, DateTime end, Color color) {
   return IcsEvent(
-    dateTimeRange: KalenderDateTimeRange(start: start, end: end),
+    start: start,
+    end: end,
     uid: source.uid,
     title: source.summary,
     description: source.description,

--- a/examples/ics/lib/ics_event.dart
+++ b/examples/ics/lib/ics_event.dart
@@ -7,7 +7,8 @@ import 'package:kalender/kalender.dart';
 class IcsEvent extends CalendarEvent {
   IcsEvent({
     super.id,
-    required super.dateTimeRange,
+    required super.start,
+    required super.end,
     required this.uid,
     required this.title,
     required this.color,
@@ -23,9 +24,10 @@ class IcsEvent extends CalendarEvent {
   final Color color;
 
   @override
-  IcsEvent copyWithData({required KalenderDateTimeRange dateTimeRange}) {
+  IcsEvent copyWithData({required DateTime start, required DateTime end}) {
     return IcsEvent(
-      dateTimeRange: dateTimeRange,
+      start: start,
+      end: end,
       uid: uid,
       title: title,
       description: description,

--- a/examples/intl4x/lib/main.dart
+++ b/examples/intl4x/lib/main.dart
@@ -75,10 +75,8 @@ class _IntlFourXAppState extends State<IntlFourXApp> {
     final today = DateTime.now();
     _eventsController.addEvents([
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: DateTime(today.year, today.month, today.day, 9),
-          end: DateTime(today.year, today.month, today.day, 11),
-        ),
+        start: DateTime(today.year, today.month, today.day, 9),
+        end: DateTime(today.year, today.month, today.day, 11),
       ),
     ]);
   }
@@ -113,8 +111,7 @@ class _IntlFourXAppState extends State<IntlFourXApp> {
               value: _locale,
               onChanged: (value) => setState(() => _locale = value!),
               items: [
-                for (final locale in _locales)
-                  DropdownMenuItem(value: locale, child: Text(locale.toLanguageTag())),
+                for (final locale in _locales) DropdownMenuItem(value: locale, child: Text(locale.toLanguageTag())),
               ],
             ),
             const SizedBox(width: 16),

--- a/examples/intl4x/test/intl4x_replaces_intl_test.dart
+++ b/examples/intl4x/test/intl4x_replaces_intl_test.dart
@@ -20,7 +20,8 @@ void main() {
     // The schedule draws a month heading and a day row only where events exist.
     eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 6, 9), end: DateTime(2025, 1, 6, 10)),
+        start: DateTime(2025, 1, 6, 9),
+        end: DateTime(2025, 1, 6, 10),
       ),
     );
   });

--- a/examples/material_ui/lib/main.dart
+++ b/examples/material_ui/lib/main.dart
@@ -49,17 +49,10 @@ class _HomePageState extends State<HomePage> {
     super.initState();
     final today = DateTime(now.year, now.month, now.day);
     eventsController.addEvents([
+      CalendarEvent(start: today.add(const Duration(hours: 9)), end: today.add(const Duration(hours: 10, minutes: 30))),
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: today.add(const Duration(hours: 9)),
-          end: today.add(const Duration(hours: 10, minutes: 30)),
-        ),
-      ),
-      CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: today.add(const Duration(days: 1, hours: 13)),
-          end: today.add(const Duration(days: 1, hours: 14)),
-        ),
+        start: today.add(const Duration(days: 1, hours: 13)),
+        end: today.add(const Duration(days: 1, hours: 14)),
       ),
     ]);
   }
@@ -78,9 +71,7 @@ class _HomePageState extends State<HomePage> {
       // KalenderThemeData cannot be registered on a material_ui ThemeData, so
       // app-wide styling goes through this widget instead.
       body: KalenderTheme(
-        data: const KalenderThemeData(
-          timeIndicatorStyle: TimeIndicatorStyle(lineColor: Color(0xFFE91E63)),
-        ),
+        data: const KalenderThemeData(timeIndicatorStyle: TimeIndicatorStyle(lineColor: Color(0xFFE91E63))),
         child: KalenderView(
           eventsController: eventsController,
           calendarController: calendarController,

--- a/examples/recurrence/lib/dialog.dart
+++ b/examples/recurrence/lib/dialog.dart
@@ -275,13 +275,15 @@ class _RecurrenceDialogState extends State<RecurrenceDialog> {
                               final String message;
                               final IconData icon;
                               if (!widget.isEditing) {
-                                message = '$_recurrenceCount ${_recurrenceCount == 1 ? 'occurrence' : 'occurrences'} will be created';
+                                message =
+                                    '$_recurrenceCount ${_recurrenceCount == 1 ? 'occurrence' : 'occurrences'} will be created';
                                 icon = Icons.repeat;
                               } else if (diff > 0) {
                                 message = '$diff new ${diff == 1 ? 'occurrence' : 'occurrences'} will be added';
                                 icon = Icons.add_circle_outline;
                               } else if (diff < 0) {
-                                message = '${diff.abs()} ${diff.abs() == 1 ? 'occurrence' : 'occurrences'} will be removed';
+                                message =
+                                    '${diff.abs()} ${diff.abs() == 1 ? 'occurrence' : 'occurrences'} will be removed';
                                 icon = Icons.remove_circle_outline;
                               } else {
                                 message = 'No change in occurrences';

--- a/examples/recurrence/lib/recurrence.dart
+++ b/examples/recurrence/lib/recurrence.dart
@@ -170,7 +170,7 @@ class Recurrence {
     final recurrences = type.generateDateTimeRanges(first, number);
     return recurrences.map(
       (recurrence) {
-        return RecurringCalendarEvent(dateTimeRange: recurrence, groupId: groupId);
+        return RecurringCalendarEvent(start: recurrence.start, end: recurrence.end, groupId: groupId);
       },
     ).toList();
   }

--- a/examples/recurrence/lib/recurring_event.dart
+++ b/examples/recurrence/lib/recurring_event.dart
@@ -7,7 +7,8 @@ class RecurringCalendarEvent extends CalendarEvent {
   RecurringCalendarEvent({
     super.id,
     required this.groupId,
-    required super.dateTimeRange,
+    required super.start,
+    required super.end,
     super.interaction,
     super.multiDayRule,
   });
@@ -15,8 +16,8 @@ class RecurringCalendarEvent extends CalendarEvent {
   /// Rebuilds the group this occurrence belongs to. The rest is restored by
   /// [CalendarEvent].
   @override
-  RecurringCalendarEvent copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return RecurringCalendarEvent(dateTimeRange: dateTimeRange, groupId: groupId);
+  RecurringCalendarEvent copyWithData({required DateTime start, required DateTime end}) {
+    return RecurringCalendarEvent(start: start, end: end, groupId: groupId);
   }
 
   @override

--- a/examples/riverpod/lib/main.dart
+++ b/examples/riverpod/lib/main.dart
@@ -28,7 +28,8 @@ final eventsProvider = Provider<EventsController>((ref) => DefaultEventsControll
 /// The view configurations the user can pick from.
 final viewConfigurationsProvider = Provider<List<ViewConfiguration>>((ref) {
   final now = DateTime.now();
-  final displayRange = KalenderDateTimeRange(start: now.copyWith(day: now.day - 365), end: now.copyWith(day: now.day + 365));
+  final displayRange =
+      KalenderDateTimeRange(start: now.copyWith(day: now.day - 365), end: now.copyWith(day: now.day + 365));
   return [
     MultiDayViewConfiguration.week(displayRange: displayRange, firstDayOfWeek: 1),
     MultiDayViewConfiguration.singleDay(displayRange: displayRange),

--- a/examples/testing/integration_test/performance_profiling_test.dart
+++ b/examples/testing/integration_test/performance_profiling_test.dart
@@ -17,12 +17,8 @@ void main() {
         for (var view in Views.values) {
           late TestConfiguration config;
           setUp(() {
-            config = TestConfiguration(
-              viewConfiguration: view.viewConfiguration,
-            );
-            config.eventsController.addEvents(
-              TestConfiguration.generate(scenario.eventRanges),
-            );
+            config = TestConfiguration(viewConfiguration: view.viewConfiguration);
+            config.eventsController.addEvents(TestConfiguration.generate(scenario.eventRanges));
           });
 
           // 1. Profile loading events.
@@ -36,20 +32,13 @@ void main() {
 
             await tester.pumpWidget(MyApp(config: config));
             await tester.pumpAndSettle(Duration(milliseconds: 100));
-            await binding.traceAction(
-              () async {
-                for (var batch in eventBatches) {
-                  await tester.pumpAndSettle(Duration(milliseconds: 100));
-                  config.eventsController.addEvents(batch);
-                  await tester.pumpAndSettle(Duration(milliseconds: 100));
-                }
-              },
-              reportKey: scenario.getReportKey(
-                view,
-                ReportKeys.loadingEvents,
-                run,
-              ),
-            );
+            await binding.traceAction(() async {
+              for (var batch in eventBatches) {
+                await tester.pumpAndSettle(Duration(milliseconds: 100));
+                config.eventsController.addEvents(batch);
+                await tester.pumpAndSettle(Duration(milliseconds: 100));
+              }
+            }, reportKey: scenario.getReportKey(view, ReportKeys.loadingEvents, run));
             await tester.pumpAndSettle(Duration(milliseconds: 100));
           });
 
@@ -62,43 +51,26 @@ void main() {
             config.calendarController.jumpToDate(current);
             await tester.pumpAndSettle(Duration(milliseconds: 100));
 
-            await binding.traceAction(
-              () async {
-                await tester.pumpAndSettle(Duration(milliseconds: 250));
-                config.calendarController.animateToDate(
-                  current.copyWith(day: current.day - 7),
-                );
-                await tester.pumpAndSettle(Duration(milliseconds: 250));
-                config.calendarController.animateToDate(current);
-                await tester.pumpAndSettle(Duration(milliseconds: 250));
-                config.calendarController.animateToDate(
-                  current.copyWith(day: current.day + 7),
-                );
-                await tester.pumpAndSettle(Duration(milliseconds: 250));
-                config.calendarController.animateToDate(
-                  current.copyWith(day: current.day + 14),
-                );
-                await tester.pumpAndSettle(Duration(milliseconds: 250));
-                config.calendarController.animateToDate(current);
-                await tester.pumpAndSettle(Duration(milliseconds: 250));
-              },
-              reportKey: scenario.getReportKey(
-                view,
-                ReportKeys.navigation,
-                run,
-              ),
-            );
+            await binding.traceAction(() async {
+              await tester.pumpAndSettle(Duration(milliseconds: 250));
+              config.calendarController.animateToDate(current.copyWith(day: current.day - 7));
+              await tester.pumpAndSettle(Duration(milliseconds: 250));
+              config.calendarController.animateToDate(current);
+              await tester.pumpAndSettle(Duration(milliseconds: 250));
+              config.calendarController.animateToDate(current.copyWith(day: current.day + 7));
+              await tester.pumpAndSettle(Duration(milliseconds: 250));
+              config.calendarController.animateToDate(current.copyWith(day: current.day + 14));
+              await tester.pumpAndSettle(Duration(milliseconds: 250));
+              config.calendarController.animateToDate(current);
+              await tester.pumpAndSettle(Duration(milliseconds: 250));
+            }, reportKey: scenario.getReportKey(view, ReportKeys.navigation, run));
           });
 
           // 3. Profile scrolling.
-          testWidgets('${scenario.name} Scrolling', skip: view != Views.week, (
-            tester,
-          ) async {
+          testWidgets('${scenario.name} Scrolling', skip: view != Views.week, (tester) async {
             await tester.pumpWidget(MyApp(config: config));
             await tester.pumpAndSettle(Duration(milliseconds: 100));
-            config.calendarController.jumpToDate(
-              TestConfiguration.initialDateTime,
-            );
+            config.calendarController.jumpToDate(TestConfiguration.initialDateTime);
             await tester.pumpAndSettle(Duration(milliseconds: 100));
 
             final scrollable = find.descendant(
@@ -108,26 +80,15 @@ void main() {
             final startFinder = find.byKey(TimeLine.getTimeKey(1, 0));
             final endFinder = find.byKey(TimeLine.getTimeKey(23, 0));
 
-            await binding.traceAction(
-              () async {
-                await tester.pumpAndSettle(Duration(milliseconds: 100));
-                for (var i = 0; i < 10; i++) {
-                  await tester.scrollUntilVisible(
-                    startFinder,
-                    250.0,
-                    scrollable: scrollable,
-                  );
-                  await tester.pump(Duration(milliseconds: 10));
-                  await tester.scrollUntilVisible(
-                    endFinder,
-                    -250.0,
-                    scrollable: scrollable,
-                  );
-                  await tester.pump(Duration(milliseconds: 10));
-                }
-              },
-              reportKey: scenario.getReportKey(view, ReportKeys.scrolling, run),
-            );
+            await binding.traceAction(() async {
+              await tester.pumpAndSettle(Duration(milliseconds: 100));
+              for (var i = 0; i < 10; i++) {
+                await tester.scrollUntilVisible(startFinder, 250.0, scrollable: scrollable);
+                await tester.pump(Duration(milliseconds: 10));
+                await tester.scrollUntilVisible(endFinder, -250.0, scrollable: scrollable);
+                await tester.pump(Duration(milliseconds: 10));
+              }
+            }, reportKey: scenario.getReportKey(view, ReportKeys.scrolling, run));
           });
 
           // 4. Profile rescheduling.
@@ -139,130 +100,81 @@ void main() {
             final center = tester.getCenter(body);
             final topLeft = tester.getTopLeft(body) + const Offset(25, 25);
             final topRight = tester.getTopRight(body) + const Offset(-25, 25);
-            final bottomLeft =
-                tester.getBottomLeft(body) + const Offset(25, -25);
-            final bottomRight =
-                tester.getBottomRight(body) - const Offset(25, 25);
+            final bottomLeft = tester.getBottomLeft(body) + const Offset(25, -25);
+            final bottomRight = tester.getBottomRight(body) - const Offset(25, 25);
 
             final tileFinder = find.byType(switch (view) {
               Views.week => EventTile,
               Views.month => MultiDayEventTile,
               Views.schedule => MultiDayEventTile,
             }).first;
-            final dragStart =
-                tester.getCenter(tileFinder) + const Offset(-2, 0);
+            final dragStart = tester.getCenter(tileFinder) + const Offset(-2, 0);
 
-            await binding.traceAction(
-              () async {
-                final dragGesture = await tester.startGesture(
-                  dragStart,
-                  pointer: 1,
-                );
-                await tester.pump(Duration(milliseconds: 100));
-                await performSegmentedDrag(
-                  dragGesture,
-                  tester,
-                  dragStart,
-                  topLeft,
-                );
-                await tester.pumpAndSettle();
-                await performSegmentedDrag(
-                  dragGesture,
-                  tester,
-                  topLeft,
-                  topRight,
-                );
-                await tester.pumpAndSettle();
-                await performSegmentedDrag(
-                  dragGesture,
-                  tester,
-                  topRight,
-                  bottomRight,
-                );
-                await tester.pumpAndSettle();
-                await performSegmentedDrag(
-                  dragGesture,
-                  tester,
-                  bottomRight,
-                  bottomLeft,
-                );
-                await tester.pumpAndSettle();
-                await performSegmentedDrag(
-                  dragGesture,
-                  tester,
-                  bottomLeft,
-                  center,
-                );
-                await tester.pumpAndSettle();
-                await dragGesture.up();
-                await tester.pumpAndSettle(Duration(milliseconds: 100));
-              },
-              reportKey: scenario.getReportKey(
-                view,
-                ReportKeys.rescheduling,
-                run,
-              ),
-            );
+            await binding.traceAction(() async {
+              final dragGesture = await tester.startGesture(dragStart, pointer: 1);
+              await tester.pump(Duration(milliseconds: 100));
+              await performSegmentedDrag(dragGesture, tester, dragStart, topLeft);
+              await tester.pumpAndSettle();
+              await performSegmentedDrag(dragGesture, tester, topLeft, topRight);
+              await tester.pumpAndSettle();
+              await performSegmentedDrag(dragGesture, tester, topRight, bottomRight);
+              await tester.pumpAndSettle();
+              await performSegmentedDrag(dragGesture, tester, bottomRight, bottomLeft);
+              await tester.pumpAndSettle();
+              await performSegmentedDrag(dragGesture, tester, bottomLeft, center);
+              await tester.pumpAndSettle();
+              await dragGesture.up();
+              await tester.pumpAndSettle(Duration(milliseconds: 100));
+            }, reportKey: scenario.getReportKey(view, ReportKeys.rescheduling, run));
           });
 
           // 5. Profile resizing.
-          testWidgets(
-            '${scenario.name} Resizing',
-            skip: view == Views.schedule,
-            (tester) async {
-              await tester.pumpWidget(MyApp(config: config));
-              await tester.pumpAndSettle(Duration(milliseconds: 100));
+          testWidgets('${scenario.name} Resizing', skip: view == Views.schedule, (tester) async {
+            await tester.pumpWidget(MyApp(config: config));
+            await tester.pumpAndSettle(Duration(milliseconds: 100));
 
-              final tileFinder = find.byType(switch (view) {
-                Views.week => EventTile,
-                Views.month => MultiDayEventTile,
-                _ => MultiDayEventTile,
-              }).first;
+            final tileFinder = find.byType(switch (view) {
+              Views.week => EventTile,
+              Views.month => MultiDayEventTile,
+              _ => MultiDayEventTile,
+            }).first;
 
-              final size = tester.getSize(tileFinder);
+            final size = tester.getSize(tileFinder);
 
-              final gesture = await tester.createGesture();
-              await gesture.addPointer(location: Offset.zero);
-              addTearDown(gesture.removePointer);
-              await tester.pump();
+            final gesture = await tester.createGesture();
+            await gesture.addPointer(location: Offset.zero);
+            addTearDown(gesture.removePointer);
+            await tester.pump();
 
-              final dragStart =
-                  tester.getCenter(tileFinder) +
-                  switch (view) {
-                    Views.week => Offset(0, (size.height / 2) - 2),
-                    Views.month => Offset((size.width / 2) - 2, 0),
-                    _ => const Offset(0, 0),
-                  };
+            final dragStart =
+                tester.getCenter(tileFinder) +
+                switch (view) {
+                  Views.week => Offset(0, (size.height / 2) - 2),
+                  Views.month => Offset((size.width / 2) - 2, 0),
+                  _ => const Offset(0, 0),
+                };
 
-              await binding.traceAction(
-                () async {
-                  await gesture.moveTo(dragStart);
-                  await tester.pumpAndSettle(Duration(milliseconds: 200));
-                  await gesture.down(dragStart);
-                  await performSegmentedDrag(
-                    gesture,
-                    tester,
-                    dragStart,
-                    dragStart +
-                        switch (view) {
-                          Views.week => Offset(0, 50),
-                          Views.month => Offset(100, 0),
-                          _ => const Offset(0, 0),
-                        },
-                  );
-                  await tester.pumpAndSettle();
-
-                  await gesture.up();
-                  await tester.pumpAndSettle(Duration(milliseconds: 100));
-                },
-                reportKey: scenario.getReportKey(
-                  view,
-                  ReportKeys.resizing,
-                  run,
-                ),
+            await binding.traceAction(() async {
+              await gesture.moveTo(dragStart);
+              await tester.pumpAndSettle(Duration(milliseconds: 200));
+              await gesture.down(dragStart);
+              await performSegmentedDrag(
+                gesture,
+                tester,
+                dragStart,
+                dragStart +
+                    switch (view) {
+                      Views.week => Offset(0, 50),
+                      Views.month => Offset(100, 0),
+                      _ => const Offset(0, 0),
+                    },
               );
-            },
-          );
+              await tester.pumpAndSettle();
+
+              await gesture.up();
+              await tester.pumpAndSettle(Duration(milliseconds: 100));
+            }, reportKey: scenario.getReportKey(view, ReportKeys.resizing, run));
+          });
         }
       }
     }

--- a/examples/testing/integration_test/utils.dart
+++ b/examples/testing/integration_test/utils.dart
@@ -25,10 +25,7 @@ Future<void> performSegmentedDrag(
   for (int i = 1; i <= segmentCount; i++) {
     final t = i / segmentCount;
     final intermediate = Offset.lerp(start, end, t)!;
-    await dragGesture.moveTo(
-      intermediate,
-      timeStamp: Duration(milliseconds: segmentDurationMs * i),
-    );
+    await dragGesture.moveTo(intermediate, timeStamp: Duration(milliseconds: segmentDurationMs * i));
     await tester.pump(Duration(milliseconds: pumpDurationMs));
   }
 }
@@ -56,6 +53,5 @@ extension ViewUtils on Views {
 }
 
 extension ScenarioUtils on Scenario {
-  List<KalenderTimeRange> get eventRanges =>
-      timeOfDayRanges.take(numberOfEvents).toList();
+  List<KalenderTimeRange> get eventRanges => timeOfDayRanges.take(numberOfEvents).toList();
 }

--- a/examples/testing/lib/main.dart
+++ b/examples/testing/lib/main.dart
@@ -5,9 +5,7 @@ import 'package:testing/tiles.dart';
 
 void main() {
   final config = TestConfiguration.week();
-  config.eventsController.addEvents(
-    TestConfiguration.generate(timeOfDayRanges.take(10).toList()),
-  );
+  config.eventsController.addEvents(TestConfiguration.generate(timeOfDayRanges.take(10).toList()));
   runApp(MyApp(config: config));
 }
 
@@ -19,9 +17,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Performance Profiling',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-      ),
+      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue)),
       home: Home(config: config),
     );
   }
@@ -36,8 +32,7 @@ class Home extends StatefulWidget {
 }
 
 class _HomeState extends State<Home> {
-  late final TestConfiguration config =
-      widget.config ?? TestConfiguration.week();
+  late final TestConfiguration config = widget.config ?? TestConfiguration.week();
   EventsController get eventsController => config.eventsController;
   CalendarController get calendarController => config.calendarController;
 
@@ -50,14 +45,11 @@ class _HomeState extends State<Home> {
         viewConfiguration: config.viewConfiguration,
         components: CalendarComponents(),
         callbacks: CalendarCallbacks(
-          onEventTapped: (event) =>
-              calendarController.selectEvent(event),
+          onEventTapped: (event) => calendarController.selectEvent(event),
           onEventCreate: (event) => event,
           onEventCreated: (event) => eventsController.addEvent(event),
-          onEventChanged: (event, updatedEvent) => eventsController.updateEvent(
-            event: event,
-            updatedEvent: updatedEvent,
-          ),
+          onEventChanged: (event, updatedEvent) =>
+              eventsController.updateEvent(event: event, updatedEvent: updatedEvent),
         ),
         header: CalendarHeader(multiDayTileComponents: _multiDayTileComponents),
         body: CalendarBody(
@@ -73,35 +65,26 @@ class _HomeState extends State<Home> {
     return TileComponents(
       tileBuilder: (context, event, range) => EventTile.builder(event as Event, range),
       dropTargetTile: (context, event) => DropTargetTile.builder(event as Event),
-      feedbackTileBuilder: (context, event, size) =>
-          FeedbackTile.builder(event as Event, size),
-      tileWhenDraggingBuilder: (context, event) =>
-          TileWhenDragging.builder(event as Event),
+      feedbackTileBuilder: (context, event, size) => FeedbackTile.builder(event as Event, size),
+      tileWhenDraggingBuilder: (context, event) => TileWhenDragging.builder(event as Event),
     );
   }
 
   TileComponents get _multiDayTileComponents {
     return TileComponents(
-      tileBuilder: (context, event, range) =>
-          MultiDayEventTile.builder(event as Event, range),
-      overlayTileBuilder: (context, event, range) =>
-          OverlayEventTile.builder(event as Event, range),
+      tileBuilder: (context, event, range) => MultiDayEventTile.builder(event as Event, range),
+      overlayTileBuilder: (context, event, range) => OverlayEventTile.builder(event as Event, range),
       dropTargetTile: (context, event) => DropTargetTile.builder(event as Event),
-      feedbackTileBuilder: (context, event, size) =>
-          FeedbackTile.builder(event as Event, size),
-      tileWhenDraggingBuilder: (context, event) =>
-          TileWhenDragging.builder(event as Event),
+      feedbackTileBuilder: (context, event, size) => FeedbackTile.builder(event as Event, size),
+      tileWhenDraggingBuilder: (context, event) => TileWhenDragging.builder(event as Event),
     );
   }
 
   ScheduleTileComponents get _scheduleTileComponents {
     return ScheduleTileComponents(
-      tileBuilder: (context, event, range) =>
-          MultiDayEventTile.builder(event as Event, range),
-      feedbackTileBuilder: (context, event, size) =>
-          FeedbackTile.builder(event as Event, size),
-      tileWhenDraggingBuilder: (context, event) =>
-          TileWhenDragging.builder(event as Event),
+      tileBuilder: (context, event, range) => MultiDayEventTile.builder(event as Event, range),
+      feedbackTileBuilder: (context, event, size) => FeedbackTile.builder(event as Event, size),
+      tileWhenDraggingBuilder: (context, event) => TileWhenDragging.builder(event as Event),
     );
   }
 }

--- a/examples/testing/lib/test_configuration.dart
+++ b/examples/testing/lib/test_configuration.dart
@@ -7,16 +7,10 @@ class TestConfiguration {
   TestConfiguration({required this.viewConfiguration});
 
   TestConfiguration.week()
-    : viewConfiguration = MultiDayViewConfiguration.week(
-        displayRange: testRange,
-        initialDateTime: initialDateTime,
-      );
+    : viewConfiguration = MultiDayViewConfiguration.week(displayRange: testRange, initialDateTime: initialDateTime);
 
   TestConfiguration.month()
-    : viewConfiguration = MonthViewConfiguration.singleMonth(
-        displayRange: testRange,
-        initialDateTime: initialDateTime,
-      );
+    : viewConfiguration = MonthViewConfiguration.singleMonth(displayRange: testRange, initialDateTime: initialDateTime);
 
   TestConfiguration.schedule()
     : viewConfiguration = ScheduleViewConfiguration.continuous(
@@ -43,10 +37,8 @@ class TestConfiguration {
       for (var date in InternalDateTimeRange.fromDateTimeRange(testRange).dates()) ...[
         for (var timeOfDayRange in timeOfDayRanges)
           Event(
-            dateTimeRange: KalenderDateTimeRange(
-              start: timeOfDayRange.start.toInternalDateTime(date),
-              end: timeOfDayRange.end.toInternalDateTime(date),
-            ),
+            start: timeOfDayRange.start.toInternalDateTime(date),
+            end: timeOfDayRange.end.toInternalDateTime(date),
             title: 'Event',
             description: '${date.year}-${date.month}-${date.day} ${timeOfDayRange.start.hour}',
             color: Colors.primaries[date.day % Colors.primaries.length],
@@ -62,7 +54,8 @@ class TestConfiguration {
 class Event extends CalendarEvent {
   Event({
     super.id,
-    required super.dateTimeRange,
+    required super.start,
+    required super.end,
     required this.title,
     this.description,
     this.color,
@@ -80,98 +73,38 @@ class Event extends CalendarEvent {
   final Color? color;
 
   @override
-  Event copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return Event(dateTimeRange: dateTimeRange, title: title, description: description, color: color);
+  Event copyWithData({required DateTime start, required DateTime end}) {
+    return Event(start: start, end: end, title: title, description: description, color: color);
   }
 }
 
 final timeOfDayRanges = [
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 5, minute: 0),
-    end: const KalenderTime(hour: 6, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 5, minute: 30),
-    end: const KalenderTime(hour: 6, minute: 15),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 6, minute: 0),
-    end: const KalenderTime(hour: 8, minute: 15),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 8, minute: 0),
-    end: const KalenderTime(hour: 9, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 8, minute: 30),
-    end: const KalenderTime(hour: 10, minute: 0),
-  ),
+  KalenderTimeRange(start: const KalenderTime(hour: 5, minute: 0), end: const KalenderTime(hour: 6, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 5, minute: 30), end: const KalenderTime(hour: 6, minute: 15)),
+  KalenderTimeRange(start: const KalenderTime(hour: 6, minute: 0), end: const KalenderTime(hour: 8, minute: 15)),
+  KalenderTimeRange(start: const KalenderTime(hour: 8, minute: 0), end: const KalenderTime(hour: 9, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 8, minute: 30), end: const KalenderTime(hour: 10, minute: 0)),
 
   /// 5
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 9, minute: 0),
-    end: const KalenderTime(hour: 10, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 10, minute: 0),
-    end: const KalenderTime(hour: 11, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 12, minute: 0),
-    end: const KalenderTime(hour: 13, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 13, minute: 0),
-    end: const KalenderTime(hour: 14, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 8, minute: 0),
-    end: const KalenderTime(hour: 14, minute: 0),
-  ),
+  KalenderTimeRange(start: const KalenderTime(hour: 9, minute: 0), end: const KalenderTime(hour: 10, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 10, minute: 0), end: const KalenderTime(hour: 11, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 12, minute: 0), end: const KalenderTime(hour: 13, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 13, minute: 0), end: const KalenderTime(hour: 14, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 8, minute: 0), end: const KalenderTime(hour: 14, minute: 0)),
 
   /// 5
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 14, minute: 0),
-    end: const KalenderTime(hour: 15, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 14, minute: 30),
-    end: const KalenderTime(hour: 15, minute: 30),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 15, minute: 0),
-    end: const KalenderTime(hour: 16, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 16, minute: 0),
-    end: const KalenderTime(hour: 17, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 8, minute: 0),
-    end: const KalenderTime(hour: 17, minute: 0),
-  ),
+  KalenderTimeRange(start: const KalenderTime(hour: 14, minute: 0), end: const KalenderTime(hour: 15, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 14, minute: 30), end: const KalenderTime(hour: 15, minute: 30)),
+  KalenderTimeRange(start: const KalenderTime(hour: 15, minute: 0), end: const KalenderTime(hour: 16, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 16, minute: 0), end: const KalenderTime(hour: 17, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 8, minute: 0), end: const KalenderTime(hour: 17, minute: 0)),
 
   /// 5
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 17, minute: 0),
-    end: const KalenderTime(hour: 18, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 17, minute: 30),
-    end: const KalenderTime(hour: 18, minute: 30),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 18, minute: 0),
-    end: const KalenderTime(hour: 19, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 19, minute: 0),
-    end: const KalenderTime(hour: 20, minute: 0),
-  ),
-  KalenderTimeRange(
-    start: const KalenderTime(hour: 20, minute: 0),
-    end: const KalenderTime(hour: 21, minute: 0),
-  ),
+  KalenderTimeRange(start: const KalenderTime(hour: 17, minute: 0), end: const KalenderTime(hour: 18, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 17, minute: 30), end: const KalenderTime(hour: 18, minute: 30)),
+  KalenderTimeRange(start: const KalenderTime(hour: 18, minute: 0), end: const KalenderTime(hour: 19, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 19, minute: 0), end: const KalenderTime(hour: 20, minute: 0)),
+  KalenderTimeRange(start: const KalenderTime(hour: 20, minute: 0), end: const KalenderTime(hour: 21, minute: 0)),
 
   /// Additional generated ranges (indices 20–49) so the heavy
   /// 50-events-per-day scenario has enough distinct slots. Spread across the

--- a/examples/testing/lib/tiles.dart
+++ b/examples/testing/lib/tiles.dart
@@ -5,27 +5,18 @@ import 'package:testing/test_configuration.dart';
 abstract class BaseEventTile extends StatelessWidget {
   final Event event;
   final KalenderDateTimeRange tileRange;
-  const BaseEventTile({
-    super.key,
-    required this.event,
-    required this.tileRange,
-  });
+  const BaseEventTile({super.key, required this.event, required this.tileRange});
 
   static const defaultColor = Colors.blueGrey;
   Color get color => event.color ?? defaultColor;
-  Color textColor(Color color) =>
-      color.computeLuminance() > 0.5 ? Colors.black : Colors.white;
+  Color textColor(Color color) => color.computeLuminance() > 0.5 ? Colors.black : Colors.white;
 
   bool get continuesAfter => event.dateTimeRange.end.isAfter(tileRange.end);
-  bool get continuesBefore =>
-      event.dateTimeRange.start.isBefore(tileRange.start);
+  bool get continuesBefore => event.dateTimeRange.start.isBefore(tileRange.start);
   String title(BuildContext context) => "${event.title} (${event.id})";
 
   static BorderRadius defaultBorderRadius = BorderRadius.circular(8);
-  BoxDecoration get decoration => BoxDecoration(
-    color: color.withAlpha(150),
-    borderRadius: defaultBorderRadius,
-  );
+  BoxDecoration get decoration => BoxDecoration(color: color.withAlpha(150), borderRadius: defaultBorderRadius);
 }
 
 class EventTile extends BaseEventTile {
@@ -49,17 +40,12 @@ class EventTile extends BaseEventTile {
 }
 
 class MultiDayEventTile extends BaseEventTile {
-  const MultiDayEventTile({
-    super.key,
-    required super.event,
-    required super.tileRange,
-  });
+  const MultiDayEventTile({super.key, required super.event, required super.tileRange});
   static MultiDayEventTile builder(Event event, KalenderDateTimeRange tileRange) {
     return MultiDayEventTile(event: event, tileRange: tileRange);
   }
 
-  EdgeInsets get padding =>
-      const EdgeInsets.symmetric(vertical: 1, horizontal: 4);
+  EdgeInsets get padding => const EdgeInsets.symmetric(vertical: 1, horizontal: 4);
 
   static Key getKey(String id) => Key('MultiDayEventTile-$id');
 
@@ -81,18 +67,13 @@ class MultiDayEventTile extends BaseEventTile {
 }
 
 class OverlayEventTile extends BaseEventTile {
-  const OverlayEventTile({
-    super.key,
-    required super.event,
-    required super.tileRange,
-  });
+  const OverlayEventTile({super.key, required super.event, required super.tileRange});
 
   static OverlayEventTile builder(Event event, KalenderDateTimeRange tileRange) {
     return OverlayEventTile(event: event, tileRange: tileRange);
   }
 
-  EdgeInsets get padding =>
-      const EdgeInsets.symmetric(vertical: 1, horizontal: 4);
+  EdgeInsets get padding => const EdgeInsets.symmetric(vertical: 1, horizontal: 4);
 
   @override
   Widget build(BuildContext context) {
@@ -102,29 +83,15 @@ class OverlayEventTile extends BaseEventTile {
           left: continuesBefore ? 20 : 0,
           right: continuesAfter ? 20 : 0,
           child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: color.withAlpha(150),
-              borderRadius: BorderRadius.circular(8),
-            ),
+            decoration: BoxDecoration(color: color.withAlpha(150), borderRadius: BorderRadius.circular(8)),
             child: Padding(
               padding: padding,
-              child: Text(
-                title(context),
-                style: TextStyle(color: textColor(color)),
-              ),
+              child: Text(title(context), style: TextStyle(color: textColor(color))),
             ),
           ),
         ),
-        if (continuesAfter)
-          const Align(
-            alignment: Alignment.centerRight,
-            child: Icon(Icons.chevron_right),
-          ),
-        if (continuesBefore)
-          const Align(
-            alignment: Alignment.centerLeft,
-            child: Icon(Icons.chevron_left),
-          ),
+        if (continuesAfter) const Align(alignment: Alignment.centerRight, child: Icon(Icons.chevron_right)),
+        if (continuesBefore) const Align(alignment: Alignment.centerLeft, child: Icon(Icons.chevron_left)),
       ],
     );
   }
@@ -133,16 +100,9 @@ class OverlayEventTile extends BaseEventTile {
 class FeedbackTile extends StatelessWidget {
   final Event event;
   final Size dropTargetWidgetSize;
-  const FeedbackTile({
-    super.key,
-    required this.event,
-    required this.dropTargetWidgetSize,
-  });
+  const FeedbackTile({super.key, required this.event, required this.dropTargetWidgetSize});
   static FeedbackTile builder(Event event, Size dropTargetWidgetSize) {
-    return FeedbackTile(
-      event: event,
-      dropTargetWidgetSize: dropTargetWidgetSize,
-    );
+    return FeedbackTile(event: event, dropTargetWidgetSize: dropTargetWidgetSize);
   }
 
   @override
@@ -170,10 +130,7 @@ class DropTargetTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        border: Border.all(
-          color: (event.color ?? BaseEventTile.defaultColor),
-          width: 2,
-        ),
+        border: Border.all(color: (event.color ?? BaseEventTile.defaultColor), width: 2),
         borderRadius: BaseEventTile.defaultBorderRadius,
       ),
     );

--- a/examples/testing/test_driver/perf_driver.dart
+++ b/examples/testing/test_driver/perf_driver.dart
@@ -17,8 +17,7 @@ enum Scenario {
   const Scenario(this.numberOfEvents);
   final int numberOfEvents;
 
-  String getReportKey(Views view, ReportKeys key, int run) =>
-      '${name.toLowerCase()}-${view.name}-${key.name}-$run';
+  String getReportKey(Views view, ReportKeys key, int run) => '${name.toLowerCase()}-${view.name}-${key.name}-$run';
 
   static String baseKeyFromReportKey(String key) {
     return key.split('-').take(3).join('-');
@@ -112,7 +111,8 @@ Future<void> main() {
           return suffix == 'ms' ? '${median.toStringAsFixed(fraction)}ms' : '${median.round()}';
         }
 
-        final extra = 'p90_build=${fmt(_p90Metric)} '
+        final extra =
+            'p90_build=${fmt(_p90Metric)} '
             'p99_build=${fmt(_p99Metric)} '
             'missed_build=${fmt(_missedBuildMetric, suffix: 'count')} '
             '(runs=${buildValues.length})';

--- a/examples/web_demo/lib/models/event.dart
+++ b/examples/web_demo/lib/models/event.dart
@@ -8,7 +8,8 @@ class Event extends CalendarEvent {
   /// Creates an [Event].
   Event({
     super.id,
-    required super.dateTimeRange,
+    required super.start,
+    required super.end,
     required this.title,
     this.description,
     this.color,
@@ -30,18 +31,19 @@ class Event extends CalendarEvent {
   /// The id, the interaction config and the rule are restored by [CalendarEvent]
   /// afterwards, so they are deliberately not listed here.
   @override
-  Event copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return Event(dateTimeRange: dateTimeRange, title: title, description: description, color: color);
+  Event copyWithData({required DateTime start, required DateTime end}) {
+    return Event(start: start, end: end, title: title, description: description, color: color);
   }
 
   /// A copy with the given fields replaced.
   ///
   /// This is the demo's own method rather than an override, so it takes whatever
   /// parameters are useful here. [carryOver] keeps the copy's identity.
-  Event copyWith({KalenderDateTimeRange? dateTimeRange, String? title, String? description, Color? color}) {
+  Event copyWith({DateTime? start, DateTime? end, String? title, String? description, Color? color}) {
     return carryOver(
       Event(
-        dateTimeRange: dateTimeRange ?? this.dateTimeRange,
+        start: start ?? this.start,
+        end: end ?? this.end,
         title: title ?? this.title,
         description: description ?? this.description,
         color: color ?? this.color,

--- a/examples/web_demo/lib/utils.dart
+++ b/examples/web_demo/lib/utils.dart
@@ -77,7 +77,8 @@ List<CalendarEvent> generateEvents(BuildContext context) {
   Event timed(DateTime day, int hour, int minute, Duration duration, String title, Color color, {String? description}) {
     final start = DateTime(day.year, day.month, day.day, hour, minute);
     return Event(
-      dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(duration)),
+      start: start,
+      end: start.add(duration),
       title: title,
       description: description,
       color: color,
@@ -144,7 +145,8 @@ List<CalendarEvent> generateEvents(BuildContext context) {
     final start = today.add(Duration(days: startOffset));
     events.add(
       Event(
-        dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(Duration(days: days))),
+        start: start,
+        end: start.add(Duration(days: days)),
         title: title,
         description: description,
         color: color,

--- a/examples/web_demo/lib/widgets/calendar/calendar.dart
+++ b/examples/web_demo/lib/widgets/calendar/calendar.dart
@@ -261,7 +261,8 @@ class _CalendarContentState extends State<CalendarContent> {
         },
         onTapped: (_) => context.controller.deselectEvent(),
         onEventCreate: (event) => Event(
-          dateTimeRange: KalenderDateTimeRange(start: event.start, end: event.end),
+          start: event.start,
+          end: event.end,
           title: context.l10n.newEventTitle,
         ),
         onEventCreated: (event) => context.eventsController.addEvent(event),
@@ -271,11 +272,13 @@ class _CalendarContentState extends State<CalendarContent> {
         ),
         onLongPressedWithDetail: (TapDetail detail) {
           final range = switch (detail) {
-            DayDetail detail => KalenderDateTimeRange(start: detail.date, end: detail.date.add(const Duration(minutes: 45))),
+            DayDetail detail =>
+              KalenderDateTimeRange(start: detail.date, end: detail.date.add(const Duration(minutes: 45))),
             MultiDayDetail detail => detail.dateTimeRange,
             _ => throw Exception('Unsupported detail type: ${detail.runtimeType}'),
           };
-          context.eventsController.addEvent(Event(dateTimeRange: range, title: context.l10n.newEventTitle));
+          context.eventsController
+              .addEvent(Event(start: range.start, end: range.end, title: context.l10n.newEventTitle));
         },
       );
 }

--- a/examples/web_demo/lib/widgets/calendar/detail_card.dart
+++ b/examples/web_demo/lib/widgets/calendar/detail_card.dart
@@ -226,7 +226,7 @@ class _EventDetailCardState extends State<EventDetailCard> {
   }
 
   void _updateEvent(KalenderDateTimeRange newRange) {
-    final updatedEvent = event.copyWith(dateTimeRange: newRange);
+    final updatedEvent = event.copyWith(start: newRange.start, end: newRange.end);
     widget.eventsController.updateEvent(event: event, updatedEvent: updatedEvent);
     setState(() => event = updatedEvent);
   }

--- a/examples/web_demo/lib/widgets/calendar/detail_overlay.dart
+++ b/examples/web_demo/lib/widgets/calendar/detail_overlay.dart
@@ -40,7 +40,8 @@ class EventDetailOverlayState extends State<EventDetailOverlay> with SingleTicke
     // the first access would be in dispose(), where the ticker's context lookup
     // is unsafe.
     _animationController = AnimationController(vsync: this, duration: const Duration(milliseconds: 150));
-    _curvedAnimation = CurvedAnimation(parent: _animationController, curve: Curves.easeOut, reverseCurve: Curves.easeIn);
+    _curvedAnimation =
+        CurvedAnimation(parent: _animationController, curve: Curves.easeOut, reverseCurve: Curves.easeIn);
     _scaleAnimation = Tween<double>(begin: 0.85, end: 1.0).animate(_curvedAnimation);
   }
 

--- a/examples/web_demo/lib/widgets/toolbar/text_direction_button.dart
+++ b/examples/web_demo/lib/widgets/toolbar/text_direction_button.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:web_demo/utils.dart';
 
-
 class TextDirectionButton extends StatelessWidget {
   const TextDirectionButton({super.key});
 
@@ -10,11 +9,10 @@ class TextDirectionButton extends StatelessWidget {
     return ValueListenableBuilder(
       valueListenable: context.textDirectionNotifier,
       builder: (context, textDirection, _) => IconButton.filledTonal(
-        onPressed: () => context.textDirectionNotifier.value = textDirection == TextDirection.ltr ? TextDirection.rtl : TextDirection.ltr,
+        onPressed: () => context.textDirectionNotifier.value =
+            textDirection == TextDirection.ltr ? TextDirection.rtl : TextDirection.ltr,
         icon: Icon(
-          textDirection == TextDirection.ltr
-              ? Icons.format_textdirection_l_to_r
-              : Icons.format_textdirection_r_to_l,
+          textDirection == TextDirection.ltr ? Icons.format_textdirection_l_to_r : Icons.format_textdirection_r_to_l,
         ),
       ),
     );

--- a/lib/src/models/calendar_events/calendar_event.dart
+++ b/lib/src/models/calendar_events/calendar_event.dart
@@ -14,7 +14,8 @@ import 'package:meta/meta.dart';
 /// class Event extends CalendarEvent {
 ///   Event({
 ///     super.id,
-///     required super.dateTimeRange,
+///     required super.start,
+///     required super.end,
 ///     required this.title,
 ///     super.interaction,
 ///     super.multiDayRule,
@@ -22,8 +23,8 @@ import 'package:meta/meta.dart';
 ///   final String title;
 ///
 ///   @override
-///   Event copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-///     return Event(dateTimeRange: dateTimeRange, title: title);
+///   Event copyWithData({required DateTime start, required DateTime end}) {
+///     return Event(start: start, end: end, title: title);
 ///   }
 ///
 ///   @override
@@ -75,17 +76,20 @@ class CalendarEvent {
 
   /// Creates a [CalendarEvent].
   ///
-  /// [dateTimeRange] is stored in UTC. A unique [id] is generated if omitted.
-  /// [interaction] defaults to fully modifiable.
+  /// [start] and [end] are stored in UTC, and [start] must not be after [end].
+  /// A unique [id] is generated if omitted. [interaction] defaults to fully
+  /// modifiable.
   CalendarEvent({
     String? id,
-    required KalenderDateTimeRange dateTimeRange,
+    required DateTime start,
+    required DateTime end,
     EventInteraction? interaction,
     MultiDayRule? multiDayRule,
     bool isAllDay = false,
-  })  : id = id ?? _createUniqueId(),
-        start = dateTimeRange.start.toUtc(),
-        end = dateTimeRange.end.toUtc(),
+  })  : assert(!start.isAfter(end), 'start must not be after end'),
+        id = id ?? _createUniqueId(),
+        start = start.toUtc(),
+        end = end.toUtc(),
         _multiDayRule = multiDayRule,
         _isAllDay = isAllDay,
         _interaction = interaction ?? EventInteraction.fromCanModify(true);
@@ -117,7 +121,7 @@ class CalendarEvent {
       InternalDateTimeRange(start: internalStart(location: location), end: internalEnd(location: location));
 
   /// Total duration (UTC-based).
-  Duration get duration => dateTimeRange.duration;
+  Duration get duration => end.difference(start);
 
   /// Whether this event belongs in the multi-day header lane rather than the
   /// day timeline, with calendar days measured in [location].
@@ -144,7 +148,7 @@ class CalendarEvent {
   /// config and its rule whatever the subclass returns.
   @nonVirtual
   CalendarEvent withDateTimeRange(KalenderDateTimeRange dateTimeRange) {
-    final copy = copyWithData(dateTimeRange: dateTimeRange);
+    final copy = copyWithData(start: dateTimeRange.start, end: dateTimeRange.end);
 
     assert(
       copy.runtimeType == runtimeType,
@@ -156,7 +160,7 @@ class CalendarEvent {
     return carryOver(copy);
   }
 
-  /// Rebuilds this event covering [dateTimeRange], keeping the data this
+  /// Rebuilds this event covering [start] to [end], keeping the data this
   /// subclass adds.
   ///
   /// Override this and return a new instance of your own type. Do not forward
@@ -165,8 +169,8 @@ class CalendarEvent {
   /// field added to [CalendarEvent] later from silently going missing.
   @protected
   @mustBeOverridden
-  CalendarEvent copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return CalendarEvent(dateTimeRange: dateTimeRange);
+  CalendarEvent copyWithData({required DateTime start, required DateTime end}) {
+    return CalendarEvent(start: start, end: end);
   }
 
   /// Reapplies the state [CalendarEvent] holds to [copy], and returns it.
@@ -176,7 +180,7 @@ class CalendarEvent {
   ///
   /// ```dart
   /// Event copyWith({String? title}) {
-  ///   return carryOver(Event(dateTimeRange: dateTimeRange, title: title ?? this.title));
+  ///   return carryOver(Event(start: start, end: end, title: title ?? this.title));
   /// }
   /// ```
   @protected

--- a/lib/src/widgets/draggable/new_draggable.dart
+++ b/lib/src/widgets/draggable/new_draggable.dart
@@ -21,7 +21,8 @@ mixin NewDraggableWidget {
   /// Create the new event and select it where needed.
   void createNewEvent(BuildContext context, InternalDateTime date, Offset localPosition) {
     final dateTimeRange = calculateDateTimeRange(date, localPosition);
-    final newEvent = CalendarEvent(dateTimeRange: dateTimeRange.forLocation(location: context.location));
+    final range = dateTimeRange.forLocation(location: context.location);
+    final newEvent = CalendarEvent(start: range.start, end: range.end);
 
     CalendarEvent? event;
     if (callbacks?.onEventCreateWithDetail != null) {

--- a/test/configuration/view_configuration_multi_day_rule_test.dart
+++ b/test/configuration/view_configuration_multi_day_rule_test.dart
@@ -55,7 +55,8 @@ void main() {
     // classify differently.
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 15, 22), end: DateTime(2025, 1, 16, 2)),
+        start: DateTime(2025, 1, 15, 22),
+        end: DateTime(2025, 1, 16, 2),
       ),
     );
     final base = MultiDayViewConfiguration.week(

--- a/test/configuration/view_configuration_test.dart
+++ b/test/configuration/view_configuration_test.dart
@@ -60,7 +60,7 @@ void main() {
       final key = start.copyWith(year: start.year, month: start.month, day: start.day + i);
       final end = key.copyWith(hour: start.hour + 1);
       final value = eventsController.addEvent(
-        CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: key, end: end)),
+        CalendarEvent(start: key, end: end),
       );
       return MapEntry<DateTime, String>(key, value);
     },

--- a/test/interactions/calendar_callback_test.dart
+++ b/test/interactions/calendar_callback_test.dart
@@ -245,7 +245,8 @@ void main() {
 
       final id = eventsController.addEvent(
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 12)),
+          start: DateTime(2025, 1, 1, 1),
+          end: DateTime(2025, 1, 1, 12),
         ),
       );
       await tester.pumpAndSettle();
@@ -276,7 +277,8 @@ void main() {
 
       final id = eventsController.addEvent(
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 12)),
+          start: DateTime(2025, 1, 1, 1),
+          end: DateTime(2025, 1, 1, 12),
         ),
       );
       await tester.pumpAndSettle();
@@ -502,7 +504,7 @@ void main() {
       );
 
       final id = eventsController.addEvent(
-        CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1), end: DateTime(2025, 1, 1, 1))),
+        CalendarEvent(start: DateTime(2025, 1, 1), end: DateTime(2025, 1, 1, 1)),
       );
       await tester.pumpAndSettle();
 
@@ -531,7 +533,7 @@ void main() {
       );
 
       final id = eventsController.addEvent(
-        CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1), end: DateTime(2025, 1, 1, 1))),
+        CalendarEvent(start: DateTime(2025, 1, 1), end: DateTime(2025, 1, 1, 1)),
       );
       await tester.pumpAndSettle();
 
@@ -708,7 +710,8 @@ void main() {
 
       final id = eventsController.addEvent(
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 12)),
+          start: DateTime(2025, 1, 1, 1),
+          end: DateTime(2025, 1, 1, 12),
         ),
       );
       await tester.pumpAndSettle();
@@ -769,7 +772,7 @@ void main() {
       );
 
       final id = eventsController.addEvent(
-        CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1), end: DateTime(2025, 1, 1, 1))),
+        CalendarEvent(start: DateTime(2025, 1, 1), end: DateTime(2025, 1, 1, 1)),
       );
       await tester.pumpAndSettle();
 

--- a/test/interactions/drag_target_edge_cases_test.dart
+++ b/test/interactions/drag_target_edge_cases_test.dart
@@ -49,18 +49,14 @@ final _restrictedRange = KalenderTimeRange(
 
 /// A single-day event (2 h) on Jan 6, 2025.
 CalendarEvent _singleDayEvent({DateTime? start, DateTime? end}) => CalendarEvent(
-      dateTimeRange: KalenderDateTimeRange(
-        start: start ?? DateTime(2025, 1, 6, 10, 0),
-        end: end ?? DateTime(2025, 1, 6, 12, 0),
-      ),
+      start: start ?? DateTime(2025, 1, 6, 10, 0),
+      end: end ?? DateTime(2025, 1, 6, 12, 0),
     );
 
 /// A midnight-to-midnight event (always spans multiple days).
 CalendarEvent _multiDayEvent() => CalendarEvent(
-      dateTimeRange: KalenderDateTimeRange(
-        start: DateTime(2025, 1, 6, 0, 0),
-        end: DateTime(2025, 1, 7, 0, 0),
-      ),
+      start: DateTime(2025, 1, 6, 0, 0),
+      end: DateTime(2025, 1, 7, 0, 0),
     );
 
 DragTargetDetails<Object?> _dragDetails(Object? data) => DragTargetDetails(data: data, offset: Offset.zero);
@@ -284,10 +280,8 @@ void main() {
 
       // 10-hour event (> 8h 1min range duration) — still a single-day event
       final hugeEvent = CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: DateTime(2025, 1, 6, 8, 0),
-          end: DateTime(2025, 1, 6, 18, 0),
-        ),
+        start: DateTime(2025, 1, 6, 8, 0),
+        end: DateTime(2025, 1, 6, 18, 0),
       );
       expect(hugeEvent.spansMultipleDays(location: null, defaultRule: kDefaultMultiDayRule), isFalse);
 
@@ -716,10 +710,8 @@ void main() {
       final ec = DefaultEventsController();
       ec.addEvent(
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 1, 6, 10),
-            end: DateTime(2025, 1, 6, 12),
-          ),
+          start: DateTime(2025, 1, 6, 10),
+          end: DateTime(2025, 1, 6, 12),
         ),
       );
 

--- a/test/interactions/drag_target_utils_test.dart
+++ b/test/interactions/drag_target_utils_test.dart
@@ -60,7 +60,8 @@ void main() {
   CalendarEvent eventWithId(String id) {
     return CalendarEvent(
       id: id,
-      dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 9), end: DateTime.utc(2024, 1, 15, 10)),
+      start: DateTime.utc(2024, 1, 15, 9),
+      end: DateTime.utc(2024, 1, 15, 10),
     );
   }
 

--- a/test/interactions/interaction_test.dart
+++ b/test/interactions/interaction_test.dart
@@ -47,20 +47,22 @@ void main() {
     calendarController = CalendarController();
 
     dayEventID = eventsController.addEvent(
-      CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 4))),
+      CalendarEvent(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 4)),
     );
     multiDayEventID = eventsController.addEvent(
-      CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1), end: DateTime(2025, 1, 2))),
+      CalendarEvent(start: DateTime(2025, 1, 1), end: DateTime(2025, 1, 2)),
     );
     customDayEventID = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 23)),
+        start: DateTime(2025, 1, 1, 1),
+        end: DateTime(2025, 1, 1, 23),
         interaction: EventInteraction(allowEndResize: true, allowStartResize: false, allowRescheduling: false),
       ),
     );
     customMultiDayEventID = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1), end: DateTime(2025, 1, 2)),
+        start: DateTime(2025, 1, 1),
+        end: DateTime(2025, 1, 2),
         interaction: EventInteraction(allowEndResize: true, allowStartResize: false, allowRescheduling: false),
       ),
     );

--- a/test/layout/event_layout_delegate_test.dart
+++ b/test/layout/event_layout_delegate_test.dart
@@ -16,19 +16,15 @@ void main() {
   // full width.
   final events = [
     CalendarEvent(
-      dateTimeRange: KalenderDateTimeRange(
-        start: date.copyWith(hour: 1, minute: 29),
-        end: date.copyWith(hour: 1, minute: 30),
-      ),
+      start: date.copyWith(hour: 1, minute: 29),
+      end: date.copyWith(hour: 1, minute: 30),
     ),
     CalendarEvent(
-      dateTimeRange: KalenderDateTimeRange(
-        start: date.copyWith(hour: 1, minute: 30),
-        end: date.copyWith(hour: 1, minute: 59, second: 59, microsecond: 999999),
-      ),
+      start: date.copyWith(hour: 1, minute: 30),
+      end: date.copyWith(hour: 1, minute: 59, second: 59, microsecond: 999999),
     ),
-    CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: date.copyWith(hour: 2), end: date.copyWith(hour: 3))),
-    CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: date.copyWith(hour: 3), end: date.copyWith(hour: 4))),
+    CalendarEvent(start: date.copyWith(hour: 2), end: date.copyWith(hour: 3)),
+    CalendarEvent(start: date.copyWith(hour: 3), end: date.copyWith(hour: 4)),
   ];
 
   final heightPerMinutes = List.generate(100, (i) => 0.1 + i / 100);

--- a/test/layout/event_overlap_rounding_test.dart
+++ b/test/layout/event_overlap_rounding_test.dart
@@ -14,10 +14,8 @@ void main() {
   // them on the delegate's date on any machine. UTC times would shift to a
   // different day under a non-UTC timezone and the events would be clamped out.
   CalendarEvent event(int startSeconds, int endSeconds) => CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: DateTime(2024, 1, 1).add(Duration(seconds: startSeconds)),
-          end: DateTime(2024, 1, 1).add(Duration(seconds: endSeconds)),
-        ),
+        start: DateTime(2024, 1, 1).add(Duration(seconds: startSeconds)),
+        end: DateTime(2024, 1, 1).add(Duration(seconds: endSeconds)),
       );
 
   int groupCountForTouchingPair({

--- a/test/layout/layout_data_per_child_test.dart
+++ b/test/layout/layout_data_per_child_test.dart
@@ -13,10 +13,8 @@ void main() {
   CalendarEvent event({String? id, int hour = 9}) {
     return CalendarEvent(
       id: id,
-      dateTimeRange: KalenderDateTimeRange(
-        start: DateTime.utc(2024, 1, 1, hour),
-        end: DateTime.utc(2024, 1, 1, hour + 1),
-      ),
+      start: DateTime.utc(2024, 1, 1, hour),
+      end: DateTime.utc(2024, 1, 1, hour + 1),
     );
   }
 
@@ -79,15 +77,13 @@ void main() {
 class _ConstantHashEvent extends CalendarEvent {
   _ConstantHashEvent({required int hour})
       : super(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime.utc(2024, 1, 1, hour),
-            end: DateTime.utc(2024, 1, 1, hour + 1),
-          ),
+          start: DateTime.utc(2024, 1, 1, hour),
+          end: DateTime.utc(2024, 1, 1, hour + 1),
         );
 
   @override
-  _ConstantHashEvent copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return _ConstantHashEvent(hour: dateTimeRange.start.toUtc().hour);
+  _ConstantHashEvent copyWithData({required DateTime start, required DateTime end}) {
+    return _ConstantHashEvent(hour: start.toUtc().hour);
   }
 
   @override

--- a/test/layout/multi_day_event_layout_test.dart
+++ b/test/layout/multi_day_event_layout_test.dart
@@ -134,10 +134,12 @@ void main() {
       // so the 26th is not included → 2 of the 7 visible columns).
       final events = [
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start, end: start.copyWith(day: start.day + 2)),
+          start: start,
+          end: start.copyWith(day: start.day + 2),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start, end: start.copyWith(day: start.day + 2)),
+          start: start,
+          end: start.copyWith(day: start.day + 2),
         ),
       ];
       eventsController.addEvents(events);
@@ -166,13 +168,16 @@ void main() {
     testWidgets('Basic', (tester) async {
       final events = [
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start, end: start.copyWith(day: start.day + 3)),
+          start: start,
+          end: start.copyWith(day: start.day + 3),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start, end: start.copyWith(day: start.day + 3)),
+          start: start,
+          end: start.copyWith(day: start.day + 3),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(const Duration(hours: 6))),
+          start: start,
+          end: start.add(const Duration(hours: 6)),
         ),
       ];
       eventsController.addEvents(events);
@@ -200,10 +205,8 @@ void main() {
 
     testWidgets('Drop target layout uses the selected event span during horizontal resize', (tester) async {
       final storedEvent = CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: DateTime(2025, 3, 24),
-          end: DateTime(2025, 3, 25),
-        ),
+        start: DateTime(2025, 3, 24),
+        end: DateTime(2025, 3, 25),
       );
       eventsController.addEvent(storedEvent);
 
@@ -249,40 +252,28 @@ void main() {
 
       final events = [
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 3, 24),
-            end: DateTime(2025, 3, 27),
-          ),
+          start: DateTime(2025, 3, 24),
+          end: DateTime(2025, 3, 27),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 3, 27),
-            end: DateTime(2025, 3, 30),
-          ),
+          start: DateTime(2025, 3, 27),
+          end: DateTime(2025, 3, 30),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 3, 24),
-            end: DateTime(2025, 3, 25),
-          ),
+          start: DateTime(2025, 3, 24),
+          end: DateTime(2025, 3, 25),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 3, 25),
-            end: DateTime(2025, 3, 28),
-          ),
+          start: DateTime(2025, 3, 25),
+          end: DateTime(2025, 3, 28),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 3, 28),
-            end: DateTime(2025, 3, 30),
-          ),
+          start: DateTime(2025, 3, 28),
+          end: DateTime(2025, 3, 30),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 3, 27),
-            end: DateTime(2025, 3, 30),
-          ),
+          start: DateTime(2025, 3, 27),
+          end: DateTime(2025, 3, 30),
         ),
       ];
       eventsController.addEvents(events);
@@ -317,28 +308,20 @@ void main() {
       ///                 |------4----|
       final events = [
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 3, 24),
-            end: DateTime(2025, 3, 27),
-          ),
+          start: DateTime(2025, 3, 24),
+          end: DateTime(2025, 3, 27),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 3, 27),
-            end: DateTime(2025, 3, 30),
-          ),
+          start: DateTime(2025, 3, 27),
+          end: DateTime(2025, 3, 30),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 3, 25),
-            end: DateTime(2025, 3, 28),
-          ),
+          start: DateTime(2025, 3, 25),
+          end: DateTime(2025, 3, 28),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 3, 27),
-            end: DateTime(2025, 3, 30),
-          ),
+          start: DateTime(2025, 3, 27),
+          end: DateTime(2025, 3, 30),
         ),
       ];
       eventsController.addEvents(events);
@@ -377,16 +360,20 @@ void main() {
       ///   |-4-|
       final events = [
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start.copyWith(hour: 6), end: start.copyWith(day: start.day + 3)),
+          start: start.copyWith(hour: 6),
+          end: start.copyWith(day: start.day + 3),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start, end: start.copyWith(day: start.day + 3)),
+          start: start,
+          end: start.copyWith(day: start.day + 3),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start.copyWith(hour: 3), end: start.copyWith(hour: 6)),
+          start: start.copyWith(hour: 3),
+          end: start.copyWith(hour: 6),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start.copyWith(hour: 7), end: start.copyWith(hour: 10)),
+          start: start.copyWith(hour: 7),
+          end: start.copyWith(hour: 10),
         ),
       ];
       eventsController.addEvents(events);
@@ -444,16 +431,20 @@ void main() {
       ///   |-4-|
       final events = [
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start, end: start.copyWith(hour: 12)),
+          start: start,
+          end: start.copyWith(hour: 12),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start, end: start.copyWith(hour: 8)),
+          start: start,
+          end: start.copyWith(hour: 8),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start.copyWith(hour: 3), end: start.copyWith(hour: 4)),
+          start: start.copyWith(hour: 3),
+          end: start.copyWith(hour: 4),
         ),
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start.copyWith(hour: 3), end: start.copyWith(hour: 16)),
+          start: start.copyWith(hour: 3),
+          end: start.copyWith(hour: 16),
         ),
       ];
       eventsController.addEvents(events);

--- a/test/models/calendar_event_test.dart
+++ b/test/models/calendar_event_test.dart
@@ -14,7 +14,8 @@ void main() {
   CalendarEvent eventUtc(DateTime start, DateTime end, {String? id, EventInteraction? interaction}) {
     return CalendarEvent(
       id: id,
-      dateTimeRange: KalenderDateTimeRange(start: start, end: end),
+      start: start,
+      end: end,
       interaction: interaction,
     );
   }
@@ -25,8 +26,7 @@ void main() {
     test('start and end are stored in UTC', () {
       // A non-UTC (local) input must be normalised to UTC on construction.
       final local = DateTime(2024, 1, 15, 9);
-      final event =
-          CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: local, end: local.add(const Duration(hours: 1))));
+      final event = CalendarEvent(start: local, end: local.add(const Duration(hours: 1)));
       expect(event.start.isUtc, isTrue);
       expect(event.end.isUtc, isTrue);
       expect(event.start, equals(local.toUtc()));
@@ -48,6 +48,30 @@ void main() {
     test('interaction defaults to fully modifiable', () {
       final event = eventUtc(DateTime.utc(2024, 1, 15, 9), DateTime.utc(2024, 1, 15, 10));
       expect(event.interaction, equals(EventInteraction.fromCanModify(true)));
+    });
+
+    test('rejects an end before the start', () {
+      expect(
+        () => eventUtc(DateTime.utc(2024, 1, 15, 10), DateTime.utc(2024, 1, 15, 9)),
+        throwsAssertionError,
+      );
+    });
+
+    test('accepts an end equal to the start', () {
+      final instant = DateTime.utc(2024, 1, 15, 9);
+      expect(() => eventUtc(instant, instant), returnsNormally);
+    });
+
+    test('compares the two after normalising to UTC', () {
+      // 09:30+01:00 is 08:30Z, so the pair reads forwards as wall clock values
+      // and backwards as instants. The check runs on the instants.
+      expect(
+        () => CalendarEvent(
+          start: DateTime.utc(2024, 1, 15, 9),
+          end: DateTime.parse('2024-01-15T09:30:00+01:00'),
+        ),
+        throwsAssertionError,
+      );
     });
   });
 
@@ -235,7 +259,8 @@ void main() {
   group('MultiDayRule.calendarDays', () {
     CalendarEvent event(DateTime start, DateTime end) {
       return CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: start, end: end),
+        start: start,
+        end: end,
         multiDayRule: const MultiDayRule.calendarDays(),
       );
     }
@@ -269,7 +294,7 @@ void main() {
     final crossing = KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 23), end: DateTime.utc(2024, 1, 16, 1));
 
     test('an event with no rule of its own follows the one it is given', () {
-      final event = CalendarEvent(dateTimeRange: crossing);
+      final event = CalendarEvent(start: crossing.start, end: crossing.end);
       expect(event.multiDayRule, isNull, reason: 'unset means "use the calendar\'s rule"');
       expect(
         event.spansMultipleDays(location: utcLocation, defaultRule: const MultiDayRule.calendarDays()),
@@ -285,7 +310,8 @@ void main() {
     });
 
     test('an event override beats the calendar rule, in both directions', () {
-      final strict = CalendarEvent(dateTimeRange: crossing, multiDayRule: const MultiDayRule.calendarDays());
+      final strict =
+          CalendarEvent(start: crossing.start, end: crossing.end, multiDayRule: const MultiDayRule.calendarDays());
       expect(
         strict.spansMultipleDays(
           location: utcLocation,
@@ -296,7 +322,8 @@ void main() {
       );
 
       final loose = CalendarEvent(
-        dateTimeRange: crossing,
+        start: crossing.start,
+        end: crossing.end,
         multiDayRule: const MultiDayRule.minimumDuration(Duration(hours: 24)),
       );
       expect(
@@ -311,12 +338,12 @@ void main() {
     test('per event, via the constructor', () {
       final crossing = KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 23), end: DateTime.utc(2024, 1, 16, 1));
       expect(
-        CalendarEvent(dateTimeRange: crossing)
+        CalendarEvent(start: crossing.start, end: crossing.end)
             .spansMultipleDays(location: utcLocation, defaultRule: kDefaultMultiDayRule),
         isFalse,
       );
       expect(
-        CalendarEvent(dateTimeRange: crossing, multiDayRule: const MultiDayRule.calendarDays())
+        CalendarEvent(start: crossing.start, end: crossing.end, multiDayRule: const MultiDayRule.calendarDays())
             .spansMultipleDays(location: utcLocation, defaultRule: kDefaultMultiDayRule),
         isTrue,
       );
@@ -324,7 +351,8 @@ void main() {
 
     test('per app, via a subclass that fixes the rule', () {
       final event = _CalendarDayEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 23), end: DateTime.utc(2024, 1, 16, 1)),
+        start: DateTime.utc(2024, 1, 15, 23),
+        end: DateTime.utc(2024, 1, 16, 1),
       );
       expect(
         event.spansMultipleDays(location: utcLocation, defaultRule: kDefaultMultiDayRule),
@@ -335,12 +363,12 @@ void main() {
     test('fully custom, by overriding spansMultipleDays', () {
       final fullDay = KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15), end: DateTime.utc(2024, 1, 16));
       expect(
-        CalendarEvent(dateTimeRange: fullDay)
+        CalendarEvent(start: fullDay.start, end: fullDay.end)
             .spansMultipleDays(location: utcLocation, defaultRule: kDefaultMultiDayRule),
         isTrue,
       );
       expect(
-        _StrictMultiDayEvent(dateTimeRange: fullDay)
+        _StrictMultiDayEvent(start: fullDay.start, end: fullDay.end)
             .spansMultipleDays(location: utcLocation, defaultRule: kDefaultMultiDayRule),
         isFalse,
       );
@@ -349,7 +377,8 @@ void main() {
     test('copyWith carries the rule, and takes no parameter for it', () {
       // carryOver reapplies it, so a subclass never forwards it by hand.
       final event = CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15), end: DateTime.utc(2024, 1, 16)),
+        start: DateTime.utc(2024, 1, 15),
+        end: DateTime.utc(2024, 1, 16),
         multiDayRule: const MultiDayRule.calendarDays(),
       );
       expect(
@@ -362,7 +391,8 @@ void main() {
       // The pattern the Custom Events guide documents. copyWithData rebuilds
       // only the title, and carryOver puts the rule back.
       final event = _DataEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15), end: DateTime.utc(2024, 1, 16)),
+        start: DateTime.utc(2024, 1, 15),
+        end: DateTime.utc(2024, 1, 16),
         title: 'Night shift',
         multiDayRule: const MultiDayRule.calendarDays(),
       );
@@ -376,8 +406,13 @@ void main() {
 
     test('the rule participates in layoutEquals, since it decides the lane', () {
       final range = KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 23), end: DateTime.utc(2024, 1, 16, 1));
-      final a = CalendarEvent(id: 'same', dateTimeRange: range);
-      final b = CalendarEvent(id: 'same', dateTimeRange: range, multiDayRule: const MultiDayRule.calendarDays());
+      final a = CalendarEvent(id: 'same', start: range.start, end: range.end);
+      final b = CalendarEvent(
+        id: 'same',
+        start: range.start,
+        end: range.end,
+        multiDayRule: const MultiDayRule.calendarDays(),
+      );
       expect(a.layoutEquals(b), isFalse);
       expect(a, isNot(equals(b)));
     });
@@ -387,7 +422,7 @@ void main() {
     final shortRange = KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 9), end: DateTime.utc(2024, 1, 15, 10));
 
     test('defaults to false and changes nothing', () {
-      final event = CalendarEvent(dateTimeRange: shortRange);
+      final event = CalendarEvent(start: shortRange.start, end: shortRange.end);
       expect(event.isAllDay, isFalse);
       expect(event.spansMultipleDays(location: utcLocation, defaultRule: kDefaultMultiDayRule), isFalse);
     });
@@ -396,14 +431,15 @@ void main() {
       // No MultiDayRule can express this: the event is under 24 hours and sits
       // inside one calendar day, so before the flag it needed an override of
       // spansMultipleDays.
-      final event = CalendarEvent(dateTimeRange: shortRange, isAllDay: true);
+      final event = CalendarEvent(start: shortRange.start, end: shortRange.end, isAllDay: true);
       expect(event.spansMultipleDays(location: utcLocation, defaultRule: kDefaultMultiDayRule), isTrue);
       expect(event.spansMultipleDays(location: utcLocation, defaultRule: const MultiDayRule.calendarDays()), isTrue);
     });
 
     test('outranks a per-event rule that says otherwise', () {
       final event = CalendarEvent(
-        dateTimeRange: shortRange,
+        start: shortRange.start,
+        end: shortRange.end,
         isAllDay: true,
         multiDayRule: const MultiDayRule.minimumDuration(Duration(days: 7)),
       );
@@ -411,12 +447,12 @@ void main() {
     });
 
     test('leaves the date range alone', () {
-      final event = CalendarEvent(dateTimeRange: shortRange, isAllDay: true);
+      final event = CalendarEvent(start: shortRange.start, end: shortRange.end, isAllDay: true);
       expect(event.dateTimeRange, equals(shortRange));
     });
 
     test('survives a drag', () {
-      final event = CalendarEvent(dateTimeRange: shortRange, isAllDay: true);
+      final event = CalendarEvent(start: shortRange.start, end: shortRange.end, isAllDay: true);
       final moved = event.withDateTimeRange(
         KalenderDateTimeRange(start: DateTime.utc(2024, 1, 16, 9), end: DateTime.utc(2024, 1, 16, 10)),
       );
@@ -424,8 +460,8 @@ void main() {
     });
 
     test('participates in layoutEquals, since it decides the lane', () {
-      final a = CalendarEvent(id: 'same', dateTimeRange: shortRange);
-      final b = CalendarEvent(id: 'same', dateTimeRange: shortRange, isAllDay: true);
+      final a = CalendarEvent(id: 'same', start: shortRange.start, end: shortRange.end);
+      final b = CalendarEvent(id: 'same', start: shortRange.start, end: shortRange.end, isAllDay: true);
       expect(a.layoutEquals(b), isFalse);
       expect(a, isNot(equals(b)));
     });
@@ -434,8 +470,8 @@ void main() {
       final controller = DefaultEventsController();
       addTearDown(controller.dispose);
 
-      final timed = CalendarEvent(dateTimeRange: shortRange);
-      final allDay = CalendarEvent(dateTimeRange: shortRange, isAllDay: true);
+      final timed = CalendarEvent(start: shortRange.start, end: shortRange.end);
+      final allDay = CalendarEvent(start: shortRange.start, end: shortRange.end, isAllDay: true);
       controller.addEvents([timed, allDay]);
 
       final day = InternalDateTimeRange(
@@ -485,18 +521,20 @@ void main() {
 
 /// Fixes the rule for a whole app in one place, the way a real subclass would.
 class _CalendarDayEvent extends CalendarEvent {
-  _CalendarDayEvent({required super.dateTimeRange}) : super(multiDayRule: const MultiDayRule.calendarDays());
+  _CalendarDayEvent({required super.start, required super.end})
+      : super(multiDayRule: const MultiDayRule.calendarDays());
 
   @override
-  _CalendarDayEvent copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return _CalendarDayEvent(dateTimeRange: dateTimeRange);
+  _CalendarDayEvent copyWithData({required DateTime start, required DateTime end}) {
+    return _CalendarDayEvent(start: start, end: end);
   }
 }
 
 /// Attaches data the way the Custom Events guide shows, forwarding the rule.
 class _DataEvent extends CalendarEvent {
   _DataEvent({
-    required super.dateTimeRange,
+    required super.start,
+    required super.end,
     required this.title,
     super.multiDayRule,
   });
@@ -504,18 +542,18 @@ class _DataEvent extends CalendarEvent {
   final String title;
 
   @override
-  _DataEvent copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return _DataEvent(dateTimeRange: dateTimeRange, title: title);
+  _DataEvent copyWithData({required DateTime start, required DateTime end}) {
+    return _DataEvent(start: start, end: end, title: title);
   }
 }
 
 /// Replaces the rule entirely with a strict "more than one calendar day".
 class _StrictMultiDayEvent extends CalendarEvent {
-  _StrictMultiDayEvent({required super.dateTimeRange});
+  _StrictMultiDayEvent({required super.start, required super.end});
 
   @override
-  _StrictMultiDayEvent copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return _StrictMultiDayEvent(dateTimeRange: dateTimeRange);
+  _StrictMultiDayEvent copyWithData({required DateTime start, required DateTime end}) {
+    return _StrictMultiDayEvent(start: start, end: end);
   }
 
   @override

--- a/test/models/constrained_builder_return_types_test.dart
+++ b/test/models/constrained_builder_return_types_test.dart
@@ -34,7 +34,7 @@ void main() {
   test('ResizeHandleDetails builds a nameable ResizeDetector', () {
     final range = KalenderDateTimeRange(start: DateTime(2025), end: DateTime(2025, 1, 2));
     final details = ResizeHandleDetails(
-      event: CalendarEvent(dateTimeRange: range),
+      event: CalendarEvent(start: range.start, end: range.end),
       interaction: CalendarInteraction(),
       dateTimeRange: InternalDateTimeRange.fromDateTimeRange(range),
       size: const Size(100, 100),

--- a/test/models/copy_contract_test.dart
+++ b/test/models/copy_contract_test.dart
@@ -13,7 +13,8 @@ import 'package:kalender/kalender.dart';
 /// Rebuilds only its own field, as the documentation shows.
 class _Task extends CalendarEvent {
   _Task({
-    required super.dateTimeRange,
+    required super.start,
+    required super.end,
     required this.title,
     super.interaction,
     super.multiDayRule,
@@ -22,14 +23,14 @@ class _Task extends CalendarEvent {
   final String title;
 
   @override
-  _Task copyWithData({required KalenderDateTimeRange dateTimeRange}) {
-    return _Task(dateTimeRange: dateTimeRange, title: title);
+  _Task copyWithData({required DateTime start, required DateTime end}) {
+    return _Task(start: start, end: end, title: title);
   }
 
   /// A copy method of the subclass's own, which is no longer an override and so
   /// can take whatever parameters it likes.
   _Task copyWith({String? title}) {
-    return carryOver(_Task(dateTimeRange: dateTimeRange, title: title ?? this.title));
+    return carryOver(_Task(start: dateTimeRange.start, end: dateTimeRange.end, title: title ?? this.title));
   }
 }
 
@@ -37,7 +38,7 @@ class _Task extends CalendarEvent {
 /// implementation returns a plain [CalendarEvent].
 // ignore: missing_override_of_must_be_overridden
 class _NoHook extends CalendarEvent {
-  _NoHook({required super.dateTimeRange});
+  _NoHook({required super.start, required super.end});
 }
 
 void main() {
@@ -46,7 +47,7 @@ void main() {
 
   group('withDateTimeRange', () {
     test('moves a base event and keeps its identity and rule', () {
-      final event = CalendarEvent(dateTimeRange: range, multiDayRule: const MultiDayRule.calendarDays());
+      final event = CalendarEvent(start: range.start, end: range.end, multiDayRule: const MultiDayRule.calendarDays());
       final copy = event.withDateTimeRange(moved);
 
       expect(copy.dateTimeRange, equals(moved));
@@ -56,7 +57,8 @@ void main() {
 
     test('keeps the state a subclass never mentions', () {
       final event = _Task(
-        dateTimeRange: range,
+        start: range.start,
+        end: range.end,
         title: 'standup',
         multiDayRule: const MultiDayRule.calendarDays(),
         interaction: EventInteraction.fromCanModify(false),
@@ -72,12 +74,12 @@ void main() {
     });
 
     test('returns the subclass type, not the base one', () {
-      final event = _Task(dateTimeRange: range, title: 'standup');
+      final event = _Task(start: range.start, end: range.end, title: 'standup');
       expect(event.withDateTimeRange(moved), isA<_Task>());
     });
 
     test('a subclass with no hook is reported by name', () {
-      final event = _NoHook(dateTimeRange: range);
+      final event = _NoHook(start: range.start, end: range.end);
 
       expect(
         () => event.withDateTimeRange(moved),
@@ -95,7 +97,8 @@ void main() {
   group('carryOver', () {
     test('a copyWith of the subclass keeps the base state too', () {
       final event = _Task(
-        dateTimeRange: range,
+        start: range.start,
+        end: range.end,
         title: 'standup',
         multiDayRule: const MultiDayRule.calendarDays(),
       );
@@ -113,7 +116,7 @@ void main() {
       final controller = DefaultEventsController();
       addTearDown(controller.dispose);
 
-      final event = _Task(dateTimeRange: range, title: 'standup');
+      final event = _Task(start: range.start, end: range.end, title: 'standup');
       controller.addEvent(event);
 
       final moved0 = event.withDateTimeRange(moved);

--- a/test/models/default_events_controller_test.dart
+++ b/test/models/default_events_controller_test.dart
@@ -45,7 +45,7 @@ void main() {
       final events = List.generate(5, (i) {
         final start = DateTime.utc(2024, 2, i + 1, 9);
         final end = DateTime.utc(2024, 2, i + 1, 10);
-        return CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        return CalendarEvent(start: start, end: end);
       });
       final ids = controller.addEvents(events);
       expect(ids.length, events.length);
@@ -58,7 +58,7 @@ void main() {
       final events = List.generate(3, (i) {
         final start = DateTime.utc(2024, 3, i + 1, 8);
         final end = DateTime.utc(2024, 3, i + 1, 9);
-        return CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        return CalendarEvent(start: start, end: end);
       });
       controller.addEvents(events);
       for (final event in events) {
@@ -77,7 +77,7 @@ void main() {
     test('Returns null after the event has been removed', () {
       final start = DateTime.utc(2024, 1, 10, 10);
       final end = DateTime.utc(2024, 1, 10, 11);
-      final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+      final event = CalendarEvent(start: start, end: end);
       final id = controller.addEvent(event);
       controller.removeById(id);
       expect(controller.byId(id), isNull);
@@ -90,7 +90,7 @@ void main() {
     test('Removes event by object reference', () {
       final start = DateTime.utc(2024, 1, 10, 10);
       final end = DateTime.utc(2024, 1, 10, 11);
-      final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+      final event = CalendarEvent(start: start, end: end);
       final id = controller.addEvent(event);
       controller.removeEvent(event);
       expect(controller.byId(id), isNull);
@@ -101,7 +101,8 @@ void main() {
       // Spans Jan 10, 11, 12; removal must clear the id from all three date
       // buckets, not just the start day.
       final event = CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 1, 10, 9), end: DateTime.utc(2024, 1, 12, 17)),
+        start: DateTime.utc(2024, 1, 10, 9),
+        end: DateTime.utc(2024, 1, 12, 17),
       );
       controller.addEvent(event);
       controller.removeEvent(event);
@@ -127,7 +128,7 @@ void main() {
       final events = List.generate(4, (i) {
         final start = DateTime.utc(2024, 4, i + 1, 9);
         final end = DateTime.utc(2024, 4, i + 1, 10);
-        return CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        return CalendarEvent(start: start, end: end);
       });
       final ids = controller.addEvents(events);
       controller.removeEvents(events.take(2).toList());
@@ -140,7 +141,7 @@ void main() {
     test('Removing an empty list leaves events unchanged', () {
       final start = DateTime.utc(2024, 4, 10, 9);
       final end = DateTime.utc(2024, 4, 10, 10);
-      final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+      final event = CalendarEvent(start: start, end: end);
       final id = controller.addEvent(event);
       controller.removeEvents([]);
       expect(controller.byId(id), event);
@@ -153,11 +154,11 @@ void main() {
     test('Removes only events matching the predicate', () {
       final start1 = DateTime.utc(2024, 5, 1, 9);
       final end1 = DateTime.utc(2024, 5, 1, 10);
-      final event1 = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start1, end: end1));
+      final event1 = CalendarEvent(start: start1, end: end1);
 
       final start2 = DateTime.utc(2024, 5, 2, 9);
       final end2 = DateTime.utc(2024, 5, 2, 10);
-      final event2 = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start2, end: end2));
+      final event2 = CalendarEvent(start: start2, end: end2);
 
       final id1 = controller.addEvent(event1);
       final id2 = controller.addEvent(event2);
@@ -172,7 +173,7 @@ void main() {
       final events = List.generate(3, (i) {
         final start = DateTime.utc(2024, 5, i + 10, 9);
         final end = DateTime.utc(2024, 5, i + 10, 10);
-        return CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        return CalendarEvent(start: start, end: end);
       });
       controller.addEvents(events);
       controller.removeWhere((_, __) => true);
@@ -187,7 +188,7 @@ void main() {
       final events = List.generate(5, (i) {
         final start = DateTime.utc(2024, 6, i + 1, 9);
         final end = DateTime.utc(2024, 6, i + 1, 10);
-        return CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        return CalendarEvent(start: start, end: end);
       });
       controller.addEvents(events);
       expect(controller.events, isNotEmpty);
@@ -198,12 +199,12 @@ void main() {
     test('Adding events after clearEvents works correctly', () {
       final start = DateTime.utc(2024, 7, 1, 9);
       final end = DateTime.utc(2024, 7, 1, 10);
-      controller.addEvent(CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end)));
+      controller.addEvent(CalendarEvent(start: start, end: end));
       controller.clearEvents();
 
       final start2 = DateTime.utc(2024, 7, 5, 14);
       final end2 = DateTime.utc(2024, 7, 5, 15);
-      final secondEvent = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start2, end: end2));
+      final secondEvent = CalendarEvent(start: start2, end: end2);
       final id = controller.addEvent(secondEvent);
       expect(controller.byId(id), secondEvent);
       expect(controller.events.length, 1);
@@ -217,7 +218,8 @@ void main() {
       final old = List.generate(3, (i) {
         final start = DateTime.utc(2024, 6, i + 1, 9);
         return CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(const Duration(hours: 1))),
+          start: start,
+          end: start.add(const Duration(hours: 1)),
         );
       });
       controller.addEvents(old);
@@ -225,7 +227,8 @@ void main() {
       final replacement = List.generate(2, (i) {
         final start = DateTime.utc(2024, 7, i + 1, 9);
         return CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(const Duration(hours: 1))),
+          start: start,
+          end: start.add(const Duration(hours: 1)),
         );
       });
       final ids = controller.replaceEvents(replacement);
@@ -243,7 +246,8 @@ void main() {
     test('Notifies listeners exactly once', () {
       controller.addEvents([
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 6, 1, 9), end: DateTime.utc(2024, 6, 1, 10)),
+          start: DateTime.utc(2024, 6, 1, 9),
+          end: DateTime.utc(2024, 6, 1, 10),
         ),
       ]);
 
@@ -251,7 +255,8 @@ void main() {
       controller.addListener(() => count++);
       controller.replaceEvents([
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 7, 1, 9), end: DateTime.utc(2024, 7, 1, 10)),
+          start: DateTime.utc(2024, 7, 1, 9),
+          end: DateTime.utc(2024, 7, 1, 10),
         ),
       ]);
       expect(count, 1, reason: 'A single atomic update, not a clear followed by an add.');
@@ -260,7 +265,8 @@ void main() {
     test('Replacing with an empty list clears all events', () {
       controller.addEvents([
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 6, 1, 9), end: DateTime.utc(2024, 6, 1, 10)),
+          start: DateTime.utc(2024, 6, 1, 9),
+          end: DateTime.utc(2024, 6, 1, 10),
         ),
       ]);
       controller.replaceEvents([]);
@@ -276,7 +282,7 @@ void main() {
       controller.addListener(() => notified = true);
       final start = DateTime.utc(2024, 8, 1, 9);
       final end = DateTime.utc(2024, 8, 1, 10);
-      controller.addEvent(CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end)));
+      controller.addEvent(CalendarEvent(start: start, end: end));
       expect(notified, isTrue);
     });
 
@@ -286,7 +292,7 @@ void main() {
       final events = List.generate(2, (i) {
         final start = DateTime.utc(2024, 8, i + 5, 9);
         final end = DateTime.utc(2024, 8, i + 5, 10);
-        return CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        return CalendarEvent(start: start, end: end);
       });
       controller.addEvents(events);
       expect(notified, isTrue);
@@ -296,7 +302,7 @@ void main() {
       var notified = false;
       final start = DateTime.utc(2024, 8, 2, 9);
       final end = DateTime.utc(2024, 8, 2, 10);
-      final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+      final event = CalendarEvent(start: start, end: end);
       controller.addEvent(event);
       controller.addListener(() => notified = true);
       controller.removeEvent(event);
@@ -307,7 +313,7 @@ void main() {
       var notified = false;
       final start = DateTime.utc(2024, 8, 9, 9);
       final end = DateTime.utc(2024, 8, 9, 10);
-      final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+      final event = CalendarEvent(start: start, end: end);
       final id = controller.addEvent(event);
       controller.addListener(() => notified = true);
       controller.removeById(id);
@@ -325,11 +331,12 @@ void main() {
       var notified = false;
       final start = DateTime.utc(2024, 8, 3, 9);
       final end = DateTime.utc(2024, 8, 3, 10);
-      final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+      final event = CalendarEvent(start: start, end: end);
       controller.addEvent(event);
       controller.addListener(() => notified = true);
       final updatedEvent = CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 8, 3, 11), end: DateTime.utc(2024, 8, 3, 12)),
+        start: DateTime.utc(2024, 8, 3, 11),
+        end: DateTime.utc(2024, 8, 3, 12),
       );
       controller.updateEvent(event: event, updatedEvent: updatedEvent);
       expect(notified, isTrue);
@@ -342,7 +349,7 @@ void main() {
     test('Event not returned for a range it does not overlap', () {
       final start = DateTime.utc(2024, 9, 1, 10);
       final end = DateTime.utc(2024, 9, 1, 11);
-      final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+      final event = CalendarEvent(start: start, end: end);
       controller.addEvent(event);
       final range = InternalDateTimeRange(start: InternalDateTime(2024, 9, 10), end: InternalDateTime(2024, 9, 11));
       expect(controller.eventsFromDateTimeRange(multiDayRule: kDefaultMultiDayRule, range), isNot(contains(event)));
@@ -352,7 +359,7 @@ void main() {
       final events = List.generate(3, (i) {
         final start = DateTime.utc(2024, 10, 5, 9 + i);
         final end = DateTime.utc(2024, 10, 5, 10 + i);
-        return CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        return CalendarEvent(start: start, end: end);
       });
       controller.addEvents(events);
       final range = InternalDateTimeRange(start: InternalDateTime(2024, 10, 5), end: InternalDateTime(2024, 10, 6));
@@ -365,7 +372,7 @@ void main() {
     test('Removed event is no longer returned from range query', () {
       final start = DateTime.utc(2024, 11, 1, 10);
       final end = DateTime.utc(2024, 11, 1, 11);
-      final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+      final event = CalendarEvent(start: start, end: end);
       controller.addEvent(event);
       controller.removeEvent(event);
       final range = InternalDateTimeRange(start: InternalDateTime(2024, 11, 1), end: InternalDateTime(2024, 11, 2));
@@ -375,12 +382,12 @@ void main() {
     test('Updated event is found in new range but not old range', () {
       final start = DateTime.utc(2024, 12, 1, 10);
       final end = DateTime.utc(2024, 12, 1, 11);
-      final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+      final event = CalendarEvent(start: start, end: end);
       controller.addEvent(event);
 
       final newStart = DateTime.utc(2024, 12, 20, 6);
       final newEnd = DateTime.utc(2024, 12, 20, 7);
-      final updatedEvent = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: newStart, end: newEnd));
+      final updatedEvent = CalendarEvent(start: newStart, end: newEnd);
       controller.updateEvent(event: event, updatedEvent: updatedEvent);
 
       final oldRange = InternalDateTimeRange(
@@ -401,7 +408,7 @@ void main() {
     test('Both filters disabled returns empty iterable', () {
       final start = DateTime.utc(2024, 9, 5, 10);
       final end = DateTime.utc(2024, 9, 5, 11);
-      final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+      final event = CalendarEvent(start: start, end: end);
       controller.addEvent(event);
       final range = InternalDateTimeRange(start: InternalDateTime(2024, 9, 5), end: InternalDateTime(2024, 9, 6));
       final result = controller.eventsFromDateTimeRange(
@@ -421,7 +428,7 @@ void main() {
       test('Short event (< 1 day)', () {
         final start = TZDateTime(location, 2024, 1, 15, 10);
         final end = TZDateTime(location, 2024, 1, 15, 11);
-        final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        final event = CalendarEvent(start: start, end: end);
         final id = controller.addEvent(event);
         expect(controller.byId(id), event, reason: 'Event should be retrievable by its id after being added.');
 
@@ -456,7 +463,7 @@ void main() {
       test('Multi-day event (>= 1 day)', () {
         final start = TZDateTime(location, 2024, 1, 15);
         final end = TZDateTime(location, 2024, 1, 16);
-        final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        final event = CalendarEvent(start: start, end: end);
         final id = controller.addEvent(event);
         expect(controller.byId(id), event, reason: 'Event should be retrievable by its id after being added.');
 
@@ -491,7 +498,7 @@ void main() {
       test('Zero-duration event', () {
         final start = TZDateTime(location, 2024, 1, 15);
         final end = TZDateTime(location, 2024, 1, 15);
-        final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        final event = CalendarEvent(start: start, end: end);
         final id = controller.addEvent(event);
         expect(controller.byId(id), event, reason: 'Event should be retrievable by its id after being added.');
 
@@ -526,7 +533,7 @@ void main() {
       test('Remove event by id', () {
         final start = TZDateTime(location, 2024, 1, 15);
         final end = TZDateTime(location, 2024, 1, 16);
-        final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        final event = CalendarEvent(start: start, end: end);
         final id = controller.addEvent(event);
         controller.removeById(id);
         expect(controller.byId(id), isNull, reason: 'Event should not be retrievable after removal.');
@@ -535,7 +542,7 @@ void main() {
       test('Remove event by reference', () {
         final start = TZDateTime(location, 2024, 2, 5);
         final end = TZDateTime(location, 2024, 2, 6);
-        final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        final event = CalendarEvent(start: start, end: end);
         final id = controller.addEvent(event);
         controller.removeEvent(event);
         expect(controller.byId(id), isNull, reason: 'Event should not be retrievable after removal by reference.');
@@ -545,12 +552,12 @@ void main() {
       test('Update event: id preserved and new range is queryable', () {
         final start = TZDateTime(location, 2024, 1, 15);
         final end = TZDateTime(location, 2024, 1, 16);
-        final event = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end));
+        final event = CalendarEvent(start: start, end: end);
         final id = controller.addEvent(event);
 
         final newStart = TZDateTime(location, 2024, 1, 17);
         final newEnd = TZDateTime(location, 2024, 1, 18);
-        final updatedEvent = CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: newStart, end: newEnd));
+        final updatedEvent = CalendarEvent(start: newStart, end: newEnd);
         controller.updateEvent(event: event, updatedEvent: updatedEvent);
 
         expect(updatedEvent.id, id, reason: 'Updated event should retain the original id.');

--- a/test/models/draggable_event_test.dart
+++ b/test/models/draggable_event_test.dart
@@ -5,7 +5,8 @@ import 'package:kalender/src/models/calendar_events/draggable_event.dart';
 void main() {
   CalendarEvent makeEvent({String id = 'e1'}) => CalendarEvent(
         id: id,
-        dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 9), end: DateTime.utc(2024, 1, 15, 10)),
+        start: DateTime.utc(2024, 1, 15, 9),
+        end: DateTime.utc(2024, 1, 15, 10),
       );
 
   // ─── ResizeDirection ─────────────────────────────────────────────────────────

--- a/test/models/event_tile_utils_test.dart
+++ b/test/models/event_tile_utils_test.dart
@@ -78,7 +78,8 @@ void main() {
 
   group('DayEventTileUtils', () {
     final event = CalendarEvent(
-      dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 9), end: DateTime.utc(2024, 1, 15, 10)),
+      start: DateTime.utc(2024, 1, 15, 9),
+      end: DateTime.utc(2024, 1, 15, 10),
     );
     final tileRange = KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15), end: DateTime.utc(2024, 1, 16));
 
@@ -113,15 +114,15 @@ void main() {
       // Within a +/-30min window of 09:00-10:00 (08:30-10:30).
       final nearbyId = eventsController.addEvent(
         CalendarEvent(
-          dateTimeRange:
-              KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 8), end: DateTime.utc(2024, 1, 15, 8, 45)),
+          start: DateTime.utc(2024, 1, 15, 8),
+          end: DateTime.utc(2024, 1, 15, 8, 45),
         ),
       );
       // Outside the window.
       eventsController.addEvent(
         CalendarEvent(
-          dateTimeRange:
-              KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 11), end: DateTime.utc(2024, 1, 15, 12)),
+          start: DateTime.utc(2024, 1, 15, 11),
+          end: DateTime.utc(2024, 1, 15, 12),
         ),
       );
 
@@ -152,7 +153,8 @@ void main() {
 
   group('MultiDayEventTileUtils', () {
     final event = CalendarEvent(
-      dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15, 9), end: DateTime.utc(2024, 1, 17, 18)),
+      start: DateTime.utc(2024, 1, 15, 9),
+      end: DateTime.utc(2024, 1, 17, 18),
     );
     final tileRange = KalenderDateTimeRange(start: DateTime.utc(2024, 1, 15), end: DateTime.utc(2024, 1, 18));
 
@@ -194,7 +196,8 @@ void main() {
       // Event runs Jan 13 → Jan 20 but the tile only shows Jan 15 → Jan 18, so
       // the 300px width maps to the 3 visible days (Jan 15, 16, 17).
       final overflowing = CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 1, 13, 9), end: DateTime.utc(2024, 1, 20, 18)),
+        start: DateTime.utc(2024, 1, 13, 9),
+        end: DateTime.utc(2024, 1, 20, 18),
       );
       final harness = _MultiDayTileHarness(event: overflowing, tileRange: tileRange);
       final context = await pumpHarness(tester, harness);
@@ -207,7 +210,8 @@ void main() {
       final selfId = eventsController.addEvent(event);
       final otherMultiDayId = eventsController.addEvent(
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: DateTime.utc(2024, 1, 16), end: DateTime.utc(2024, 1, 18)),
+          start: DateTime.utc(2024, 1, 16),
+          end: DateTime.utc(2024, 1, 18),
         ),
       );
 

--- a/test/models/snap_points_test.dart
+++ b/test/models/snap_points_test.dart
@@ -9,9 +9,9 @@ void main() {
   // Adding them as snap points produces 6 entries (start + end per event):
   //   10:00, 11:00, 11:00, 12:00, 12:00, 13:00
   final testEvents = [
-    CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: DateTime(2024, 1, 1, 10), end: DateTime(2024, 1, 1, 11))),
-    CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: DateTime(2024, 1, 1, 11), end: DateTime(2024, 1, 1, 12))),
-    CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: DateTime(2024, 1, 1, 12), end: DateTime(2024, 1, 1, 13))),
+    CalendarEvent(start: DateTime(2024, 1, 1, 10), end: DateTime(2024, 1, 1, 11)),
+    CalendarEvent(start: DateTime(2024, 1, 1, 11), end: DateTime(2024, 1, 1, 12)),
+    CalendarEvent(start: DateTime(2024, 1, 1, 12), end: DateTime(2024, 1, 1, 13)),
   ];
 
   late MockSnapPoint points;

--- a/test/widgets/day_events_culling_test.dart
+++ b/test/widgets/day_events_culling_test.dart
@@ -28,10 +28,8 @@ void main() {
   String addEvent(int hour, {int durationHours = 1}) {
     return eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: day.copyWith(hour: hour),
-          end: day.copyWith(hour: hour + durationHours),
-        ),
+        start: day.copyWith(hour: hour),
+        end: day.copyWith(hour: hour + durationHours),
       ),
     );
   }

--- a/test/widgets/day_events_widget_test.dart
+++ b/test/widgets/day_events_widget_test.dart
@@ -20,24 +20,18 @@ void main() {
     events = [
       // Event 0: 23:00 day before → 01:00 start day (2h, crosses midnight)
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: start.copyWith(hour: start.hour - 1),
-          end: start.copyWith(hour: start.hour + 1),
-        ),
+        start: start.copyWith(hour: start.hour - 1),
+        end: start.copyWith(hour: start.hour + 1),
       ),
       // Event 1: 00:00 → 02:00 on start day (2h)
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: start,
-          end: start.copyWith(hour: start.hour + 2),
-        ),
+        start: start,
+        end: start.copyWith(hour: start.hour + 2),
       ),
       // Event 2: 00:00 → 03:00 on next day (3h)
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: start.copyWith(day: start.day + 1),
-          end: start.copyWith(day: start.day + 1, hour: start.hour + 3),
-        ),
+        start: start.copyWith(day: start.day + 1),
+        end: start.copyWith(day: start.day + 1, hour: start.hour + 3),
       ),
     ];
 
@@ -153,10 +147,8 @@ void main() {
     testWidgets('renders a single event', (tester) async {
       eventsController.clearEvents();
       final singleEvent = CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: start,
-          end: start.copyWith(hour: 4),
-        ),
+        start: start,
+        end: start.copyWith(hour: 4),
       );
       eventsController.addEvent(singleEvent);
       events = [singleEvent]; // update local list for finder
@@ -169,10 +161,8 @@ void main() {
     testWidgets('renders short event (15 min)', (tester) async {
       eventsController.clearEvents();
       final shortEvent = CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: start.copyWith(hour: 10),
-          end: start.copyWith(hour: 10, minute: 15),
-        ),
+        start: start.copyWith(hour: 10),
+        end: start.copyWith(hour: 10, minute: 15),
       );
       eventsController.addEvent(shortEvent);
       events = [shortEvent];
@@ -200,10 +190,8 @@ void main() {
 
       // Add a 4th event on the same day.
       final newEvent = CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: start.copyWith(hour: 5),
-          end: start.copyWith(hour: 7),
-        ),
+        start: start.copyWith(hour: 5),
+        end: start.copyWith(hour: 7),
       );
       eventsController.addEvent(newEvent);
       events.add(newEvent);

--- a/test/widgets/drag_move_coalescing_test.dart
+++ b/test/widgets/drag_move_coalescing_test.dart
@@ -25,7 +25,8 @@ void main() {
     calendarController = CalendarController();
     eventId = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: start.copyWith(hour: 6), end: start.copyWith(hour: 8)),
+        start: start.copyWith(hour: 6),
+        end: start.copyWith(hour: 8),
       ),
     );
   });

--- a/test/widgets/event_all_day_test.dart
+++ b/test/widgets/event_all_day_test.dart
@@ -51,7 +51,7 @@ void main() {
   }
 
   testWidgets('an hour-long all-day event renders in the header', (tester) async {
-    final id = eventsController.addEvent(CalendarEvent(dateTimeRange: shortRange, isAllDay: true));
+    final id = eventsController.addEvent(CalendarEvent(start: shortRange.start, end: shortRange.end, isAllDay: true));
 
     await pumpWeek(tester, const MultiDayRule.minimumDuration(Duration(hours: 24)));
 
@@ -60,7 +60,7 @@ void main() {
   });
 
   testWidgets('the same event without the flag stays in the body', (tester) async {
-    final id = eventsController.addEvent(CalendarEvent(dateTimeRange: shortRange));
+    final id = eventsController.addEvent(CalendarEvent(start: shortRange.start, end: shortRange.end));
 
     await pumpWeek(tester, const MultiDayRule.minimumDuration(Duration(hours: 24)));
 
@@ -70,7 +70,7 @@ void main() {
 
   testWidgets('the view rule cannot pull it back into the body', (tester) async {
     // A rule nothing satisfies. The flag still decides.
-    final id = eventsController.addEvent(CalendarEvent(dateTimeRange: shortRange, isAllDay: true));
+    final id = eventsController.addEvent(CalendarEvent(start: shortRange.start, end: shortRange.end, isAllDay: true));
 
     await pumpWeek(tester, const MultiDayRule.minimumDuration(Duration(days: 365)));
 
@@ -79,7 +79,7 @@ void main() {
   });
 
   testWidgets('rescheduling it in the header keeps it all-day', (tester) async {
-    final id = eventsController.addEvent(CalendarEvent(dateTimeRange: shortRange, isAllDay: true));
+    final id = eventsController.addEvent(CalendarEvent(start: shortRange.start, end: shortRange.end, isAllDay: true));
 
     CalendarEvent? changed;
     await pumpWeek(

--- a/test/widgets/frame_cache_text_direction_test.dart
+++ b/test/widgets/frame_cache_text_direction_test.dart
@@ -21,7 +21,7 @@ void main() {
     );
     for (var i = 0; i < 8; i++) {
       eventsController.addEvent(
-        CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+        CalendarEvent(start: day, end: day.add(const Duration(days: 1))),
       );
     }
   });

--- a/test/widgets/free_scroll_band_test.dart
+++ b/test/widgets/free_scroll_band_test.dart
@@ -49,7 +49,8 @@ void main() {
     // Monday 00:00 -> Friday 00:00, a 4-day span inside the first visible week.
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(const Duration(days: 4))),
+        start: start,
+        end: start.add(const Duration(days: 4)),
       ),
     );
 
@@ -68,8 +69,8 @@ void main() {
   testWidgets('the spanning tile stays one tile and moves as the view scrolls', (tester) async {
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange:
-            KalenderDateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 4))),
+        start: start.add(const Duration(days: 1)),
+        end: start.add(const Duration(days: 4)),
       ),
     );
 
@@ -95,7 +96,8 @@ void main() {
     final bigRange = KalenderDateTimeRange(start: DateTime(2018), end: DateTime(2036));
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime(2026, 7, 6), end: DateTime(2026, 7, 9)),
+        start: DateTime(2026, 7, 6),
+        end: DateTime(2026, 7, 9),
       ),
     );
 

--- a/test/widgets/free_scroll_cache_invalidation_test.dart
+++ b/test/widgets/free_scroll_cache_invalidation_test.dart
@@ -65,7 +65,7 @@ void main() {
 
     // A three-day event starting on the initial leading day.
     final id = eventsController.addEvent(
-      CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: initial, end: initial.add(const Duration(days: 3)))),
+      CalendarEvent(start: initial, end: initial.add(const Duration(days: 3))),
     );
     await tester.pumpAndSettle();
 

--- a/test/widgets/free_scroll_header_test.dart
+++ b/test/widgets/free_scroll_header_test.dart
@@ -35,12 +35,12 @@ void main() {
   void addTwoRowDay() {
     eventsController.addEvents([
       CalendarEvent(
-        dateTimeRange:
-            KalenderDateTimeRange(start: base.add(const Duration(days: 1)), end: base.add(const Duration(days: 3))),
+        start: base.add(const Duration(days: 1)),
+        end: base.add(const Duration(days: 3)),
       ),
       CalendarEvent(
-        dateTimeRange:
-            KalenderDateTimeRange(start: base.add(const Duration(days: 2)), end: base.add(const Duration(days: 4))),
+        start: base.add(const Duration(days: 2)),
+        end: base.add(const Duration(days: 4)),
       ),
     ]);
   }

--- a/test/widgets/free_scroll_interaction_test.dart
+++ b/test/widgets/free_scroll_interaction_test.dart
@@ -92,8 +92,8 @@ void main() {
     // A 3-day event inside the first visible week.
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange:
-            KalenderDateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 4))),
+        start: start.add(const Duration(days: 1)),
+        end: start.add(const Duration(days: 4)),
       ),
     );
 
@@ -122,8 +122,8 @@ void main() {
   testWidgets('dragging an event to the viewport edge scrolls to adjacent days', (tester) async {
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange:
-            KalenderDateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 3))),
+        start: start.add(const Duration(days: 1)),
+        end: start.add(const Duration(days: 3)),
       ),
     );
 

--- a/test/widgets/free_scroll_overflow_test.dart
+++ b/test/widgets/free_scroll_overflow_test.dart
@@ -46,8 +46,8 @@ void main() {
     // Two overlapping 2-day events. With a one-row limit the second overflows,
     // so Mon and Tue each get a "+N more" portal.
     eventsController.addEvents([
-      CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(const Duration(days: 2)))),
-      CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(const Duration(days: 2)))),
+      CalendarEvent(start: start, end: start.add(const Duration(days: 2))),
+      CalendarEvent(start: start, end: start.add(const Duration(days: 2))),
     ]);
 
     await pumpFreeScroll(tester);

--- a/test/widgets/free_scroll_rtl_test.dart
+++ b/test/widgets/free_scroll_rtl_test.dart
@@ -48,7 +48,7 @@ void main() {
 
   testWidgets('RTL: a multi-day event renders as one spanning tile', (tester) async {
     final id = eventsController.addEvent(
-      CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(const Duration(days: 4)))),
+      CalendarEvent(start: start, end: start.add(const Duration(days: 4))),
     );
 
     await pump(tester, TextDirection.rtl);
@@ -62,7 +62,8 @@ void main() {
   testWidgets('RTL mirrors the tile position relative to LTR', (tester) async {
     // A 2-day event on the first two visible days.
     final event = CalendarEvent(
-      dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(const Duration(days: 2))),
+      start: start,
+      end: start.add(const Duration(days: 2)),
     );
     final id = eventsController.addEvent(event);
 
@@ -85,8 +86,8 @@ void main() {
   testWidgets('RTL: scrolling forward moves the tile toward the start side (right)', (tester) async {
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange:
-            KalenderDateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 4))),
+        start: start.add(const Duration(days: 1)),
+        end: start.add(const Duration(days: 4)),
       ),
     );
 

--- a/test/widgets/month_body_event_padding_test.dart
+++ b/test/widgets/month_body_event_padding_test.dart
@@ -38,7 +38,8 @@ void main() {
 
       eventsController.addEvent(
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 15, 9), end: DateTime(2025, 1, 15, 10)),
+          start: DateTime(2025, 1, 15, 9),
+          end: DateTime(2025, 1, 15, 10),
         ),
       );
 

--- a/test/widgets/month_body_test.dart
+++ b/test/widgets/month_body_test.dart
@@ -386,10 +386,8 @@ void main() {
       // A single-day event on Jan 15, 2025 (within the displayed month).
       eventsController.addEvent(
         CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 1, 15, 9),
-            end: DateTime(2025, 1, 15, 10),
-          ),
+          start: DateTime(2025, 1, 15, 9),
+          end: DateTime(2025, 1, 15, 10),
         ),
       );
 
@@ -439,10 +437,8 @@ void main() {
 
       testWidgets('renders month view without error and is invoked', (tester) async {
         final event = CalendarEvent(
-          dateTimeRange: KalenderDateTimeRange(
-            start: DateTime(2025, 1, 15, 9),
-            end: DateTime(2025, 1, 15, 10),
-          ),
+          start: DateTime(2025, 1, 15, 9),
+          end: DateTime(2025, 1, 15, 10),
         );
         eventsController.addEvent(event);
 

--- a/test/widgets/month_event_focus_test.dart
+++ b/test/widgets/month_event_focus_test.dart
@@ -14,8 +14,8 @@ void main() {
     // Two events covering the same days (Tue–Thu of the first full week) so they
     // stack: one on row 0, one on row 1.
     final range = KalenderDateTimeRange(start: DateTime(2025, 1, 7), end: DateTime(2025, 1, 10));
-    final eventA = CalendarEvent(dateTimeRange: range);
-    final eventB = CalendarEvent(dateTimeRange: range);
+    final eventA = CalendarEvent(start: range.start, end: range.end);
+    final eventB = CalendarEvent(start: range.start, end: range.end);
     eventsController.addEvent(eventA);
     eventsController.addEvent(eventB);
 

--- a/test/widgets/month_rtl_overflow_test.dart
+++ b/test/widgets/month_rtl_overflow_test.dart
@@ -69,7 +69,7 @@ void main() {
       final eventsController = DefaultEventsController();
       for (var i = 0; i < eventCount; i++) {
         eventsController.addEvent(
-          CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+          CalendarEvent(start: day, end: day.add(const Duration(days: 1))),
         );
       }
 

--- a/test/widgets/multi_day_body_test.dart
+++ b/test/widgets/multi_day_body_test.dart
@@ -75,10 +75,8 @@ void main() {
       setUp(() {
         eventId = eventsController.addEvent(
           CalendarEvent(
-            dateTimeRange: KalenderDateTimeRange(
-              start: start.copyWith(hour: 6),
-              end: start.copyWith(hour: 8),
-            ),
+            start: start.copyWith(hour: 6),
+            end: start.copyWith(hour: 8),
           ),
         );
       });
@@ -191,10 +189,8 @@ void main() {
         final weekConfiguration = viewConfigurations[1];
         final id = eventsController.addEvent(
           CalendarEvent(
-            dateTimeRange: KalenderDateTimeRange(
-              start: start.copyWith(day: start.day + 2, hour: 10),
-              end: start.copyWith(day: start.day + 2, hour: 12),
-            ),
+            start: start.copyWith(day: start.day + 2, hour: 10),
+            end: start.copyWith(day: start.day + 2, hour: 12),
           ),
         );
 
@@ -257,10 +253,8 @@ void main() {
       setUp(() {
         eventId = eventsController.addEvent(
           CalendarEvent(
-            dateTimeRange: KalenderDateTimeRange(
-              start: start.copyWith(hour: 6),
-              end: start.copyWith(hour: 8),
-            ),
+            start: start.copyWith(hour: 6),
+            end: start.copyWith(hour: 8),
           ),
         );
       });

--- a/test/widgets/multi_day_drag_over_body_test.dart
+++ b/test/widgets/multi_day_drag_over_body_test.dart
@@ -25,10 +25,8 @@ void main() {
     // A two-day event starting on the Tuesday.
     eventId = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: start.add(const Duration(days: 1, hours: 9)),
-          end: start.add(const Duration(days: 3, hours: 9)),
-        ),
+        start: start.add(const Duration(days: 1, hours: 9)),
+        end: start.add(const Duration(days: 3, hours: 9)),
       ),
     );
   });

--- a/test/widgets/multi_day_rule_on_view_test.dart
+++ b/test/widgets/multi_day_rule_on_view_test.dart
@@ -27,10 +27,8 @@ void main() {
     // disagree about it and nothing else does.
     eventId = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: start.add(const Duration(days: 1, hours: 23)),
-          end: start.add(const Duration(days: 2, hours: 1)),
-        ),
+        start: start.add(const Duration(days: 1, hours: 23)),
+        end: start.add(const Duration(days: 2, hours: 1)),
       ),
     );
   });
@@ -88,10 +86,8 @@ void main() {
     eventsController.clearEvents();
     final pinned = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: start.add(const Duration(days: 1, hours: 23)),
-          end: start.add(const Duration(days: 2, hours: 1)),
-        ),
+        start: start.add(const Duration(days: 1, hours: 23)),
+        end: start.add(const Duration(days: 2, hours: 1)),
         multiDayRule: const MultiDayRule.calendarDays(),
       ),
     );

--- a/test/widgets/overlay_portal_builder_test.dart
+++ b/test/widgets/overlay_portal_builder_test.dart
@@ -25,7 +25,7 @@ void main() {
     final eventsController = DefaultEventsController();
     for (var i = 0; i < 8; i++) {
       eventsController.addEvent(
-        CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+        CalendarEvent(start: day, end: day.add(const Duration(days: 1))),
       );
     }
     addTearDown(eventsController.dispose);
@@ -155,7 +155,7 @@ void main() {
     final eventsController = DefaultEventsController();
     for (var i = 0; i < 8; i++) {
       eventsController.addEvent(
-        CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+        CalendarEvent(start: day, end: day.add(const Duration(days: 1))),
       );
     }
     addTearDown(eventsController.dispose);

--- a/test/widgets/overlay_style_precedence_test.dart
+++ b/test/widgets/overlay_style_precedence_test.dart
@@ -45,7 +45,7 @@ void main() {
     final eventsController = DefaultEventsController();
     for (var i = 0; i < 8; i++) {
       eventsController.addEvent(
-        CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+        CalendarEvent(start: day, end: day.add(const Duration(days: 1))),
       );
     }
     return eventsController;

--- a/test/widgets/overlay_style_test.dart
+++ b/test/widgets/overlay_style_test.dart
@@ -29,7 +29,7 @@ void main() {
     final eventsController = DefaultEventsController();
     for (var i = 0; i < 8; i++) {
       eventsController.addEvent(
-        CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+        CalendarEvent(start: day, end: day.add(const Duration(days: 1))),
       );
     }
 

--- a/test/widgets/overlay_test.dart
+++ b/test/widgets/overlay_test.dart
@@ -24,16 +24,12 @@ void main() {
 
     eventsController.addEvents([
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: startOfWeek,
-          end: startOfWeek.copyWith(day: startOfWeek.day + 2),
-        ),
+        start: startOfWeek,
+        end: startOfWeek.copyWith(day: startOfWeek.day + 2),
       ),
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: startOfWeek,
-          end: startOfWeek.copyWith(day: startOfWeek.day + 2),
-        ),
+        start: startOfWeek,
+        end: startOfWeek.copyWith(day: startOfWeek.day + 2),
       ),
     ]);
   });
@@ -147,7 +143,7 @@ void main() {
       final eventsController = DefaultEventsController();
       for (var i = 0; i < eventCount; i++) {
         eventsController.addEvent(
-          CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+          CalendarEvent(start: day, end: day.add(const Duration(days: 1))),
         );
       }
 

--- a/test/widgets/overlay_tile_builder_test.dart
+++ b/test/widgets/overlay_tile_builder_test.dart
@@ -18,8 +18,8 @@ void main() {
     final startOfWeek = DateTime(now.year, now.month, now.day);
     final range = KalenderDateTimeRange(start: startOfWeek, end: startOfWeek.copyWith(day: startOfWeek.day + 2));
     eventsController.addEvents([
-      CalendarEvent(dateTimeRange: range),
-      CalendarEvent(dateTimeRange: range),
+      CalendarEvent(start: range.start, end: range.end),
+      CalendarEvent(start: range.start, end: range.end),
     ]);
 
     final dpi = tester.view.devicePixelRatio;

--- a/test/widgets/page_trigger_test.dart
+++ b/test/widgets/page_trigger_test.dart
@@ -55,8 +55,8 @@ void main() {
     // A 2-day event in the first visible week, shown in the multi-day header.
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange:
-            KalenderDateTimeRange(start: start.add(const Duration(days: 1)), end: start.add(const Duration(days: 3))),
+        start: start.add(const Duration(days: 1)),
+        end: start.add(const Duration(days: 3)),
       ),
     );
 
@@ -93,7 +93,8 @@ void main() {
     final eventStart = start.add(const Duration(days: 1, hours: 9));
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: eventStart, end: eventStart.add(const Duration(hours: 1))),
+        start: eventStart,
+        end: eventStart.add(const Duration(hours: 1)),
       ),
     );
 

--- a/test/widgets/resize_handle_finder_test.dart
+++ b/test/widgets/resize_handle_finder_test.dart
@@ -26,11 +26,12 @@ void main() {
     eventsController = DefaultEventsController();
     calendarController = CalendarController();
     eventId = eventsController.addEvent(
-      CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 4))),
+      CalendarEvent(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 4)),
     );
     otherId = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1, 10), end: DateTime(2025, 1, 1, 14)),
+        start: DateTime(2025, 1, 1, 10),
+        end: DateTime(2025, 1, 1, 14),
       ),
     );
   });

--- a/test/widgets/resize_handle_positioner_test.dart
+++ b/test/widgets/resize_handle_positioner_test.dart
@@ -24,7 +24,8 @@ void main() {
     calendarController = CalendarController();
     eventId = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 4)),
+        start: DateTime(2025, 1, 1, 1),
+        end: DateTime(2025, 1, 1, 4),
       ),
     );
   });

--- a/test/widgets/resize_handle_style_test.dart
+++ b/test/widgets/resize_handle_style_test.dart
@@ -21,7 +21,7 @@ void main() {
     eventsController = DefaultEventsController();
     calendarController = CalendarController();
     eventId = eventsController.addEvent(
-      CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 4))),
+      CalendarEvent(start: DateTime(2025, 1, 1, 1), end: DateTime(2025, 1, 1, 4)),
     );
   });
 

--- a/test/widgets/schedule/schedule_body_test.dart
+++ b/test/widgets/schedule/schedule_body_test.dart
@@ -26,10 +26,8 @@ void main() {
 
   // A one-hour event at [hour] on [day].
   CalendarEvent eventAt(DateTime day, int hour) => CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: DateTime(day.year, day.month, day.day, hour),
-          end: DateTime(day.year, day.month, day.day, hour + 1),
-        ),
+        start: DateTime(day.year, day.month, day.day, hour),
+        end: DateTime(day.year, day.month, day.day, hour + 1),
       );
 
   KalenderView buildSchedule({

--- a/test/widgets/schedule/schedule_drag_target_test.dart
+++ b/test/widgets/schedule/schedule_drag_target_test.dart
@@ -28,8 +28,7 @@ void main() {
   });
 
   String addEvent(DateTime start, Duration duration) {
-    return eventsController
-        .addEvent(CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: start.add(duration))));
+    return eventsController.addEvent(CalendarEvent(start: start, end: start.add(duration)));
   }
 
   Future<void> pumpSchedule(

--- a/test/widgets/schedule/schedule_location_test.dart
+++ b/test/widgets/schedule/schedule_location_test.dart
@@ -27,10 +27,8 @@ void main() {
   });
 
   CalendarEvent eventAt(DateTime day, int hour) => CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(
-          start: TZDateTime(tokyo, day.year, day.month, day.day, hour),
-          end: TZDateTime(tokyo, day.year, day.month, day.day, hour + 1),
-        ),
+        start: TZDateTime(tokyo, day.year, day.month, day.day, hour),
+        end: TZDateTime(tokyo, day.year, day.month, day.day, hour + 1),
       );
 
   KalenderView buildSchedule({

--- a/test/widgets/scroll_trigger_test.dart
+++ b/test/widgets/scroll_trigger_test.dart
@@ -73,7 +73,8 @@ void main() {
     final eventStart = start.add(const Duration(hours: 1));
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: eventStart, end: eventStart.add(const Duration(hours: 1))),
+        start: eventStart,
+        end: eventStart.add(const Duration(hours: 1)),
       ),
     );
 
@@ -97,7 +98,8 @@ void main() {
     final eventStart = start.add(const Duration(hours: 12));
     final id = eventsController.addEvent(
       CalendarEvent(
-        dateTimeRange: KalenderDateTimeRange(start: eventStart, end: eventStart.add(const Duration(hours: 1))),
+        start: eventStart,
+        end: eventStart.add(const Duration(hours: 1)),
       ),
     );
 

--- a/test/widgets/string_builders_test.dart
+++ b/test/widgets/string_builders_test.dart
@@ -142,7 +142,7 @@ void main() {
     testWidgets('the components string builder replaces the day name', (tester) async {
       final eventsController = DefaultEventsController()
         ..addEvent(
-          CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: day, end: day.add(const Duration(hours: 1)))),
+          CalendarEvent(start: day, end: day.add(const Duration(hours: 1))),
         );
 
       await pumpView(
@@ -168,7 +168,7 @@ void main() {
       final eventsController = DefaultEventsController();
       for (var i = 0; i < 8; i++) {
         eventsController.addEvent(
-          CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: day, end: day.add(const Duration(days: 1)))),
+          CalendarEvent(start: day, end: day.add(const Duration(days: 1))),
         );
       }
       return eventsController;


### PR DESCRIPTION
Stacked on #507.

`CalendarEvent` always stored two UTC instants. The constructor took a range and pulled it apart on the next line, and the `dateTimeRange` getter rebuilt one on demand, so the range was a wrapper around a round trip rather than part of the model. It takes the two values now, and `copyWithData` follows.

`withDateTimeRange` keeps its `KalenderDateTimeRange` parameter and unpacks it for `copyWithData`. It is `@nonVirtual`, so it is called rather than overridden, and all eight callers already hold a whole range, so giving it two arguments would have added churn and made its name wrong.

`dateTimeRange` survives as a getter. `lib/` never reads it apart from `duration`, which is now `end.difference(start)` directly, and every use in the examples was `event.dateTimeRange.start` immediately taking it apart, which is `event.start` now. It is one line to keep, and dropping it would be a hand edit no fix can express, so it is worth another look at 1.0.0 rather than now.

This is the one change in the release that no fix can apply for a user. `copyWithData` carries `@mustBeOverridden`, and data-driven fixes rewrite call sites rather than declarations in the user's own code, so every subclass is a hand edit. The migration guide carries a before and after for exactly that.

The constructor asserts `!start.isAfter(end)`. The range it used to take carried that check, so dropping the parameter would have dropped the invariant and left an inverted event to fail later, wherever something read `dateTimeRange` or `internalRange`.

Refs #491.
