### PR TITLE
fix(web demo): the initial time of day clamps at midnight

### DIFF
--- a/examples/web_demo/lib/models/demo_configuration.dart
+++ b/examples/web_demo/lib/models/demo_configuration.dart
@@ -19,7 +19,7 @@ class DemoConfiguration extends ChangeNotifier {
 
   KalenderTime get _initialTimeOfDay {
     final now = KalenderTime.now();
-    final hour = now.hour == 2 ? 1 : (now.hour - 2);
+    final hour = now.hour < 2 ? 0 : now.hour - 2;
     return KalenderTime(hour: hour, minute: 0);
   }
 


### PR DESCRIPTION
The demo's initial scroll position took `now.hour - 2` with no floor, so between midnight and 02:00 it built a negative hour. Converting that to a `DateTime` rolls backwards into the previous day at 22:00, so the demo opened on the wrong day's scroll position. The special case for hour 2 covered only one of the three affected hours.

Found while adding range asserts to `KalenderTime` in the 0.30.0 stack. It targets `main` rather than that stack because the defect predates it.