### PR TITLE
ci: the publish workflow uses the Dart that Flutter ships

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,11 +36,9 @@ jobs:
           [ "$version" = "$tag" ] \
             || { echo "::error::pubspec.yaml is $version but the tag is $tag"; exit 1; }
 
-      # For Flutter package
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
+      # Flutter ships the Dart SDK it needs. A standalone Dart on PATH is used
+      # for pub operations instead, and cannot resolve the versions flutter_tools
+      # pins, so `flutter pub get` fails.
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'


### PR DESCRIPTION
`v0.30.0-dev.1` failed at `flutter pub get` with `Because flutter_tools depends on test 1.31.1 which doesn't match any versions, version solving failed.`

The workflow installed a standalone Dart with `dart-lang/setup-dart` alongside Flutter. That Dart is used for pub operations and cannot resolve the versions `flutter_tools` pins, so `flutter pub get` fails before anything is published. The analyze and test workflows use `subosito/flutter-action` alone and pass on the same commit, with the same `FLUTTER_ROOT` and `PUB_CACHE`. `DART_HOME` was the only difference between them.

Flutter 3.47.3 ships Dart 3.13.3, which is the version `setup-dart` was installing, so the step added nothing.

`id-token: write` stays, so `flutter pub publish` still exchanges the OIDC token for pub.dev.