### PR TITLE
docs: drop the licence bullet from the feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ A highly customizable Flutter calendar widget with Day, Multi-day, Month and Sch
 - **Material 3 by default.** Follows your app's theme with no setup.
 - **Timezone aware.** Events stored as UTC, shown in any IANA location. Tested under a matrix of timezones.
 - **Localized.** Day and month names from intl, and every string replaceable.
-- **MIT licensed.** No commercial license to buy.
 
 ## Installation
 


### PR DESCRIPTION
The licence is already in the badge row at the top of the readme, and it is not a feature of the widget.