### PR TITLE
docs: drop the readme title the banner already carries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license: MIT"></a>
 </p>
 
-# Kalender
-
 A highly customizable Flutter calendar widget with Day, Multi-day, Month and Schedule views. It supports drag-and-drop rescheduling, event resizing, timezones, and full control over appearance and behavior.
 
 **[Live Demo](https://werner-scholtz.github.io/kalender/)** · **[Benchmarks](https://werner-scholtz.github.io/kalender/dev/bench/)** · **[Migration Guide](MIGRATION.md)**


### PR DESCRIPTION
The banner image at the top of the readme spells out the package name, so the `# Kalender` heading below the badges repeated it. Nothing links to the anchor.