### PR TITLE
docs: the migration guide notes what dart fix copies

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -47,9 +47,6 @@ The sections below cover what is left after the fixes have run.
 
 ## v0.29.x → v0.30.0
 
-`dart fix --apply` applies most of this release. If it reports an analysis server
-error, run it over fewer files at a time.
-
 ### The `Calendar*` types are renamed to `Kalender*`
 
 `dart fix` applies all of these. The package has been converging on `Kalender` as
@@ -297,6 +294,12 @@ The factories on `PageIndexCalculator` still take a range, so
 `PageIndexCalculator.week(range, firstDayOfWeek)` is unchanged.
 `MonthIndexCalculator.fromRange(range, firstDayOfWeek)` is the equivalent for the
 month view.
+
+A file constructing two or more subclasses directly stops `dart fix` with an
+analysis server error. The run then applies nothing, in that file or any other, and
+does not exit on its own. Change those call sites by hand, or run `dart fix` over
+one file at a time. Constructing one subclass per file is unaffected, and so is any
+number of events.
 
 ### The schedule view converts what it reports
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -47,6 +47,9 @@ The sections below cover what is left after the fixes have run.
 
 ## v0.29.x → v0.30.0
 
+`dart fix --apply` applies most of this release. If it reports an analysis server
+error, run it over fewer files at a time.
+
 ### The `Calendar*` types are renamed to `Kalender*`
 
 `dart fix` applies all of these. The package has been converging on `Kalender` as
@@ -232,11 +235,15 @@ range you were passing.
 
 ```dart
 // Before
-CalendarEvent(dateTimeRange: KalenderDateTimeRange(start: start, end: end))
+CalendarEvent(dateTimeRange: range)
 
 // After
-KalenderEvent(start: start, end: end)
+KalenderEvent(start: range.start, end: range.end)
 ```
+
+The fix copies the argument into both parameters. Where the argument is an
+expression rather than a variable, that expression appears twice and is evaluated
+twice, so rewrite those call sites by hand.
 
 `dateTimeRange` survives as a getter, so `event.dateTimeRange` still returns a
 `KalenderDateTimeRange`. `event.start` and `event.end` are usually what you want.

--- a/test_fixes/calendar_event.dart
+++ b/test_fixes/calendar_event.dart
@@ -4,3 +4,7 @@ import 'package:kalender/kalender.dart';
 
 final range = KalenderDateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2025, 1, 2));
 final event = CalendarEvent(dateTimeRange: range);
+
+// An argument that is not a variable is copied into both parameters.
+KalenderDateTimeRange makeRange() => KalenderDateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2025, 1, 2));
+final computed = CalendarEvent(dateTimeRange: makeRange());

--- a/test_fixes/calendar_event.dart.expect
+++ b/test_fixes/calendar_event.dart.expect
@@ -4,3 +4,7 @@ import 'package:kalender/kalender.dart';
 
 final range = KalenderDateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2025, 1, 2));
 final event = KalenderEvent(start: range.start, end: range.end);
+
+// An argument that is not a variable is copied into both parameters.
+KalenderDateTimeRange makeRange() => KalenderDateTimeRange(start: DateTime.utc(2025), end: DateTime.utc(2025, 1, 2));
+final computed = KalenderEvent(start: makeRange().start, end: makeRange().end);


### PR DESCRIPTION
The `CalendarEvent` migration example showed `KalenderEvent(start: start, end: end)` for an argument that is not a variable, which is not what the fix produces. A data-driven transform substitutes the argument expression into both parameters, so that call gets the whole `KalenderDateTimeRange(...)` construction twice.

The fixture only covered a plain variable, where the duplication is invisible and harmless, so nothing caught it. It now covers an argument that is not a variable, and the golden records the duplicated output.

Also notes that `dart fix` can fail with an analysis server error when it runs over a file carrying several of these migrations at once, and that running it over fewer files works around it. That crash is in the SDK's data-driven fix code, not in the fix data.