### PR TITLE
feat: dart fix applies the 0.30.0 renames and parameter reshapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ See [MIGRATION.md](MIGRATION.md#v029x--v0300) for what to change.
 - `DateTimeExtensions.timeLocalized` formats the time of day for a locale, with `use24HourFormat` to force `HH:mm`.
 - `PageIndexCalculator.month` and `MonthIndexCalculator.fromRange` build a month calculator from a range.
 - `package:kalender/material.dart` converts `KalenderDateTimeRange` and `KalenderTime` to and from Material's `DateTimeRange` and `TimeOfDay`.
+- `dart fix --apply` renames `TimeOfDayRange` to `KalenderTimeRange` and rewrites the `dateTimeRange` argument of `CalendarEvent` and the `PageIndexCalculator` subclasses into `start` and `end`.
 
 ### Fixes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -152,7 +152,8 @@ still names no Material type.
 
 ### `TimeOfDayRange` is renamed to `KalenderTimeRange`
 
-It holds `KalenderTime` values now. Nothing else about it changes.
+`dart fix` applies this one. It holds `KalenderTime` values now, and nothing else
+about it changes.
 
 ```dart
 // Before
@@ -171,6 +172,9 @@ are unchanged and only the type they are called on differs.
 
 The event always stored two UTC instants. The constructor took a range and pulled
 it apart immediately, so it takes the two values now.
+
+`dart fix` applies this at every call site, deriving the two arguments from the
+range you were passing.
 
 ```dart
 // Before
@@ -218,7 +222,7 @@ holds a whole range.
 ### `PageIndexCalculator` takes `start` and `end`
 
 Every subclass unpacked the range into two values and converted each separately, so
-it holds the two values now.
+it holds the two values now. `dart fix` applies this at every call site.
 
 ```dart
 // Before

--- a/lib/fix_data/fix_calendar_event.yaml
+++ b/lib/fix_data/fix_calendar_event.yaml
@@ -1,0 +1,39 @@
+# For details regarding the Flutter Fix feature, see https://flutter.dev/to/flutter-fix
+#
+# Every fix must be tested. The fixtures live in `test_fixes/`, checked by
+# `dart fix --compare-to-golden test_fixes`, which CI runs.
+#
+# For documentation about this file format, see https://dart.dev/go/data-driven-fixes.
+
+version: 1
+transforms:
+  # Changes made in https://github.com/werner-scholtz/kalender/pull/508
+  - title: "Replace 'dateTimeRange' with 'start' and 'end'"
+    date: 2026-09-03
+    element:
+      uris: [ 'package:kalender/kalender.dart' ]
+      constructor: ''
+      inClass: 'CalendarEvent'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'start'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.start'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'addParameter'
+        index: 2
+        name: 'end'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.end'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'removeParameter'
+        name: 'dateTimeRange'

--- a/lib/fix_data/fix_kalender_time.yaml
+++ b/lib/fix_data/fix_kalender_time.yaml
@@ -1,0 +1,18 @@
+# For details regarding the Flutter Fix feature, see https://flutter.dev/to/flutter-fix
+#
+# Every fix must be tested. The fixtures live in `test_fixes/`, checked by
+# `dart fix --compare-to-golden test_fixes`, which CI runs.
+#
+# For documentation about this file format, see https://dart.dev/go/data-driven-fixes.
+
+version: 1
+transforms:
+  # Changes made in https://github.com/werner-scholtz/kalender/pull/506
+  - title: "Rename to 'KalenderTimeRange'"
+    date: 2026-09-03
+    element:
+      uris: [ 'package:kalender/kalender.dart' ]
+      class: 'TimeOfDayRange'
+    changes:
+      - kind: 'rename'
+        newName: 'KalenderTimeRange'

--- a/lib/fix_data/fix_page_index_calculator.yaml
+++ b/lib/fix_data/fix_page_index_calculator.yaml
@@ -1,0 +1,256 @@
+# For details regarding the Flutter Fix feature, see https://flutter.dev/to/flutter-fix
+#
+# Every fix must be tested. The fixtures live in `test_fixes/`, checked by
+# `dart fix --compare-to-golden test_fixes`, which CI runs.
+#
+# For documentation about this file format, see https://dart.dev/go/data-driven-fixes.
+
+version: 1
+transforms:
+  # Changes made in https://github.com/werner-scholtz/kalender/pull/505
+  - title: "Replace 'dateTimeRange' with 'start' and 'end' in 'DayIndexCalculator'"
+    date: 2026-09-03
+    element:
+      uris: [ 'package:kalender/kalender.dart' ]
+      constructor: ''
+      inClass: 'DayIndexCalculator'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'start'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.start'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'addParameter'
+        index: 2
+        name: 'end'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.end'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'removeParameter'
+        name: 'dateTimeRange'
+
+  # Changes made in https://github.com/werner-scholtz/kalender/pull/505
+  - title: "Replace 'dateTimeRange' with 'start' and 'end' in 'WeekIndexCalculator'"
+    date: 2026-09-03
+    element:
+      uris: [ 'package:kalender/kalender.dart' ]
+      constructor: ''
+      inClass: 'WeekIndexCalculator'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'start'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.start'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'addParameter'
+        index: 2
+        name: 'end'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.end'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'removeParameter'
+        name: 'dateTimeRange'
+
+  # Changes made in https://github.com/werner-scholtz/kalender/pull/505
+  - title: "Replace 'dateTimeRange' with 'start' and 'end' in 'WeekIndexCalculator.week'"
+    date: 2026-09-03
+    element:
+      uris: [ 'package:kalender/kalender.dart' ]
+      constructor: 'week'
+      inClass: 'WeekIndexCalculator'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'start'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.start'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'addParameter'
+        index: 2
+        name: 'end'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.end'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'removeParameter'
+        name: 'dateTimeRange'
+
+  # Changes made in https://github.com/werner-scholtz/kalender/pull/505
+  - title: "Replace 'dateTimeRange' with 'start' and 'end' in 'WeekIndexCalculator.workWeek'"
+    date: 2026-09-03
+    element:
+      uris: [ 'package:kalender/kalender.dart' ]
+      constructor: 'workWeek'
+      inClass: 'WeekIndexCalculator'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'start'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.start'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'addParameter'
+        index: 2
+        name: 'end'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.end'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'removeParameter'
+        name: 'dateTimeRange'
+
+  # Changes made in https://github.com/werner-scholtz/kalender/pull/505
+  - title: "Replace 'dateTimeRange' with 'start' and 'end' in 'CustomIndexCalculator'"
+    date: 2026-09-03
+    element:
+      uris: [ 'package:kalender/kalender.dart' ]
+      constructor: ''
+      inClass: 'CustomIndexCalculator'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'start'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.start'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'addParameter'
+        index: 2
+        name: 'end'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.end'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'removeParameter'
+        name: 'dateTimeRange'
+
+  # Changes made in https://github.com/werner-scholtz/kalender/pull/505
+  - title: "Replace 'dateTimeRange' with 'start' and 'end' in 'MonthIndexCalculator'"
+    date: 2026-09-03
+    element:
+      uris: [ 'package:kalender/kalender.dart' ]
+      constructor: ''
+      inClass: 'MonthIndexCalculator'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'start'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.start'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'addParameter'
+        index: 2
+        name: 'end'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.end'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'removeParameter'
+        name: 'dateTimeRange'
+
+  # Changes made in https://github.com/werner-scholtz/kalender/pull/505
+  - title: "Replace 'dateTimeRange' with 'start' and 'end' in 'ContinuousScheduleIndexCalculator'"
+    date: 2026-09-03
+    element:
+      uris: [ 'package:kalender/kalender.dart' ]
+      constructor: ''
+      inClass: 'ContinuousScheduleIndexCalculator'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'start'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.start'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'addParameter'
+        index: 2
+        name: 'end'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.end'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'removeParameter'
+        name: 'dateTimeRange'
+
+  # Changes made in https://github.com/werner-scholtz/kalender/pull/505
+  - title: "Replace 'dateTimeRange' with 'start' and 'end' in 'PaginatedScheduleIndexCalculator'"
+    date: 2026-09-03
+    element:
+      uris: [ 'package:kalender/kalender.dart' ]
+      constructor: ''
+      inClass: 'PaginatedScheduleIndexCalculator'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'start'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.start'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'addParameter'
+        index: 2
+        name: 'end'
+        style: required_named
+        argumentValue:
+          expression: '{% range %}.end'
+          variables:
+            range:
+              kind: 'fragment'
+              value: 'arguments[dateTimeRange]'
+      - kind: 'removeParameter'
+        name: 'dateTimeRange'

--- a/test_fixes/calendar_event.dart
+++ b/test_fixes/calendar_event.dart
@@ -1,0 +1,6 @@
+// The input for `fix_calendar_event.yaml`. Run `dart fix --compare-to-golden test_fixes`.
+
+import 'package:kalender/kalender.dart';
+
+final range = KalenderDateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2025, 1, 2));
+final event = CalendarEvent(dateTimeRange: range);

--- a/test_fixes/calendar_event.dart.expect
+++ b/test_fixes/calendar_event.dart.expect
@@ -1,0 +1,6 @@
+// The input for `fix_calendar_event.yaml`. Run `dart fix --compare-to-golden test_fixes`.
+
+import 'package:kalender/kalender.dart';
+
+final range = KalenderDateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2025, 1, 2));
+final event = CalendarEvent(start: range.start, end: range.end);

--- a/test_fixes/kalender_time.dart
+++ b/test_fixes/kalender_time.dart
@@ -1,0 +1,5 @@
+// The input for `fix_kalender_time.yaml`. Run `dart fix --compare-to-golden test_fixes`.
+
+import 'package:kalender/kalender.dart';
+
+TimeOfDayRange? range;

--- a/test_fixes/kalender_time.dart.expect
+++ b/test_fixes/kalender_time.dart.expect
@@ -1,0 +1,5 @@
+// The input for `fix_kalender_time.yaml`. Run `dart fix --compare-to-golden test_fixes`.
+
+import 'package:kalender/kalender.dart';
+
+KalenderTimeRange? range;

--- a/test_fixes/page_index_calculator.dart
+++ b/test_fixes/page_index_calculator.dart
@@ -1,0 +1,14 @@
+// The input for `fix_page_index_calculator.yaml`. Run `dart fix --compare-to-golden test_fixes`.
+
+import 'package:kalender/kalender.dart';
+
+final range = KalenderDateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2026));
+
+final day = DayIndexCalculator(dateTimeRange: range);
+final week = WeekIndexCalculator(dateTimeRange: range, firstDayOfWeek: DateTime.monday, daysToDisplay: 7);
+final standardWeek = WeekIndexCalculator.week(dateTimeRange: range, firstDayOfWeek: DateTime.monday);
+final workWeek = WeekIndexCalculator.workWeek(dateTimeRange: range);
+final custom = CustomIndexCalculator(dateTimeRange: range, numberOfDays: 3);
+final month = MonthIndexCalculator(dateTimeRange: range, firstDayOfWeek: DateTime.monday);
+final schedule = ContinuousScheduleIndexCalculator(dateTimeRange: range);
+final paginated = PaginatedScheduleIndexCalculator(dateTimeRange: range);

--- a/test_fixes/page_index_calculator.dart.expect
+++ b/test_fixes/page_index_calculator.dart.expect
@@ -1,0 +1,14 @@
+// The input for `fix_page_index_calculator.yaml`. Run `dart fix --compare-to-golden test_fixes`.
+
+import 'package:kalender/kalender.dart';
+
+final range = KalenderDateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2026));
+
+final day = DayIndexCalculator(start: range.start, end: range.end);
+final week = WeekIndexCalculator(start: range.start, end: range.end, firstDayOfWeek: DateTime.monday, daysToDisplay: 7);
+final standardWeek = WeekIndexCalculator.week(start: range.start, end: range.end, firstDayOfWeek: DateTime.monday);
+final workWeek = WeekIndexCalculator.workWeek(start: range.start, end: range.end);
+final custom = CustomIndexCalculator(start: range.start, end: range.end, numberOfDays: 3);
+final month = MonthIndexCalculator(start: range.start, end: range.end, firstDayOfWeek: DateTime.monday);
+final schedule = ContinuousScheduleIndexCalculator(start: range.start, end: range.end);
+final paginated = PaginatedScheduleIndexCalculator(start: range.start, end: range.end);


### PR DESCRIPTION
Stacked on #508.

Three fix files covering everything in the release that can carry one:

- `TimeOfDayRange` to `KalenderTimeRange`, a plain rename.
- `CalendarEvent(dateTimeRange:)` to `start` and `end`, deriving both arguments from the range the call already passes.
- The same reshape for the eight `PageIndexCalculator` constructors.

A fixture pair per file, checked by the `dart fix --compare-to-golden test_fixes` step CI already runs. I confirmed the check is real by corrupting a golden and watching it fail.

Two things worth recording. A0's fixtures all referenced deprecated members that still existed, and these reference removed ones, so I verified first that a data-driven fix still applies to an element that is gone. It does. And I checked the whole thing end to end the way A0 did, by putting old-style code in `examples/example` and running `dart fix --dry-run`, which proposed all three.

What cannot carry a fix, and is written up in the migration guide instead: the `DateTimeRange` and `TimeOfDay` type swaps, because kalender cannot deprecate another package's type and no parameter was renamed alongside them to give the fix an anchor; and every `copyWithData` override, because a fix rewrites call sites rather than declarations in the user's own code.

Refs #491.
