### PR TITLE
docs: the 0.30.0 documentation matches the API it describes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@ See [MIGRATION.md](MIGRATION.md#v029x--v0300) for what to change.
 - The deprecated `CalendarView` and `CalendarViewState` typedefs are removed.
 - `KalenderDateTimeRange` replaces Material's `DateTimeRange` in every public signature.
 - `KalenderTime` replaces Material's `TimeOfDay` in every public signature.
-- `TimeOfDayRange` is renamed to `KalenderTimeRange`, and holds `KalenderTime` values.
+- `TimeOfDayRange` is renamed to `KalenderTimeRange`.
+- `KalenderTimeRange` holds `KalenderTime` values.
 - `TimeOfDayStringBuilder` is renamed to `KalenderTimeStringBuilder`.
-- `TimeOfDayExtension` is removed. `toInternalDateTime` and `toDateTime` are methods on `KalenderTime`.
-- `InternalDateTimeRange` no longer extends `DateTimeRange`, and `forLocation` returns a `KalenderDateTimeRange`.
-- `InternalDateTimeRange.overlaps` takes an `InternalDateTimeRange`, and `InternalDateTimeRange.fromDateTimeRange` takes a `KalenderDateTimeRange`.
-- `CalendarEvent` and `CalendarEvent.copyWithData` take `start` and `end` rather than `dateTimeRange`.
+- `TimeOfDayExtension` is removed.
+- `toInternalDateTime` and `toDateTime` are methods on `KalenderTime`.
+- `InternalDateTimeRange` no longer extends `DateTimeRange`.
+- `InternalDateTimeRange.forLocation` returns a `KalenderDateTimeRange`.
+- `InternalDateTimeRange.overlaps` takes an `InternalDateTimeRange`.
+- `InternalDateTimeRange.fromDateTimeRange` takes a `KalenderDateTimeRange`.
+- `KalenderEvent` and `KalenderEvent.copyWithData` take `start` and `end` rather than `dateTimeRange`.
 - `PageIndexCalculator` and its subclasses take `start` and `end` rather than `dateTimeRange`.
 - `DragTargetUtils.calculateDateTimeRangeFromStart` and `calculateDateTimeRangeFromEnd` take an `InternalDateTimeRange`.
 - `EventTileUtils.eventRangeOnDate` returns an `InternalDateTimeRange`.
@@ -25,14 +29,14 @@ See [MIGRATION.md](MIGRATION.md#v029x--v0300) for what to change.
 
 ### Behavior Changes
 
-- The schedule view reports `onPageChanged` in the calendar's location, matching the multi-day and month views.
+- The schedule view reports `onPageChanged` in the calendar's location.
 - The schedule view's `monthItemBuilder` and `emptyItemBuilder` receive ranges in the calendar's location.
-- The timeline's drag tooltip tests visibility in the calendar's own time space rather than against converted values.
-- `KalenderTime` asserts that its `hour` and `minute` are within a day, matching `replacing`.
+- The timeline's drag tooltip tests visibility in the calendar's own time space.
+- `KalenderTime` asserts that its `hour` and `minute` are within a day.
 
 ### Deprecations
 
-- `BuildContext.calendarLocale` is renamed to `kalenderLocale`. The old name is a deprecated getter, removed in 0.31.0.
+- `BuildContext.calendarLocale` is renamed to `kalenderLocale`. The old name is removed in 0.31.0.
 
 ### Features
 
@@ -40,7 +44,7 @@ See [MIGRATION.md](MIGRATION.md#v029x--v0300) for what to change.
 - `PageIndexCalculator.month` and `MonthIndexCalculator.fromRange` build a month calculator from a range.
 - `package:kalender/material.dart` converts `KalenderDateTimeRange` and `KalenderTime` to and from Material's `DateTimeRange` and `TimeOfDay`.
 - `dart fix --apply` applies this release's renames and both parameter reshapes.
-- `context.calendarLocale` is the one rename `dart fix` cannot apply.
+- `dart fix` does not apply the `context.calendarLocale` rename.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ See [MIGRATION.md](MIGRATION.md#v029x--v0300) for what to change.
 - `PageIndexCalculator.month` and `MonthIndexCalculator.fromRange` build a month calculator from a range.
 - `package:kalender/material.dart` converts `KalenderDateTimeRange` and `KalenderTime` to and from Material's `DateTimeRange` and `TimeOfDay`.
 - `dart fix --apply` applies this release's renames and both parameter reshapes.
+- `context.calendarLocale` is the one rename `dart fix` cannot apply.
 
 ### Fixes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,8 +49,7 @@ The sections below cover what is left after the fixes have run.
 
 ### The `Calendar*` types are renamed to `Kalender*`
 
-`dart fix` applies all of these. The package has been converging on `Kalender` as
-its ownership marker since `KalenderView`, and this release finishes it.
+`dart fix` applies all of these.
 
 | Before | After |
 | --- | --- |
@@ -76,10 +75,9 @@ The `CalendarLocale` extension on `BuildContext` is `KalenderLocale` now.
 | `KalenderScope.maybeCalendarControllerOf` | `KalenderScope.maybeKalenderControllerOf` |
 | `ViewController.visibleDateTimeRange` | `ViewController.internalVisibleRange` |
 
-`ViewController`'s is the one that was not only a naming question.
-`KalenderController.visibleDateTimeRange` is a `KalenderDateTimeRange` and
-`ViewController`'s was an `InternalDateTimeRange`, so one name meant two types
-across the public API. A member carrying the internal layout space says
+`ViewController`'s changes type as well as name. `KalenderController.visibleDateTimeRange`
+is a `KalenderDateTimeRange` and `ViewController`'s is an `InternalDateTimeRange`, so
+check which one a call site holds. A member carrying the internal layout space says
 `internal` in its name now.
 
 `MultiDayRule.calendarDays` is unchanged. A calendar day is a unit of time, not a
@@ -87,10 +85,8 @@ reference to the type.
 
 ### `context.calendarLocale` is `context.kalenderLocale`
 
-The one rename in this release `dart fix` cannot apply. A data-driven fix matches
-an extension member only where the extension is named explicitly, and nobody writes
-`KalenderLocale(context).calendarLocale`. The old name is a deprecated getter that
-forwards to the new one, so the analyzer points at every call site, and it is
+The one rename in this release `dart fix` cannot apply. The old name is a deprecated
+getter that forwards to the new one, so the analyzer points at every call site. It is
 removed in 0.31.0.
 
 ```dart
@@ -108,14 +104,11 @@ them to `KalenderView` and `KalenderViewState` since 0.29.1, and still does.
 
 ### `KalenderDateTimeRange` replaces Material's `DateTimeRange`
 
-Material and Cupertino left the Flutter framework and became the `material_ui` and
-`cupertino_ui` packages. `DateTimeRange` exists in both, and two same-named classes
-from two packages are different types to the compiler, so a package naming either
-one shuts out every app on the other side. Kalender owns the type instead.
+Kalender owns this type now, so a call site reads the same whether the app uses
+Material or `material_ui`.
 
-`dart fix` cannot do this one. Kalender cannot deprecate another package's type, so
-there is nothing for a fix to trigger on. A project-wide replace of `DateTimeRange(`
-with `KalenderDateTimeRange(` covers it, plus the annotations.
+`dart fix` cannot do this one. A project-wide replace of `DateTimeRange(` with
+`KalenderDateTimeRange(` covers it, plus the annotations.
 
 ```dart
 // Before
@@ -195,8 +188,8 @@ final picked = await showTimePicker(context: context, initialTime: time.toTimeOf
 final time = picked?.toKalenderTime();
 ```
 
-It is a separate entry point, so importing `package:kalender/kalender.dart` alone
-still names no Material type.
+It is a separate entry point, so no value type in `package:kalender/kalender.dart`
+names a Material class. Theming still does, through `KalenderThemeData`.
 
 ### `TimeOfDayRange` is renamed to `KalenderTimeRange`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -231,6 +231,14 @@ The question per field is whether it reaches something an app cannot otherwise r
 
 The missing `ResizeHandleStyle` moved to 0.28.0 above.
 
+### Known defects
+
+Found reviewing 0.30.0, neither introduced by it. Both are fixable without a break, so neither waits for a window.
+
+**`KalenderController.id` is not unique.** The constructor takes it from `DateTime.now().millisecondsSinceEpoch`, so two controllers built in the same millisecond share an id, and two calendars on one screen is the ordinary way to reach that. The drag targets compare on that id to decide whether a create gesture is theirs, so a create drag can be accepted by the wrong calendar. A static counter fixes it. This one can produce wrong behaviour at runtime, so it goes first.
+
+**`KalenderTimeRange.coversWholeDay` ignores the start minute.** It tests `start.hour == 0 && end.hour == 23 && end.minute == 59`, so a range from 00:30 to 23:59 reports that it covers the whole day. The tests cover the cases it was written against and not this one, so the fix needs the missing case with it.
+
 ### Tests
 
 Coverage is 92.3% of lines, up from 88.2% at 0.24.0 and 84.4% at 0.23.0. It gates the composability work below, and that gate is now met.
@@ -248,6 +256,8 @@ Both columns are line coverage of the directory and everything under it, measure
 | `theme/` | 78% | 97% | Done. 0.25.0 rewrote this code and tested it, taking it from the lowest covered area to one of the highest. |
 
 The rest runs from 79% to 100% with no large gap.
+
+**Two things CI does not verify.** `analyze_examples.yml` pins every example to Flutter 3.44.6, `examples/material_ui` with them, though its `.fvmrc` says 3.47.2 and the SDK that moved Material out is the whole point of it. That example has never been analyzed on the version it demonstrates. Separately, `pubspec.yaml` declares `flutter: ">=3.22.0"` and nothing runs near that, while `lib/material.dart` writes `DateTimeRange<DateTime>`, which the Material class has not always been. Add a job on the declared minimum and set the bound from what it reports rather than from a guess.
 
 Both areas the 0.24.0 backfill named are now closed, so the coverage gate on the composability work below is met. What is left is smaller and spread out: `schedule_view_configuration.dart` at 42%, `multi_day_overlay_tile.dart` at 31% and `schedule_tile.dart` at 39%.
 

--- a/doc/events.md
+++ b/doc/events.md
@@ -34,8 +34,13 @@ class Event extends KalenderEvent {
   // itself, so none of those are listed here.
   @override
   Event copyWithData({required DateTime start, required DateTime end}) {
-    return Event(start: start,
-      end: end, title: title, description: description, color: color);
+    return Event(
+      start: start,
+      end: end,
+      title: title,
+      description: description,
+      color: color,
+    );
   }
 
   // A copy method of your own. It is not an override, so it takes whatever
@@ -121,7 +126,7 @@ Pass this as `KalenderView.callbacks`:
 KalenderCallbacks(
   onEventCreate: (event) => Event(
     start: event.start,
-      end: event.end,
+    end: event.end,
     title: 'New Event',
     color: Colors.blue,
   ),

--- a/doc/timezones-and-locales.md
+++ b/doc/timezones-and-locales.md
@@ -104,7 +104,7 @@ MultiDayBodyComponents(
 
 ## Location
 
-`KalenderView` accepts a `Location` from the [timezone](https://pub.dev/packages/timezone) package. The `KalenderEvent` constructor automatically converts `dateTimeRange` values to UTC, so events are always stored in UTC internally and converted to the given location for display.
+`KalenderView` accepts a `Location` from the [timezone](https://pub.dev/packages/timezone) package. The `KalenderEvent` constructor automatically converts `start` and `end` to UTC, so events are always stored in UTC internally and converted to the given location for display.
 
 <!-- snippet: expression -->
 ```dart

--- a/examples/material_ui/README.md
+++ b/examples/material_ui/README.md
@@ -36,10 +36,24 @@ can't be assigned to the parameter type 'TimeOfDay (where TimeOfDay is defined i
 flutter/lib/src/material/time.dart)'.
 ```
 
-The calendar now uses `KalenderDateTimeRange` and `KalenderTime`, so no kalender
-signature names a Material type and nothing here needs a prefix import. Import
-`package:kalender/material.dart` for the conversions where you do hand values to
-a Material API.
+The calendar now uses `KalenderDateTimeRange` and `KalenderTime`, so neither value
+type names a Material class and nothing here needs a prefix import. Theming is a
+separate matter, covered in section 3.
+
+`package:kalender/material.dart` is not the conversion for an app on `material_ui`.
+Its extensions are on the types in `package:flutter/material.dart`, which are
+different types from `material_ui`'s, and importing it would pull Material back into
+this app. Build the kalender value directly from what `material_ui` hands you:
+
+```dart
+final picked = await showDateRangePicker(context: context, firstDate: first, lastDate: last);
+final range = picked == null ? null : KalenderDateTimeRange(start: picked.start, end: picked.end);
+
+final time = await showTimePicker(context: context, initialTime: initial);
+final start = time == null ? null : KalenderTime(hour: time.hour, minute: time.minute);
+```
+
+Wrap those in extensions of your own if you cross the boundary often.
 
 ## 3. `KalenderThemeData` cannot be a theme extension
 

--- a/lib/src/models/kalender_time_range.dart
+++ b/lib/src/models/kalender_time_range.dart
@@ -4,7 +4,7 @@ import 'package:kalender/src/models/kalender_time.dart';
 /// Encapsulates a start and end [KalenderTime] that represents a day time range.
 ///
 /// - The range includes the [start] and [end] times.
-/// - The [start] time must be before to the [end] time.
+/// - The [start] time must not be after the [end] time.
 class KalenderTimeRange {
   KalenderTimeRange({
     required this.start,


### PR DESCRIPTION
A review of the release turned up documentation that describes the old API or gives advice that does not work.

The `material_ui` example pointed readers at `package:kalender/material.dart` for conversions. Its extensions are on the types in `package:flutter/material.dart`, which are different types from `material_ui`'s, so they do not resolve there, and importing it would pull Material back into an app that exists to do without it. It now builds the kalender values directly from what `material_ui` returns. The same section claimed no kalender signature names a Material type, which its own section 3 contradicts, so the claim is narrowed to the value types.

The timezone guide still said the constructor converts `dateTimeRange` values, the parameter this release removed. Two snippets in the events guide kept the indentation the rename left. The `KalenderTimeRange` comment said the start "must be before to" the end, which is a typo, and the constructor allows the two to be equal.

The changelog said `dart fix` applies this release's renames without noting the one it cannot.

Documentation only, apart from one doc comment. All 48 doc snippets still compile.