### PR TITLE
ci: a workflow to find why publishing cannot resolve dependencies

### DIFF
--- a/.github/workflows/debug_publish_auth.yml
+++ b/.github/workflows/debug_publish_auth.yml
@@ -1,0 +1,44 @@
+# Temporary. Reproduces the publish workflow's dependency resolution to find why
+# it fails, and removes the pub.dev credential to compare in the same run.
+# Delete once the cause is known.
+name: Debug publish auth
+
+on:
+  workflow_dispatch:
+
+jobs:
+  probe:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.13.2
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.47.2
+          channel: 'stable'
+
+      - name: Which hosts have a credential
+        run: dart pub token list || true
+
+      - name: Resolve with the credential present
+        id: authenticated
+        continue-on-error: true
+        run: flutter pub get
+
+      - name: The pub log from that attempt
+        if: always()
+        run: cat "${PUB_CACHE:-$HOME/.pub-cache}/log/pub_log.txt" || echo "no pub log written"
+
+      - name: Resolve again with the credential removed
+        if: always()
+        run: |
+          dart pub token remove https://pub.dev || true
+          rm -f "${PUB_CACHE:-$HOME/.pub-cache}/log/pub_log.txt"
+          flutter pub get


### PR DESCRIPTION
Publishing has failed for two days at `flutter pub get` with `flutter_tools depends on test 1.31.1 which doesn't match any versions`. That version is published on pub.dev, so the message means pub could not read the version list rather than that the version is missing. Re-running produced the same failure a day later, so it is not transient, and pinning Flutter and Dart to the versions that published 0.29.1 did not change it.

Every fix so far has been inferred from the step that failed. This runs the same resolution manually and prints `pub_log.txt`, which carries the HTTP requests and responses, then removes the pub.dev credential and resolves again in the same job. That separates an authentication rejection from a local resolution failure, which need different fixes.

Manually triggered, never publishes anything. Delete once the cause is known.