### PR TITLE
chore: prepare 0.30.0-dev.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ See [MIGRATION.md](MIGRATION.md#v029x--v0300) for what to change.
 - `DateTimeExtensions.timeLocalized` formats the time of day for a locale, with `use24HourFormat` to force `HH:mm`.
 - `PageIndexCalculator.month` and `MonthIndexCalculator.fromRange` build a month calculator from a range.
 - `package:kalender/material.dart` converts `KalenderDateTimeRange` and `KalenderTime` to and from Material's `DateTimeRange` and `TimeOfDay`.
-- `dart fix --apply` renames the eight `Calendar*` types to `Kalender*`, renames `TimeOfDayRange` and `TimeOfDayStringBuilder` to `KalenderTimeRange` and `KalenderTimeStringBuilder`, renames `calendarController` to `kalenderController`, the two `KalenderScope` controller accessors and `ViewController.visibleDateTimeRange` to match, and rewrites the `dateTimeRange` argument of `CalendarEvent` and the `PageIndexCalculator` subclasses into `start` and `end`.
+- `dart fix --apply` applies this release's renames and both parameter reshapes.
 
 ### Fixes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -187,7 +187,7 @@ The month comes along, which is what makes the rule true of the whole package ra
 `gutter_style_scope_test.dart` is replaced by `gutter_width_test.dart`. The tests that report an ignored scoped style go with the report. The ones that check the gutter and the spacer measure alike, that a theme above the calendar reaches the gutter, and that the drag target spacer matches are carried over. The labels-fit test is rewritten against the default, since a scoped text size is now meant to lay the labels out wider than the gutter.
 
 
-### 0.30.0, off Material
+### 0.30.0, off Material, previewed in 0.30.0-dev.1
 
 **Flutter moved Material and Cupertino out of the framework, and the two value types kalender's public API is built on went with them.** `material_ui` and `cupertino_ui` are 1.x packages in `flutter/packages` now, and `material_ui` redefines `DateTimeRange` and `TimeOfDay` as its own classes. `package:flutter/material.dart` still ships in 3.47.2 carrying no deprecation, so nothing is broken today. An app that runs the migration Flutter documents, `dart fix --apply --code=migrate_design_widgets`, ends up holding types with the same names as the ones kalender asks for and no relationship to them. No bridge closes that, because it is a compile-time identity problem rather than a runtime lookup.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kalender
 description: A highly customizable calendar widget with day, multi-day, month and schedule views, drag-and-drop rescheduling, event resizing, and timezone support.
-version: 0.29.1
+version: 0.30.0-dev.1
 repository: https://github.com/werner-scholtz/kalender.git
 issue_tracker: https://github.com/werner-scholtz/kalender/issues
 topics:


### PR DESCRIPTION
Bumps the version for the 0.30.0 preview. The changelog heading stays at `## 0.30.0`, matching how 0.28.0-dev.1 and 0.29.0-dev.1 shipped, so `pub publish` warns that the changelog does not name the dev version. That warning is expected and does not block publishing.

The `dart fix --apply` changelog entry had grown into a paragraph listing every transform. The migration guide covers each one.