### PR TITLE
refactor: the files that no longer need Material import widgets

### DIFF
--- a/lib/src/kalender_view.dart
+++ b/lib/src/kalender_view.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/layout_delegates/kalender_layout_delegate.dart';
 import 'package:kalender/src/models/providers/gutter_widths.dart';
@@ -25,7 +25,7 @@ class KalenderView extends StatefulWidget {
   /// - [ScheduleComponents]
   ///
   /// Styles live on [KalenderThemeData] rather than here. Register one on
-  /// [ThemeData.extensions], or wrap a calendar in a [KalenderTheme] to scope it.
+  /// `ThemeData.extensions`, or wrap a calendar in a [KalenderTheme] to scope it.
   final KalenderComponents? components;
 
   /// The header widget that will be displayed above the body.

--- a/lib/src/layout_delegates/event_layout_delegate.dart
+++ b/lib/src/layout_delegates/event_layout_delegate.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/kalender_events/kalender_event.dart';
 import 'package:kalender/src/models/kalender_time_range.dart';

--- a/lib/src/layout_delegates/multi_day_event_layout.dart
+++ b/lib/src/layout_delegates/multi_day_event_layout.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 
 /// Assigns each event in the multi-day lane a row and a span of columns.

--- a/lib/src/models/components/month_components.dart
+++ b/lib/src/models/components/month_components.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/models/components/components.dart';
 import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/models/kalender_date_time_range.dart';

--- a/lib/src/models/components/multi_day_components.dart
+++ b/lib/src/models/components/multi_day_components.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/models/components/components.dart';
 import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/models/kalender_events/kalender_event.dart';

--- a/lib/src/models/components/schedule_components.dart
+++ b/lib/src/models/components/schedule_components.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/components/string_builders.dart';
 import 'package:kalender/src/widgets/components/schedule_date.dart';
@@ -26,7 +26,7 @@ class ScheduleComponents {
 
   /// A function that builds the month heading row.
   ///
-  /// When null a [ListTile] shows the month name in the calendar's locale.
+  /// When null a `ListTile` shows the month name in the calendar's locale.
   final MonthItemBuilder? monthItemBuilder;
 
   const ScheduleComponents({

--- a/lib/src/models/components/string_builders.dart
+++ b/lib/src/models/components/string_builders.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/models/kalender_time.dart';
 import 'package:kalender/src/models/providers/kalender_provider.dart';
 

--- a/lib/src/models/components/tile_components.dart
+++ b/lib/src/models/components/tile_components.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart'
     show
         KalenderEvent,

--- a/lib/src/models/controllers/kalender_controller.dart
+++ b/lib/src/models/controllers/kalender_controller.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/extensions/internal_date_time_range.dart';
 import 'package:kalender/src/kalender_view.dart';
 import 'package:kalender/src/models/controllers/view_controller.dart';

--- a/lib/src/models/controllers/view_controllers/multi_day_view_controller.dart
+++ b/lib/src/models/controllers/view_controllers/multi_day_view_controller.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:linked_pageview/linked_pageview.dart';
 

--- a/lib/src/models/kalender_callbacks.dart
+++ b/lib/src/models/kalender_callbacks.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/kalender_events/draggable_event.dart';
 import 'package:kalender/src/widgets/drag_targets/horizontal_drag_target.dart';

--- a/lib/src/models/mixins/drag_target_utils.dart
+++ b/lib/src/models/mixins/drag_target_utils.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/kalender_events/draggable_event.dart';
 import 'package:kalender/src/models/providers/kalender_provider.dart';

--- a/lib/src/models/mixins/event_tile_utils.dart
+++ b/lib/src/models/mixins/event_tile_utils.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/kalender_provider.dart';
 

--- a/lib/src/models/view_configurations/month_view_configuration.dart
+++ b/lib/src/models/view_configurations/month_view_configuration.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 import 'package:kalender/kalender.dart';
 

--- a/lib/src/models/view_configurations/multi_day_view_configuration.dart
+++ b/lib/src/models/view_configurations/multi_day_view_configuration.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/layout_delegates/event_layout_delegate.dart';
 import 'package:kalender/src/layout_delegates/multi_day_event_layout.dart';
 import 'package:kalender/src/models/kalender_events/multi_day_rule.dart';

--- a/lib/src/models/view_configurations/page_index_calculator.dart
+++ b/lib/src/models/view_configurations/page_index_calculator.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/models/view_configurations/month_view_configuration.dart';
 import 'package:kalender/src/models/view_configurations/multi_day_view_configuration.dart';
 import 'package:kalender/src/models/view_configurations/view_configuration.dart';

--- a/lib/src/models/view_configurations/schedule_view_configuration.dart
+++ b/lib/src/models/view_configurations/schedule_view_configuration.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 
 /// The type of the schedule view.

--- a/lib/src/models/view_configurations/view_configuration.dart
+++ b/lib/src/models/view_configurations/view_configuration.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/layout_delegates/event_layout_delegate.dart';
 import 'package:kalender/src/layout_delegates/multi_day_event_layout.dart';
 import 'package:kalender/src/models/kalender_events/multi_day_rule.dart';

--- a/lib/src/widgets/components/resize_handles.dart
+++ b/lib/src/widgets/components/resize_handles.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/src/enumerations.dart';
 import 'package:kalender/src/layout_delegates/event_layout_delegate.dart';
 import 'package:kalender/src/models/components/tile_components.dart';

--- a/lib/src/widgets/drag_targets/horizontal_drag_target.dart
+++ b/lib/src/widgets/drag_targets/horizontal_drag_target.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/kalender_events/draggable_event.dart';
 import 'package:kalender/src/models/providers/kalender_provider.dart';

--- a/lib/src/widgets/drag_targets/vertical_drag_target.dart
+++ b/lib/src/widgets/drag_targets/vertical_drag_target.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/kalender_events/draggable_event.dart';
 import 'package:kalender/src/models/mixins/snap_points.dart';

--- a/lib/src/widgets/event_tiles/tiles/day_tile.dart
+++ b/lib/src/widgets/event_tiles/tiles/day_tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/kalender_provider.dart';
 import 'package:kalender/src/widgets/event_tiles/event_tile.dart';

--- a/lib/src/widgets/event_tiles/tiles/multi_day_overlay_tile.dart
+++ b/lib/src/widgets/event_tiles/tiles/multi_day_overlay_tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender_extensions.dart';
 import 'package:kalender/src/models/components/tile_components.dart';
 import 'package:kalender/src/models/kalender_callbacks.dart';

--- a/lib/src/widgets/event_tiles/tiles/multi_day_tile.dart
+++ b/lib/src/widgets/event_tiles/tiles/multi_day_tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/kalender_provider.dart';
 import 'package:kalender/src/widgets/event_tiles/event_tile.dart';

--- a/lib/src/widgets/internal_components/month_week_number_gutter.dart
+++ b/lib/src/widgets/internal_components/month_week_number_gutter.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/gutter_widths.dart';
 import 'package:kalender/src/models/providers/kalender_provider.dart';

--- a/lib/src/widgets/month/month_body.dart
+++ b/lib/src/widgets/month/month_body.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/layout_delegates/month_week_number_layout_delegate.dart';
 import 'package:kalender/src/models/providers/kalender_provider.dart';

--- a/lib/src/widgets/month/month_header.dart
+++ b/lib/src/widgets/month/month_header.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/kalender_provider.dart';
 import 'package:kalender/src/widgets/internal_components/month_week_number_gutter.dart';

--- a/lib/src/widgets/multi_day/multi_day_header.dart
+++ b/lib/src/widgets/multi_day/multi_day_header.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:kalender/kalender.dart';
 import 'package:kalender/src/models/providers/kalender_provider.dart';
 import 'package:kalender/src/widgets/drag_targets/horizontal_drag_target.dart';


### PR DESCRIPTION
Stacked on #510.

B1 and B2 removed the last reason 28 files in `lib/` had to name a Material type, and nothing re-ran A2's sweep afterwards. The analyzer decides membership rather than judgement: swapping every `material.dart` import for `widgets.dart` and reverting only the files that then fail leaves 14 that genuinely need Material, all of them widgets and theming. `multi_day_overlay.dart` (15 errors), `day_number.dart` and `kalender_theme.dart` (6 each), the two draggables and `time_line.dart` (4 each), `schedule_body.dart` (3), then singles.

Two files named a Material type from a doc comment only, so `ThemeData.extensions` in `kalender_view.dart` and `ListTile` in `schedule_components.dart` are code spans rather than links. Importing the library for a hyperlink is the thing this is undoing.

No public API changes, so no changelog entry, matching #502.

Refs #491.
