### PR TITLE
ci: the publish workflow sets up Dart just before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,5 +68,14 @@ jobs:
       - name: Dry-run publish
         run: flutter pub publish --dry-run
 
+      # Exchanges the workflow's OIDC token for a pub.dev credential. It runs
+      # here rather than with the other setup because the Dart it installs is
+      # used for pub operations ahead of the one Flutter ships, which cannot
+      # resolve the versions flutter_tools pins. By this point Flutter has built
+      # its tool snapshot, so publishing does not resolve them again.
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
       - name: Publish
         run: flutter pub publish --force


### PR DESCRIPTION
#519 removed `dart-lang/setup-dart` to fix `flutter pub get`, which worked, but that step also exchanges the workflow's OIDC token for a pub.dev credential. Without it `flutter pub publish` fell back to interactive OAuth and the job waited for a browser authorization that never came.

The step is back, placed after everything that resolves dependencies. The Dart it installs is used for pub operations ahead of the one Flutter ships and cannot resolve the versions `flutter_tools` pins, which is what broke `flutter pub get` when it ran first. By the time publishing starts, Flutter has built its tool snapshot and does not resolve them again.

Nothing has been published. `v0.30.0-dev.1` is not on pub.dev.